### PR TITLE
Minor changes to scriopt generating the requirements by deliverable

### DIFF
--- a/UseCases/SDWUseCasesAndRequirements.html
+++ b/UseCases/SDWUseCasesAndRequirements.html
@@ -1634,7 +1634,7 @@
     <section id="RequirementsByDeliverable">
       <h2>Accepted requirements by deliverable</h2>
       <p>For convenience, this chapter lists requirements grouped by Working Group deliverable.</p>
-      <div id="table1"></div>
+<!--      <div id="table1"></div> -->
     </section>
     <section id="DeferredRequirements">
       <h2>Deferred requirements</h2>
@@ -1655,7 +1655,7 @@
     </section>
     <script class='remove'> 
       <!-- Create a list of deliverables with related requirements. -->
-      var tab = document.getElementById("table1");
+      var tab = document.getElementById("RequirementsByDeliverable");
       var deliverables = document.getElementById("Deliverables").getElementsByTagName("section");
       var requirements = document.getElementById("AcceptedRequirements").getElementsByTagName("section");
       var relatedDelivs = [];
@@ -1664,8 +1664,11 @@
         dId = deliverables[i].id;
         if (dId == "UseCasesAndRequirements") {continue;}
         dLabel = deliverables[i].getElementsByTagName("h3")[0].innerText;
-        dp = document.createElement("p");
-        dpb = document.createElement("b");
+//        dp = document.createElement("p");
+        dp = document.createElement("section");
+        dp.id = 'ar'+dId ;
+//        dpb = document.createElement("b");
+        dpb = document.createElement("h3");
         dpbt1 = document.createTextNode("Requirements for deliverable ");
         dpb.appendChild(dpbt1);
         dpba = document.createElement("a");

--- a/UseCases/SDWUseCasesAndRequirements.html
+++ b/UseCases/SDWUseCasesAndRequirements.html
@@ -1162,21 +1162,21 @@
             <p>This use case is inspired by one of the conclusions of the UK Parliamentary inquiry into <a href="http://www.publications.parliament.uk/pa/cm201011/cmselect/cmsctech/444/44404.htm">ClimateGate</a> <i>"...It is not standard practice in climate science to publish the raw data and the computer code in academic papers. However, climate science is a matter of great importance and the quality of the science should be irreproachable. We therefore consider that climate scientists should take steps to make available all the data that support their work (including raw data) and full methodological workings (including the computer codes...)." </i> When a climate scientist publishes a paper, he needs to be able to refer reviewers to the source data and software source code that underpins the assertions made within the paper. Climate data are typically time-series and can be quite complex. Data can be sourced from a single National Meteorological and Hydrological Service (NMHS), or from a number of NMHS. Software source code is typically stored within a software revision control repository, such as git.</p>
 						<p>Climate data may comprise all of the following:</p>
 						<ol>
-							<li>A time-series of observations of a specific phenomenon at a single sensor, including:</li>
+							<li>A time-series of observations of a specific phenomenon at a single sensor, including:
 							<ul>
 								<li>Estimations of the value of an observed property.</li>
 								<li>A detailed understanding of the conditions under which the observation was made.<li>
-								<lie>Any changes that have been made to the observation (e.g. due to Quality Assurance processes).</li>
-							</ul>
+								<li>Any changes that have been made to the observation (e.g. due to Quality Assurance processes).</li>
+							</ul></li>
 							<li>A collection of the time-series observations described at #1, of the same phenomenon, at the same time steps, perhaps in the form of a discrete coverage (time-series).</li>
-							<li>A time-series representing the distribution of values of the collection of time-series observations represented as perhaps a:</li>
+							<li>A time-series representing the distribution of values of the collection of time-series observations represented as perhaps a:
 							<ul>
 								<li>Continuous two dimensional coverage.</li>
 								<li>Continuous coverages as three dimensional cubes.</li>
 								<li>Continuous coverage as n-dimensional models.</li>
 								<li>An ensemble, comprising a number of models.</li>
 								<li>The outputs of some analytical process as a time-series/coverage/cube/model.</li>
-							</ul>
+							</ul></li>
 						</ol>
 						<p>So using the description of climate data above, when a paper is published, the scientist needs to be able to refer viewers to:</p>
 						<ul>
@@ -1187,7 +1187,7 @@
 						</ul>
 						<p>This is not a trivial data management problem to address, however its resolution will provide a solid data management grounding for future climate science and help address much spurious debate. Parts of the puzzle are currently being worked on, e.g.:</p>
 						<ul>
-							<li>The World Meteorological Organisation (WMO) has published <a href="http://library.wmo.int/opac/index.php?lvl=notice_display&id=16300#.VdxQv_nzppi">WMO No. 1131: Climate Data Management Systems Specifications</a> that provide a high level conceptual architecture to address much of the data management issues described above.</li>
+							<li>The World Meteorological Organisation (WMO) has published <a href="http://library.wmo.int/opac/index.php?lvl=notice_display&amp;id=16300#.VdxQv_nzppi">WMO No. 1131: Climate Data Management Systems Specifications</a> that provide a high level conceptual architecture to address much of the data management issues described above.</li>
 							<li>WMO and OGC have developed and are developing relevant logical data models ISO 19156 Observations and Measurements, OGC Timeseries, and WMO METCE. The last two are based on Observations and Measurements.</li>
 							<li>WMO has released a standard for describing Observations Metadata, called WIGOS Metadata.</li>
 							<li>WMO is about to start work on a logical data model based on Observations and Measurements and Timeseries for describing WMO Observations. A future iteration of this model will need to cater for data provenance.</li>


### PR DESCRIPTION
I need to be able to refer to the specific list of reqs for the Coverages deliverable. In order to do this I wanted to use sections and headings so that ReSpec could do its work. In checking my work I found a couple of minor errors in the nested lists in one of the UCs. No text has been changed.
