### PR TITLE
Editorial changes

### DIFF
--- a/time/index.html
+++ b/time/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta content="text/html; charset=utf-8" http-equiv="content-type">
     <meta content="width=device-width,initial-scale=1" name="viewport">
@@ -7,7 +7,6 @@
     <script class="remove" src="http://www.w3.org/Tools/respec/respec-w3c-common"></script>
     <script class="remove" src="config.js"></script>
     <style type="text/css">
-
 /* Table styles, March 2016 */
 
 table {border-collapse:collapse}
@@ -52,7 +51,8 @@ DIV.test {
 DIV.test H4 {
 	MARGIN: 0px 0px 10px
 }
-</style> </head>
+    </style> 
+  </head>
   <body>
     <section id="abstract">
       <p>The OWL-Time ontology is an OWL-2 DL ontology of temporal concepts, for describing the temporal properties of
@@ -216,11 +216,10 @@ DIV.test H4 {
           whose membership is therefore disjoint from <code>Instant</code>. The class <code>ProperInterval </code>has
           one subclass, <code>DateTimeInterval</code>, whose position and extent may be expressed using a single <code>GeneralDateTimeDescription
             </code>or <code>xsd:dateTime</code>. </p>
-        <div style="text-align: center;"><img title="Temporal Entity and sub-classes" alt="UML-style diagram of temporal entity classes"
-
-            src="./images/TemporalEntity.png">
-          <p>Fig. 1 Core model model of temporal entities.</p>
-        </div>
+        <figure>
+          <img title="Temporal Entity and sub-classes" alt="UML-style diagram of temporal entity classes" src="./images/TemporalEntity.png">
+          <figcaption>Fig. 1 Core model model of temporal entities.</figcaption>
+        </figure>
         <p class="issue"><code>:durationOf</code> was mentioned in the original draft, but not in the published
           ontology. It appears to have been replaced by <code>:hasDuration</code>. </p>
         <code></code>
@@ -281,11 +280,10 @@ DIV.test H4 {
         may be omitted on individuals from this class.
         <p class="note"><code>DateTimeDescription </code>covers the case that was defined in the original note, and
           retains the original class name.&nbsp; </p>
-        <div style="text-align: center;"><img title="DataTimePosition" alt="UML-style diagram of classes for temporal position"
-
-            src="./images/DateTimeDescription.png">
-          <p>Fig. 3 Classes for temporal position.</p>
-        </div>
+        <figure>
+          <img title="DataTimePosition" alt="UML-style diagram of classes for temporal position" src="./images/DateTimeDescription.png">
+          <figcaption>Fig. 2 Classes for temporal position.</figcaption>
+        </figure>
         <p> Following the theoretical basis laid out by Allen and Ferguson, a time position has a finite extent,
           corresponding to the precision or <em>temporal unit </em>used. Thus,a <code>GeneralDateTimeDescription</code>
           or <code>DateTimeDescription</code> is strictly always a description of an interval (<code>DateTimeInterval</code>),
@@ -316,11 +314,10 @@ DIV.test H4 {
           or <code>&lt;http://www.opengis.net/def/uom/ISO-8601/0/Gregorian&gt;</code> . </p>
         <p class="note"><code>DurationDescription </code>covers the case that was in the original note, and retains the
           original class name. </p>
-        <div style="text-align: center;"> <img title="Duration description" alt="UML representation of Duration Description and associated classes"
-
-            src="./images/DurationDescription.png">
-          <p>Fig. 2 Classes for temporal duration.</p>
-        </div>
+        <figure>
+          <img title="Duration description" alt="UML representation of Duration Description and associated classes" src="./images/DurationDescription.png">
+          <figcaption>Fig. 3 Classes for temporal duration.</figcaption>
+        </figure>
         <p class="note">These classes address the 'duration' requirement from <a href="http://www.w3.org/TR/sdw-ucr/#DateTimeDuration">5.7
             Date, time and duration</a></p>
       </section>
@@ -614,10 +611,10 @@ DIV.test H4 {
         </table>
         <p>Thirteen properties support the set of interval relations defined by Allen and Ferguson [<a href="#AF-97">AF-97</a>].
           </p>
-        <div style="text-align: center;"><img style="width: 545px; height: 322px;" title="Allen's Interval Relations" alt="Schematic of Interval Relations"
-
-            src="./images/IntervalRelations.png"> <br>
-          Fig. 4 The possible relations between time periods (equality not shown) [<a href="#AF-97">AF-97</a>]</div>
+        <figure>
+          <img style="width: 545px; height: 322px;" title="Allen's Interval Relations" alt="Schematic of Interval Relations" src="./images/IntervalRelations.png"/>
+          <figcaption>Fig. 4 The possible relations between time periods (equality not shown) [<a href="#AF-97">AF-97</a>]</figcaption>
+        </figure>
         <h4 id="time:intervalEquals">Property: intervalEquals</h4>
         <table class="definition" style="width: 812px;">
           <tbody>
@@ -1829,11 +1826,7 @@ DIV.test H4 {
             </tr>
           </tbody>
         </table>
-        <p>Seven datatype properties <code>years</code>, <code>months</code>, <code>weeks</code>, <code>days</code>,
-          <code>hours</code>, <code>minute</code>, and <code>seconds</code> support the description of components of a
-          temporal extent in a calendar-clock system. These correspond with the 'seven property model' described in ISO
-          8601 [] and XML Schema Definition Language Part 2: Datatypes [], except that the calendar is not specified in
-          advance. </p>
+        <p>Seven datatype properties <code>years</code>, <code>months</code>, <code>weeks</code>, <code>days</code>, <code>hours</code>, <code>minute</code>, and <code>seconds</code> support the description of components of a temporal extent in a calendar-clock system. These correspond with the 'seven property model' described in ISO 8601 [<a href="#ISO-8601">ISO-8601</a>] and XML Schema Definition Language Part 2: Datatypes [<a href="#XSD-D">XSD-D</a>], except that the calendar is not specified in advance. </p>
         <h4 id="time:years">Property years</h4>
         <table class="definition" style="width: 812px;">
           <tbody>
@@ -1989,8 +1982,8 @@ DIV.test H4 {
         </table>
         <p>&nbsp;</p>
       </section>
-      <section id="GenDurationDescription">
-        <h3 id="time:GenDurationDescription">Class: DurationDescription</h3>
+      <section id="DurationDescription">
+        <h3 id="time:DurationDescription">Class: DurationDescription</h3>
         <table class="definition" style="width: 812px;">
           <tbody>
             <tr>
@@ -2234,9 +2227,10 @@ DIV.test H4 {
           <code>intervalFinishedBy</code>. Many other interval relationships follow logically from the ones shown (for
           example 'Neogene Period' :<code>intervalDuring </code>'Cenozoic Era') but these are sufficient to describe
           the full topology.&nbsp; </p>
-        <img title="(Part of) the international chronostratigraphic chart, formalized as a set of proper intervals" src="images/GeologicTimescale-1.png">
-        <div style="text-align: center;">Fig. 5 Part of the geologic timescale formalized as ProperIntervals, with
-          ordering relationships described using the predicates defined in this ontology.&nbsp; </div>
+          <figure>
+            <img alt="(Part of) the international chronostratigraphic chart, formalized as a set of proper intervals" title="(Part of) the international chronostratigraphic chart, formalized as a set of proper intervals" src="images/GeologicTimescale-1.png">
+            <figcaption>Fig. 5 Part of the geologic timescale formalized as ProperIntervals, with ordering relationships described using the predicates defined in this ontology.</figcaption>
+          </figure>
         <p> For example, the interval known as the 'Phanerozoic Eon' is described as follows:</p>
         <pre>geol:Phanerozoic
   rdf:type :ProperInterval ;
@@ -2630,15 +2624,17 @@ ex:meetingStartDescription
           </li>
           <li>TRS</li>
           <li>Duration</li>
-          <li>GeneralDurationDescription</li>
-          <ul>
-            <li>DurationDescription</li>
-          </ul>
+          <li>GeneralDurationDescription
+            <ul>
+              <li>DurationDescription</li>
+            </ul>
+          </li>
           <li>TimePosition</li>
-          <li>GeneralDateTimeDescription</li>
-          <ul>
-            <li>DateTimeDescription</li>
-          </ul>
+          <li>GeneralDateTimeDescription
+            <ul>
+              <li>DateTimeDescription</li>
+            </ul>
+          </li>
           <li>TemporalUnit </li>
           <li>DayOfWeek</li>
           <li>Number</li>
@@ -3189,52 +3185,62 @@ ex:meetingStartDescription
     <hr>
     <section id="references">
       <h2>References</h2>
-      <p id="AF-97">[AF-97] Allen, J. F. and Ferguson, G. 1997. Actions and events in interval temporal logic. In <em>Spatial
-          and Temporal Reasoning</em>. O. Stock, ed., Kluwer, Dordrecht, Netherlands, 205-245. <a href="http://dx.doi.org/10.1007%2F978-0-585-28322-7_7">doi:10.1007%2F978-0-585-28322-7_7</a></p>
-      <p id="AL-84">[AL-84] Allen, J. F. 1984. Towards a general theory of action and time. <em>Artificial Intelligence
-        </em> <strong>23</strong>, pp. 123-154. <a href="http://dx.doi.org/10.1016/0004-3702%2884%2990008-0">doi:10.1016/0004-3702(84)90008-0</a></p>
-      <p id="CO-15">[CO-15] Cox, S. J. D. 2015. Time Ontology Extended for Non-Gregorian Calendar Applications. <em>Semantic
-          Web Journal</em> <strong>7</strong> 201-209 <a href="http://dx.doi.org/10.3233/SW-150187">doi:
-          10.3233/SW-150187</a></p>
-      <p id="CR-05">[CR-05] S.J.D. Cox, S.M. Richard, A formal model for the geologic time scale and global stratotype
-        section and point, compatible with geospatial information transfer standards, <em>Geosphere</em>. <strong>1</strong>
-        (2005) 119. <a href="http://dx.doi.org/10.1130/GES00022.1">doi:10.1130/GES00022.1.</a></p>
-      <p id="CR-14">[CR-14] S.J.D. Cox, S.M. Richard, A geologic timescale ontology and service, <em>Earth Sci.
-          Informatics</em>. <strong>8</strong> (2014) 5–19. <a href="http://dx.doi.org/10.1007/s12145-014-0166-2">doi:10.1007/s12145-014-0166-2.</a></p>
-      <p id="DS-98">[DS-98] Dawson, F. and Stenerson, D. 1998. Internet Calendaring and Scheduling Core Object
-        Specification (iCalendar), RFC2445. <a href="http://www.ietf.org/rfc/rfc2445.txt">http://www.ietf.org/rfc/rfc2445.txt</a></p>
-      <p id="FIPS">[FIPS] FIPS 55 County instance file. <a href="http://www.daml.org/2003/02/fips55/">http://www.daml.org/2003/02/fips55/</a></p>
-      <p id="HP-04">[HP-04] Hobbs, J. R. and Pan, F. 2004. An Ontology of Time for the Semantic Web. <em>ACM
-          Transactions on Asian Language Processing (TALIP): Special issue on Temporal Information Processing</em>, <strong>3</strong>,
-        No. 1, March 2004, pp. 66-85. <a href="http://dx.doi.org/10.1145/1017068.1017073">doi:10.1145/1017068.1017073</a></p>
-      <p id="ISO-19108">[ISO-19108] ISO 19108:2002 Geographic information -- Temporal schema. <a href="http://www.iso.org/iso/iso_catalogue/catalogue_detail?csnumber=26013">http://www.iso.org/iso/iso_catalogue/catalogue_detail?csnumber=26013</a></p>
-      <p id="ISO-8601">[ISO-8601] ISO 8601:2004 Data elements and interchange formats -- Information interchange --
-        Representation of dates and times <a href="http://www.iso.org/iso/catalogue_detail?csnumber=40874">http://www.iso.org/iso/catalogue_detail?csnumber=40874</a></p>
-      <p id="ISO-C">[ISO-C] ISO Country instance file. <a href="http://www.daml.org/2001/09/countries/iso">http://www.daml.org/2001/09/countries/iso</a></p>
-      <p id="MF-13">[MF-13] X. Ma, P. Fox, Recent progress on geologic time ontologies and considerations for future
-        works, <em>Earth Sci. Informatics.</em> <strong>6</strong> (2013) 31–46. <a href="http://dx.doi.org/10.1007/s12145-013-0110-x">doi:10.1007/s12145-013-0110-x.</a></p>
-      <p id="OE-06">[OE-06] OWL code of the entry sub-ontology of time. <a href="http://www.w3.org/2006/time-entry">http://www.w3.org/2006/time-entry</a></p>
-      <p id="OT-06">[OT-06] OWL code of the time ontology. <a href="http://www.w3.org/2006/time">http://www.w3.org/2006/time</a></p>
-      <p id="OWL-2">[OWL-2] Owl2-quick-reference <a href="http://www.w3.org/TR/turtle/owl2-quick-reference/#Built-in_Datatypes">https://www.w3.org/TR/owl2-quick-reference/#Built-in_Datatypes</a></p>
-      <p id="OWL-S">[OWL-S] OWL-S homepage. <a href="http://www.daml.org/services/owl-s/">http://www.daml.org/services/owl-s/</a></p>
-      <p id="OWL-T">[OWL-T] Hobbs, J. R. and Pan, F. 2006. Time Ontology in OWL. W3C Working Draft <a href="https://www.w3.org/TR/owl-time/">https://www.w3.org/TR/owl-time/</a></p>
-      <p id="PA-05">[PA-05] Pan, F. 2005. A Temporal Aggregates Ontology in OWL for the Semantic Web. In <i>Proceedings
-          of the AAAI Fall Symposium on Agents and the Semantic Web</i>, Arlington, Virginia, pp. 30-37. <a href="https://www.semanticscholar.org/paper/A-Temporal-Aggregates-Ontology-in-OWL-for-the-Pan/3147d5c652a7e4bf4787fdff781c56259bdb5a33/pdf">https://www.semanticscholar.org/paper/A-Temporal-Aggregates-Ontology-in-OWL-for-the-Pan/3147d5c652a7e4bf4787fdff781c56259bdb5a33/pdf</a></p>
-      <p id="PH-04">[PH-04] Pan, F and Hobbs, J. R. 2004. Time in OWL-S. In <em>Proceedings of the AAAI Spring
-          Symposium on Semantic Web Services</em>, Stanford University, CA, pp. 29-36. <a href="http://www.isi.edu/%7Ehobbs/time/pub/pan-hobbs-AAAI-SSS04.pdf">http://www.isi.edu/~hobbs/time/pub/pan-hobbs-AAAI-SSS04.pdf</a></p>
-      <p id="PH-05">[PH-05] Pan, F and Hobbs, J. R. 2005. Temporal Aggregates in OWL-Time. In <em> Proceedings of the
-          18th International Florida Artificial Intelligence Research Society Conference (FLAIRS)</em>, Clearwater
-        Beach, Florida, pp. 560-565, AAAI Press. <a href="http://www.isi.edu/%7Ehobbs/FLAIRS-05.pdf">http://www.isi.edu/~hobbs/FLAIRS-05.pdf</a></p>
-      <p id="PR-OS">[PR-OS] The process file of the OWL-S 0.9 release. <a href="http://www.daml.org/services/owl-s/0.9/Process.owl">http://www.daml.org/services/owl-s/0.9/Process.owl</a></p>
-      <p id="RC-14">[RC-14] Guidelines to Authors, <em>Radiocarb. Mag.</em> (2014). <a href="https://journals.uair.arizona.edu/index.php/radiocarbon/about/submissions#authorGuidelines">https://journals.uair.arizona.edu/index.php/radiocarbon/about/submissions#authorGuidelines</a>
-        (accessed September 9, 2014)</p>
-      <p id="TTL-14">[TTL-14] Prud'hommeaux, E. and Carothers, G. 2014. RDF 1.1 Turtle - Terse RDF Triple Language. W3C
-        Recommendation. <a href="http://www.w3.org/TR/turtle/">http://www.w3.org/TR/turtle/ </a></p>
-      <p id="TZ-ON">[TZ-ON] The time zone ontology file. <a href="http://www.w3.org/2006/timezone">http://www.w3.org/2006/timezone</a></p>
-      <p id="TZ-US">[TZ-US] The US time zone instance file. <a href="http://www.w3.org/2006/timezone-us">http://www.w3.org/2006/timezone-us</a></p>
-      <p id="TZ-WO">[TZ-WO] The world time zone instance file. <a href="http://www.w3.org/2006/timezone-world">http://www.w3.org/2006/timezone-world</a></p>
-      <p id="XSD-D">[XSD-D] XML Schema Definition Language (XSD) 1.1 Part 2: Datatypes. W3C Recommendation 5 April 2012
-        <a href="https://www.w3.org/TR/xmlschema11-2/">https://www.w3.org/TR/xmlschema11-2/</a></p>
+      <dl class="bibliography">
+        <dt id="AF-97">[AF-97]</dt>
+        <dd>Allen, J. F. and Ferguson, G. 1997. <a href="http://dx.doi.org/10.1007/978-0-585-28322-7_7"><cite>Actions and events in interval temporal logic</cite></a>. In: Spatial  and Temporal Reasoning. O. Stock, ed., Kluwer, Dordrecht, Netherlands, pp. 205-245. <a href="http://dx.doi.org/10.1007/978-0-585-28322-7_7">doi:10.1007/978-0-585-28322-7_7</a></dd>
+        <dt id="AL-84">[AL-84]</dt>
+        <dd>Allen, J. F. 1984. <a href="http://dx.doi.org/10.1016/0004-3702%2884%2990008-0"><cite>Towards a general theory of action and time</cite></a>. Artificial Intelligence <strong>23</strong>, pp. 123-154. <a href="http://dx.doi.org/10.1016/0004-3702%2884%2990008-0">doi:10.1016/0004-3702(84)90008-0</a></dd>
+        <dt id="CO-15">[CO-15]</dt>
+        <dd>Cox, S. J. D. 2015. <a href="http://dx.doi.org/10.3233/SW-150187"><cite>Time Ontology Extended for Non-Gregorian Calendar Applications</cite></a>. Semantic Web Journal <strong>7</strong>, pp. 201-209 <a href="http://dx.doi.org/10.3233/SW-150187">doi:10.3233/SW-150187</a></dd>
+        <dt id="CR-05">[CR-05]</dt>
+        <dd>S.J.D. Cox, S.M. Richard, <a href="http://dx.doi.org/10.1130/GES00022.1"><cite>A formal model for the geologic time scale and global stratotype section and point, compatible with geospatial information transfer standards</cite></a>. Geosphere <strong>1</strong> (2005) 119. <a href="http://dx.doi.org/10.1130/GES00022.1">doi:10.1130/GES00022.1.</a></dd>
+        <dt id="CR-14">[CR-14]</dt>
+        <dd>S.J.D. Cox, S.M. Richard, <a href="http://dx.doi.org/10.1007/s12145-014-0166-2"><cite>A geologic timescale ontology and service</cite></a>, <em>Earth Sci. Informatics</em>. <strong>8</strong> (2014) 5–19. <a href="http://dx.doi.org/10.1007/s12145-014-0166-2">doi:10.1007/s12145-014-0166-2.</a></dd>
+        <dt id="DS-98">[DS-98]</dt>
+        <dd>Dawson, F. and Stenerson, D. 1998. <a href="http://www.ietf.org/rfc/rfc2445.txt"><cite>Internet Calendaring and Scheduling Core Object Specification (iCalendar), RFC2445</cite></a>. <a href="http://www.ietf.org/rfc/rfc2445.txt">http://www.ietf.org/rfc/rfc2445.txt</a></dd>
+        <dt id="FIPS">[FIPS]</dt>
+        <dd><a href="http://www.daml.org/2003/02/fips55/"><cite>FIPS 55 County instance file</cite></a>. <a href="http://www.daml.org/2003/02/fips55/">http://www.daml.org/2003/02/fips55/</a></dd>
+        <dt id="HP-04">[HP-04]</dt>
+        <dd>Hobbs, J. R. and Pan, F. 2004. <a href="http://dx.doi.org/10.1145/1017068.1017073"><cite>An Ontology of Time for the Semantic Web</cite></a>. <em>ACM Transactions on Asian Language Processing (TALIP): Special issue on Temporal Information Processing</em>, <strong>3</strong>, No. 1, March 2004, pp. 66-85. <a href="http://dx.doi.org/10.1145/1017068.1017073">doi:10.1145/1017068.1017073</a></dd>
+        <dt id="ISO-19108">[ISO-19108]</dt>
+        <dd><a href="http://www.iso.org/iso/iso_catalogue/catalogue_detail?csnumber=26013"><cite>ISO 19108:2002 Geographic information -- Temporal schema</cite></a>. <a href="http://www.iso.org/iso/iso_catalogue/catalogue_detail?csnumber=26013">http://www.iso.org/iso/iso_catalogue/catalogue_detail?csnumber=26013</a></dd>
+        <dt id="ISO-8601">[ISO-8601]</dt>
+        <dd><a href="http://www.iso.org/iso/catalogue_detail?csnumber=40874"><cite>ISO 8601:2004 Data elements and interchange formats -- Information interchange -- Representation of dates and times</cite></a> <a href="http://www.iso.org/iso/catalogue_detail?csnumber=40874">http://www.iso.org/iso/catalogue_detail?csnumber=40874</a></dd>
+        <dt id="ISO-C">[ISO-C]</dt>
+        <dd><a href="http://www.daml.org/2001/09/countries/iso"><cite>ISO Country instance file</cite></a>. <a href="http://www.daml.org/2001/09/countries/iso">http://www.daml.org/2001/09/countries/iso</a></dd>
+        <dt id="MF-13">[MF-13]</dt>
+        <dd>X. Ma, P. Fox, <a href="http://dx.doi.org/10.1007/s12145-013-0110-x"><cite>Recent progress on geologic time ontologies and considerations for future works</cite></a>, Earth Sci. Informatics. <strong>6</strong> (2013) 31–46. <a href="http://dx.doi.org/10.1007/s12145-013-0110-x">doi:10.1007/s12145-013-0110-x.</a></dd>
+        <dt id="OE-06">[OE-06]</dt>
+        <dd><a href="http://www.w3.org/2006/time-entry"><cite>OWL code of the entry sub-ontology of time</cite></a>. <a href="http://www.w3.org/2006/time-entry">http://www.w3.org/2006/time-entry</a></dd>
+        <dt id="OT-06">[OT-06]</dt>
+        <dd><a href="http://www.w3.org/2006/time"><cite>OWL code of the time ontology</cite></a>. <a href="http://www.w3.org/2006/time">http://www.w3.org/2006/time</a></dd>
+        <dt id="OWL-2">[OWL-2]</dt>
+        <dd><a href="http://www.w3.org/TR/turtle/owl2-quick-reference/#Built-in_Datatypes"><cite>Owl2-quick-reference</cite></a> <a href="http://www.w3.org/TR/turtle/owl2-quick-reference/#Built-in_Datatypes">https://www.w3.org/TR/owl2-quick-reference/#Built-in_Datatypes</a></dd>
+        <dt id="OWL-S">[OWL-S]</dt>
+        <dd><a href="http://www.daml.org/services/owl-s/"><cite>OWL-S homepage</cite></a>. <a href="http://www.daml.org/services/owl-s/">http://www.daml.org/services/owl-s/</a></dd>
+        <dt id="OWL-T">[OWL-T]</dt>
+        <dd>Hobbs, J. R. and Pan, F. 2006. <a href="https://www.w3.org/TR/owl-time/"><cite>Time Ontology in OWL</cite></a>. W3C Working Draft <a href="https://www.w3.org/TR/owl-time/">https://www.w3.org/TR/owl-time/</a></dd>
+        <dt id="PA-05">[PA-05]</dt>
+        <dd>Pan, F. 2005. <a href="https://www.semanticscholar.org/paper/A-Temporal-Aggregates-Ontology-in-OWL-for-the-Pan/3147d5c652a7e4bf4787fdff781c56259bdb5a33/pdf"><cite>A Temporal Aggregates Ontology in OWL for the Semantic Web</cite></a>. In: Proceedings of the AAAI Fall Symposium on Agents and the Semantic Web, Arlington, Virginia, pp. 30-37. <a href="https://www.semanticscholar.org/paper/A-Temporal-Aggregates-Ontology-in-OWL-for-the-Pan/3147d5c652a7e4bf4787fdff781c56259bdb5a33/pdf">https://www.semanticscholar.org/paper/A-Temporal-Aggregates-Ontology-in-OWL-for-the-Pan/3147d5c652a7e4bf4787fdff781c56259bdb5a33/pdf</a></dd>
+        <dt id="PH-04">[PH-04]</dt>
+        <dd>Pan, F and Hobbs, J. R. 2004. <a href="http://www.isi.edu/%7Ehobbs/time/pub/pan-hobbs-AAAI-SSS04.pdf"><cite>Time in OWL-S</cite></a>. In: Proceedings of the AAAI Spring Symposium on Semantic Web Services, Stanford University, CA, pp. 29-36. <a href="http://www.isi.edu/%7Ehobbs/time/pub/pan-hobbs-AAAI-SSS04.pdf">http://www.isi.edu/~hobbs/time/pub/pan-hobbs-AAAI-SSS04.pdf</a></dd>
+        <dt id="PH-05">[PH-05]</dt>
+        <dd>Pan, F and Hobbs, J. R. 2005. <a href="http://www.isi.edu/%7Ehobbs/FLAIRS-05.pdf"><cite>Temporal Aggregates in OWL-Time</cite></a>. In <em> Proceedings of the 18th International Florida Artificial Intelligence Research Society Conference (FLAIRS)</em>, Clearwater Beach, Florida, pp. 560-565, AAAI Press. <a href="http://www.isi.edu/%7Ehobbs/FLAIRS-05.pdf">http://www.isi.edu/~hobbs/FLAIRS-05.pdf</a></dd>
+        <dt id="PR-OS">[PR-OS]</dt>
+        <dd><a href="http://www.daml.org/services/owl-s/0.9/Process.owl"><cite>The process file of the OWL-S 0.9 release</cite></a>. <a href="http://www.daml.org/services/owl-s/0.9/Process.owl">http://www.daml.org/services/owl-s/0.9/Process.owl</a></dd>
+        <dt id="RC-14">[RC-14]</dt>
+        <dd><a href="https://journals.uair.arizona.edu/index.php/radiocarbon/about/submissions#authorGuidelines"><cite>Guidelines to Authors</cite></a>, Radiocarb. Mag. (2014). <a href="https://journals.uair.arizona.edu/index.php/radiocarbon/about/submissions#authorGuidelines">https://journals.uair.arizona.edu/index.php/radiocarbon/about/submissions#authorGuidelines</a> (accessed September 9, 2014)</dd>
+        <dt id="TTL-14">[TTL-14]</dt>
+        <dd>Prud'hommeaux, E. and Carothers, G. 2014. <a href="http://www.w3.org/TR/turtle/"><cite>RDF 1.1 Turtle - Terse RDF Triple Language</cite></a>. W3C Recommendation. <a href="http://www.w3.org/TR/turtle/">http://www.w3.org/TR/turtle/ </a></dd>
+        <dt id="TZ-ON">[TZ-ON]</dt>
+        <dd><a href="http://www.w3.org/2006/timezone"><cite>The time zone ontology file</cite></a>. <a href="http://www.w3.org/2006/timezone">http://www.w3.org/2006/timezone</a></dd>
+        <dt id="TZ-US">[TZ-US]</dt>
+        <dd><a href="http://www.w3.org/2006/timezone-us"><cite>The US time zone instance file</cite></a>. <a href="http://www.w3.org/2006/timezone-us">http://www.w3.org/2006/timezone-us</a></dd>
+        <dt id="TZ-WO">[TZ-WO]</dt>
+        <dd><a href="http://www.w3.org/2006/timezone-world"><cite>The world time zone instance file</cite></a>. <a href="http://www.w3.org/2006/timezone-world">http://www.w3.org/2006/timezone-world</a></dd>
+        <dt id="XSD-D">[XSD-D]</dt>
+        <dd><a href="https://www.w3.org/TR/xmlschema11-2/"><cite>XML Schema Definition Language (XSD) 1.1 Part 2: Datatypes</cite></a>. W3C Recommendation 5 April 2012 <a href="https://www.w3.org/TR/xmlschema11-2/">https://www.w3.org/TR/xmlschema11-2/</a></dd>
+      </dl>
     </section>
     <hr>
     <section id="ack">


### PR DESCRIPTION
- Added missing references to ISO 8601 and XSD (there were just two pair of empty brackets)
- Formatted bib section as per W3C style
- Fixed duplicate section identifier
- Figure numbering fixed (Fig. 3 was before Fig. 2)
- Used &lt;figure&gt; and &lt;figcaption&gt; for figures
- Validated HTML - minor HTML syntax fixes
