### PR TITLE
Update sosa.ttl

### DIFF
--- a/ssn/rdf/sosa.ttl
+++ b/ssn/rdf/sosa.ttl
@@ -7,6 +7,7 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <http://schema.org/> .
+@prefix meta: <http://meta.schema.org> .
 @prefix sosa-core: <https://www.w3.org/ns/sosa#> .
 @prefix terms: <http://purl.org/dc/terms/> .
 @prefix xhtm: <http://www.w3.org/1999/xhtml> .
@@ -39,10 +40,10 @@ terms:created
 terms:modified
   rdf:type owl:AnnotationProperty ;
 .
-schema:domainIncludes
+meta:domainIncludes
   rdf:type owl:AnnotationProperty ;
 .
-schema:rangeIncludes
+meta:rangeIncludes
   rdf:type owl:AnnotationProperty ;
 .
 rdfs:comment
@@ -70,33 +71,13 @@ owl:topObjectProperty
 .
 sosa-core:Activity
   rdf:type rdfs:Class ;
-  rdfs:comment "An action or event during which a Procedure is used."@en ;
+  rdfs:comment "An action or event during which a Procedure is used. This includes actuation via an actuating procedures, sampling via a sampling procedures, sensing via a sensing procedures, and so forth."@en ;
   rdfs:label "Activity"@en ;
-  rdfs:subClassOf owl:Thing ;
-.
-sosa-core:ActuatingProcedure
-  rdf:type owl:Class ;
-  rdfs:comment "When used, an ActuationProcedure can cause a change in the state of the world."@en ;
-  rdfs:label "Actuating Procedure"@en ;
-  rdfs:subClassOf sosa-core:Procedure ;
-.
-sosa-core:Actuation
-  rdf:type rdfs:Class ;
-  rdfs:comment "An Activity that uses an ActuatingProcedure to cause a change in the state of the world, for example by moving something, heating it up, turning it on."@en ;
-  rdfs:label "Actuation"@en ;
-  rdfs:subClassOf sosa-core:Activity ;
 .
 sosa-core:Actuator
   rdf:type owl:Class ;
-  rdfs:comment "A Device that is used by, or implements, an Actuating Procedure."@en ;
+  rdfs:comment "A device that is used by, or implements, an (actuating) Procedure."@en ;
   rdfs:label "Actuator"@en ;
-  rdfs:subClassOf sosa-core:Device ;
-.
-sosa-core:Device
-  rdf:type owl:Class ;
-  rdfs:comment "A physical object involved in a Procedure that observes, samples, or changes the state of the world."@en ;
-  rdfs:label "Device"@en ;
-  rdfs:subClassOf owl:Thing ;
 .
 sosa-core:ObservableProperty
   rdf:type owl:Class ;
@@ -105,44 +86,24 @@ sosa-core:ObservableProperty
 .
 sosa-core:Observation
   rdf:type owl:Class ;
-  rdfs:comment "An Observation is an Activity in which a Sensing method or ObservationProcedure has been used to estimate or calculate a value of a Property of a FeatureOfInterest. Links to an Observer or Sensor to describe what made the Observation and how; links to FeatureOfInterest detail what was observed; the Result is the output."@en ;
+  rdfs:comment "An Observation carries out an (observation) Procedure to estimate or calculate a value of a Property of a FeatureOfInterest. Links to an Observer or Sensor to describe what made the Observation and how; links to FeatureOfInterest detail what was observed; the Result is the output."@en ;
   rdfs:label "Observation"@en ;
   rdfs:subClassOf sosa-core:Activity ;
 .
 sosa-core:Observer
   rdf:type owl:Class ;
-  rdfs:comment "Device or agent involved in, or implementing, an ObservingProcedure."@en ;
+  rdfs:comment "Device, system, or agent (including humans) carrying at least one Sensor (e.g., eyes, GPS) to produce Observations by following a Procedure."@en ;
   rdfs:label "Observer"@en ;
-  rdfs:subClassOf sosa-core:Device ;
-.
-sosa-core:ObservingProcedure
-  rdf:type owl:Class ;
-  rdfs:comment "Procedure used to make an estimate of the value of a quality of a feature. Input may be a sensor stimulus, or the output from one or more previous activities."@en ;
-  rdfs:label "Observing procedure"@en ;
-  rdfs:subClassOf sosa-core:Procedure ;
-.
-sosa-core:Platform
-  rdf:type owl:Class ;
-  rdfs:comment "A Device or agent on which other Devices are mounted or hosted. Maybe stationary, moving, or portable. Examples include: station, buoy, ship, planes, satellite, balloon, cell-phone, table, tractor, automobile."@en ;
-  rdfs:label "Platform"@en ;
-  rdfs:subClassOf sosa-core:Device ;
 .
 sosa-core:Procedure
   rdf:type owl:Class ;
-  rdfs:comment "A workflow, protocol, plan, algorithm, or computational method specifying how to set up an Observation, taking a Sample, or making a change to the state of the world. A Procedure is re-usable, and might be involved in many observations, samplings, or actuations. It explains the steps to be carried out to arrive at reproducible results."@en ;
+  rdfs:comment "A workflow, protocol, plan, algorithm, or computational method specifying how to set up an Observation, take a Sample, or make a change to the state of the world (via an Actuator). A Procedure is re-usable, and might be involved in many observations, samplings, or actuations. It explains the steps to be carried out to arrive at reproducible results. Put differently, millions of observations may be created via the same Procedure the same way as millions of tables are assembled using the same instructions (as information objects, not their concrete realization). "@en ;
   rdfs:label "Procedure"@en ;
 .
-sosa-core:Sampling
-  rdf:type rdfs:Class ;
-  rdfs:comment "An Activity that uses a SamplingProcedure to obtain or define a SamplingFeature (sample), such as a subset, specimen, cross-section, transect etc."@en ;
-  rdfs:label "Sampling"@en ;
-  rdfs:subClassOf sosa-core:Activity ;
-.
-sosa-core:SamplingDevice
+sosa-core:FeatureOfInterest
   rdf:type owl:Class ;
-  rdfs:comment "Device used to obtain a sample"@en ;
-  rdfs:label "Sampling device"@en ;
-  rdfs:subClassOf sosa-core:Device ;
+  rdfs:comment "The feature whose ObservableProperty is being observed by a Sensor to arrive at a Result. For example, when measuring the height of a tree, said height is the ObservedProperty, 20m may be the Result of the Observation, and the tree is the FeatureOfInterest. "@en ;
+  rdfs:label "Feature Of Interest"@en ;
 .
 sosa-core:SamplingFeature
   rdf:type owl:Class ;
@@ -157,110 +118,84 @@ A sampling feature is intended to sample some feature-of-interest in an applicat
   rdfs:label "Sample"@en ;
   rdfs:label "Sampling Feature"@en ;
 .
-sosa-core:SamplingProcedure
-  rdf:type owl:Class ;
-  rdfs:comment "A Procedure of sampling, i.e., a description of the sampling process a sampling device can execute."@en ;
-  rdfs:label "Sampling Procedure"@en ;
-  rdfs:subClassOf sosa-core:Procedure ;
-.
-sosa-core:Sensing
-  rdf:type owl:Class ;
-  rdfs:comment "Sensing is an Activity in which a SensingProcedure has been used to estimate or calculate a value of a Property of a FeatureOfInterest. Links to a or Sensor to describe what performed the Sensing and how; links to FeatureOfInterest detail what was observed; the Result is the output."@en ;
-  rdfs:label "Sensing"@en ;
-  rdfs:subClassOf sosa-core:Observation ;
-.
-sosa-core:SensingProcedure
-  rdf:type owl:Class ;
-  rdfs:comment "A Procedure of sensing, i.e. a description of a procedure that uses or is implemented by a SensingDevice."@en ;
-  rdfs:label "Sensing Procedure"@en ;
-  rdfs:subClassOf sosa-core:ObservingProcedure ;
-.
 sosa-core:Sensor
   rdf:type owl:Class ;
-  rdfs:comment "Device or agent involved in, or implementing, a SensingProcedure. Responds to a stimulus and generates a result."@en ;
+  rdfs:comment "Device or agent involved in, or implementing, a (sensing) Procedure. Sensors responds to a stimulus, e.g., a change in the environment, and generates a result. Sensors can be mounted on observers, e.g., a modern smartphone hosts multiple sensors."@en ;
   rdfs:label "Sensor"@en ;
-  rdfs:subClassOf sosa-core:Observer ;
 .
 sosa-core:featureOfInterest
   rdf:type owl:ObjectProperty ;
-  schema:domainIncludes sosa-core:Observation ;
-  schema:rangeIncludes owl:Thing ;
+  meta:domainIncludes sosa-core:Observation ;
+  meta:rangeIncludes sosa-core:FeatureOfInterest ;
   rdfs:comment "A relation between an Observation and the entity whose quality was observed. For example, in an Observation of the weight of a person, the feature of interest is the person and the quality is weight."^^xsd:string ;
   rdfs:label "feature of interest"@en ;
 .
 sosa-core:hasResult
   rdf:type owl:ObjectProperty ;
-  schema:domainIncludes sosa-core:Observation ;
-  schema:domainIncludes sosa-core:Procedure ;
+  meta:domainIncludes sosa-core:Observation ;
+  meta:domainIncludes sosa-core:Procedure ;
   rdfs:comment "Relation linking an Observation and a Sensor or Actuator and a Result, which contains a value representing the value associated with the observed Property."^^xsd:string ;
   rdfs:label "result"@en ;
 .
 sosa-core:hostedBy
   rdf:type owl:ObjectProperty ;
-  schema:domainIncludes sosa-core:Device ;
-  schema:rangeIncludes sosa-core:Platform ;
-  rdfs:comment "Relation between a Device and the Platform that it is mounted on or hosted by."^^xsd:string ;
+  meta:domainIncludes sosa-core:Sensor ;
+  meta:domainIncludes sosa-core:Actuator ;
+  meta:rangeIncludes sosa-core:Observer ;
+  rdfs:comment "Relation between a Sensor or Actuator and the Observer that it is mounted on or hosted by."^^xsd:string ;
   rdfs:label "hosted by"^^xsd:string ;
 .
 sosa-core:hosts
   rdf:type owl:ObjectProperty ;
-  schema:domainIncludes sosa-core:Platform ;
-  schema:rangeIncludes sosa-core:Device ;
-  rdfs:comment "Relation between a Platform and a Device hosted or mounted on it."^^xsd:string ;
+  meta:domainIncludes sosa-core:Observer ;
+  meta:rangeIncludes sosa-core:Sensor ;
+    meta:rangeIncludes sosa-core:Actuator ;
+  rdfs:comment "Relation between an Observer and a Sensor or Actuator hosted or mounted on it."^^xsd:string ;
   rdfs:label "hosts"^^xsd:string ;
 .
 sosa-core:madeObservation
   rdf:type owl:ObjectProperty ;
-  schema:domainIncludes sosa-core:SensingProcedure ;
-  schema:rangeIncludes sosa-core:Observation ;
+  meta:domainIncludes sosa-core:Procedure ;
+  meta:rangeIncludes sosa-core:Observation ;
   rdfs:comment "Relation between a Sensor and an Observations it has made."^^xsd:string ;
   rdfs:label "made observation" ;
 .
 sosa-core:observedProperty
   rdf:type owl:ObjectProperty ;
-  schema:domainIncludes sosa-core:Observation ;
-  schema:rangeIncludes sosa-core:ObservableProperty ;
+  meta:domainIncludes sosa-core:Observation ;
+  meta:rangeIncludes sosa-core:ObservableProperty ;
   rdfs:comment "Relation linking an Observation to the Property that was observed.  The observedProperty should be a Property (hasProperty) of the FeatureOfInterest (linked by featureOfInterest) of this observation." ;
   rdfs:label "observed property"@en ;
 .
 sosa-core:observes
   rdf:type owl:ObjectProperty ;
-  schema:domainIncludes sosa-core:SensingProcedure ;
-  schema:rangeIncludes sosa-core:ObservableProperty ;
-  rdfs:comment "Relation between a SensingProcedure and an ObservableProperty."^^xsd:string ;
+  meta:domainIncludes sosa-core:Procedure ;
+  meta:rangeIncludes sosa-core:ObservableProperty ;
+  rdfs:comment "Relation between a Procedure and an ObservableProperty."^^xsd:string ;
   rdfs:label "observes"^^xsd:string ;
 .
 sosa-core:phenomenonTime
   rdf:type owl:ObjectProperty ;
-  schema:domainIncludes sosa-core:Observation ;
+  meta:domainIncludes sosa-core:Observation ;
   rdfs:comment "The time that the Result of an Observation applies to the FeatureOfInterest - not necessarily the same as the result-time."^^xsd:string ;
   rdfs:label "phenomenon time" ;
 .
 sosa-core:resultTime
   rdf:type owl:DatatypeProperty ;
-  schema:domainIncludes sosa-core:Observation ;
+  meta:domainIncludes sosa-core:Observation ;
   rdfs:comment "The result time is the time when the Procedure associated with the Observation act was completed."^^xsd:string ;
   rdfs:range xsd:dateTime ;
 .
 sosa-core:sampledFeature
   rdf:type owl:ObjectProperty ;
-  schema:domainIncludes sosa-core:SamplingFeature ;
-  schema:rangeIncludes owl:Thing ;
+  meta:domainIncludes sosa-core:SamplingFeature ;
   rdfs:comment "Relation from a SamplingFeature to the Feature that it is intended to be representative of." ;
   rdfs:label "sampled feature" ;
 .
-sosa-core:samplingStrategy
-  rdf:type owl:ObjectProperty ;
-  schema:domainIncludes sosa-core:Observation ;
-  schema:rangeIncludes sosa-core:SamplingFeature ;
-  schema:rangeIncludes sosa-core:SamplingProcedure ;
-  rdfs:comment "Relation from an Observation or Sensing activity to a SamplingFeature or SamplingProcedure."@en ;
-  rdfs:label "sampling strategy"@en ;
-.
 sosa-core:usedProcedure
   rdf:type owl:ObjectProperty ;
-  schema:domainIncludes sosa-core:Observation ;
-  schema:rangeIncludes sosa-core:Procedure ;
+  meta:domainIncludes sosa-core:Observation ;
+  meta:rangeIncludes sosa-core:Procedure ;
   rdfs:comment "Link to a re-usable Procedure used in making Observation. Typically a sensor or sensor-system, algorithm, computational procedure."^^xsd:string ;
   rdfs:label "observation procedure"@en ;
 .


### PR DESCRIPTION
I went into more details what a Procedure is and what it can be used for.

I removed all subclasses of Activity (such as Actuation) but not Activity itself. The description of Activity now names the previous subclasses as examples, e.g., a sampling activity. I changed all the comments that referred to these classes while making sure that the descriptions clarify that different procedures can be set up for different activities. Summing up, we have something like a soft hierarchy now, i.e., no axiomatization but natural descriptions for which kinds of activities and procedures can exist/ be useful.

I removed the strong link between Observation and Activity. We have to agree first whether an Observation is an Information Object or not. This is basically reverting the changes to the original SSN view _without_ implying that this is the right way to go.

I removed Device and Platform but left Observer. Before somebody panics, there is actually a good reason for doing so based on yesterday's emails. We discussed before that we need something like SensingDevice for the thing that carries one or multiple sensors. We also discussed that this should not be Device because humans are not devices. We also discussed that the term Platform is often used in a different sense. To do so, I had to change the textual definition of Observer a bit. I suggest using mereotopology instead of class hierarchies here, i.e., a Sensor is mounted on (partOf, hostedBy,..) an Observer, but a Sensor is not a specific kind of Observer.I also removed all hierarchical relations that relate other classes to Device. As always, these are just proposals, nothing is set in stone. You will see later on that not having a common class for Actuators and Sensors is not perfect, but we can leave it like this for our initial discussion.

I left SamplingFeature in SOSA-core. Please read the initial rdfs:comment. IMHO, it makes a very strong and compelling case.

I left domainIncludes and rangeIncludes but changed the namespace to meta. Thanks Kerry for pointing this out.

I removed some statements that (IMHO) do not carry any semantics such as '  meta:rangeIncludes owl:Thing ;' or 'rdfs:subClassOf owl:Thing ;'.

I removed some relations that we cannot use without subclasses of Procedure or Activity. One example is the samplingStrategy relation. I am not saying that this is the right path to take but simply do so to reflect yesterday's discussion.

Overall, the implemented changes reduce SOSA-core to 9 classes and 11 relations (those will need more work in another commit).
