### PR TITLE
Update sosa.ttl

### DIFF
--- a/ssn/rdf/sosa.ttl
+++ b/ssn/rdf/sosa.ttl
@@ -69,15 +69,15 @@ owl:topObjectProperty
   rdfs:label "Sensing, Observing, Sampling, and Actuating"^^xsd:string ;
   owl:imports <http://schema.org> ;
 .
-sosa-core:Activity
-  rdf:type rdfs:Class ;
-  rdfs:comment "An action or event during which a Procedure is used. This includes actuation via an actuating procedures, sampling via a sampling procedures, sensing via a sensing procedures, and so forth."@en ;
-  rdfs:label "Activity"@en ;
-.
 sosa-core:Actuator
   rdf:type owl:Class ;
   rdfs:comment "A device that is used by, or implements, an (actuating) Procedure."@en ;
   rdfs:label "Actuator"@en ;
+.
+sosa-core:Result
+  rdf:type owl:Class ;
+  rdfs:comment "The result of an observation or actuation, e.g., the value for on observed property of some feature of interest such as 20m for the height of a tree."@en ;
+  rdfs:label "Result"@en ;
 .
 sosa-core:ObservableProperty
   rdf:type owl:Class ;
@@ -88,12 +88,16 @@ sosa-core:Observation
   rdf:type owl:Class ;
   rdfs:comment "An Observation carries out an (observation) Procedure to estimate or calculate a value of a Property of a FeatureOfInterest. Links to an Observer or Sensor to describe what made the Observation and how; links to FeatureOfInterest detail what was observed; the Result is the output."@en ;
   rdfs:label "Observation"@en ;
-  rdfs:subClassOf sosa-core:Activity ;
 .
-sosa-core:Observer
+sosa-core:Actuation
   rdf:type owl:Class ;
-  rdfs:comment "Device, system, or agent (including humans) carrying at least one Sensor (e.g., eyes, GPS) to produce Observations by following a Procedure."@en ;
-  rdfs:label "Observer"@en ;
+  rdfs:comment "An Actuation carries out an (actuation) Procedure to change the state of the world via an Actuator."@en ;
+  rdfs:label "Actuation"@en ;
+.
+sosa-core:Host
+  rdf:type owl:Class ;
+  rdfs:comment "A device, system, platform, or agent (including humans). a host carries at least one Sensor or Actuator to produce observations or actuations by following a Procedure."@en ;
+  rdfs:label "Host"@en ;
 .
 sosa-core:Procedure
   rdf:type owl:Class ;
@@ -105,22 +109,21 @@ sosa-core:FeatureOfInterest
   rdfs:comment "The feature whose ObservableProperty is being observed by a Sensor to arrive at a Result. For example, when measuring the height of a tree, said height is the ObservedProperty, 20m may be the Result of the Observation, and the tree is the FeatureOfInterest. "@en ;
   rdfs:label "Feature Of Interest"@en ;
 .
-sosa-core:SamplingFeature
+sosa-core:Sample
   rdf:type owl:Class ;
   rdfs:comment "Feature on which observations may be made, which is intended to be representative of a FeatureOfInterest that is not fully accessible."@en ;
-  rdfs:comment """Sampling features are artifacts of an observational strategy, and have no significant function outside of their role in the observation process. The physical characteristics of the features themselves are of little interest, except perhaps to the manager of a sampling campaign.
+  rdfs:comment """Samples are artifacts of an observational strategy, and have no significant function outside of their role in the observation process. The physical characteristics of the features themselves are of little interest, except perhaps to the manager of a sampling campaign.
 
 EXAMPLE A “station” is essentially an identifiable locality where a sensor system or procedure may be deployed and an observation made. In the context of the observation model, it connotes the “world in the vicinity of the station”, so the observed properties relate to the physical medium at the station, and not to any physical artifact such as a mooring, buoy, benchmark, monument, well, etc.
 
-NOTE A transient sampling feature, such as a ships-track or flight-line, might be identified and described, but is unlikely to be revisited exactly.
+NOTE A transient sample, such as a ships-track or flight-line, might be identified and described, but is unlikely to be revisited exactly.
 
-A sampling feature is intended to sample some feature-of-interest in an application domain, so there is an expectation of at least one sampledFeature property. However, in some cases the identity, and even the exact type, of the sampled feature may not be known when observations are made using the sampling features."""@en ;
+A sample is intended to sample some feature-of-interest in an application domain, so there is an expectation of at least one sampledFeature property. However, in some cases the identity, and even the exact type, of the sampled feature may not be known when observations are made using the sampling features."""@en ;
   rdfs:label "Sample"@en ;
-  rdfs:label "Sampling Feature"@en ;
 .
 sosa-core:Sensor
   rdf:type owl:Class ;
-  rdfs:comment "Device or agent involved in, or implementing, a (sensing) Procedure. Sensors responds to a stimulus, e.g., a change in the environment, and generates a result. Sensors can be mounted on observers, e.g., a modern smartphone hosts multiple sensors."@en ;
+  rdfs:comment "Device or agent involved in, or implementing, a (sensing) Procedure. Sensors responds to a stimulus, e.g., a change in the environment, and generates a result. Sensors can be mounted on observers, e.g., a modern smart phone hosts multiple sensors."@en ;
   rdfs:label "Sensor"@en ;
 .
 sosa-core:featureOfInterest
@@ -133,7 +136,7 @@ sosa-core:featureOfInterest
 sosa-core:hasResult
   rdf:type owl:ObjectProperty ;
   meta:domainIncludes sosa-core:Observation ;
-  meta:domainIncludes sosa-core:Procedure ;
+  meta:domainIncludes sosa-core:Result ;
   rdfs:comment "Relation linking an Observation and a Sensor or Actuator and a Result, which contains a value representing the value associated with the observed Property."^^xsd:string ;
   rdfs:label "result"@en ;
 .
@@ -141,21 +144,21 @@ sosa-core:hostedBy
   rdf:type owl:ObjectProperty ;
   meta:domainIncludes sosa-core:Sensor ;
   meta:domainIncludes sosa-core:Actuator ;
-  meta:rangeIncludes sosa-core:Observer ;
-  rdfs:comment "Relation between a Sensor or Actuator and the Observer that it is mounted on or hosted by."^^xsd:string ;
+  meta:rangeIncludes sosa-core:Host ;
+  rdfs:comment "Relation between a Sensor or Actuator and the Host that it is mounted on or hosted by."^^xsd:string ;
   rdfs:label "hosted by"^^xsd:string ;
 .
 sosa-core:hosts
   rdf:type owl:ObjectProperty ;
-  meta:domainIncludes sosa-core:Observer ;
+  meta:domainIncludes sosa-core:Host ;
   meta:rangeIncludes sosa-core:Sensor ;
     meta:rangeIncludes sosa-core:Actuator ;
-  rdfs:comment "Relation between an Observer and a Sensor or Actuator hosted or mounted on it."^^xsd:string ;
+  rdfs:comment "Relation between a Host and a Sensor or Actuator hosted or mounted on it."^^xsd:string ;
   rdfs:label "hosts"^^xsd:string ;
 .
 sosa-core:madeObservation
   rdf:type owl:ObjectProperty ;
-  meta:domainIncludes sosa-core:Procedure ;
+  meta:domainIncludes sosa-core:Sensor ;
   meta:rangeIncludes sosa-core:Observation ;
   rdfs:comment "Relation between a Sensor and an Observations it has made."^^xsd:string ;
   rdfs:label "made observation" ;
@@ -169,33 +172,36 @@ sosa-core:observedProperty
 .
 sosa-core:observes
   rdf:type owl:ObjectProperty ;
-  meta:domainIncludes sosa-core:Procedure ;
+  meta:domainIncludes sosa-core:Sensor ;
   meta:rangeIncludes sosa-core:ObservableProperty ;
-  rdfs:comment "Relation between a Procedure and an ObservableProperty."^^xsd:string ;
+  rdfs:comment "Relation between a Sensor and an ObservableProperty."^^xsd:string ;
   rdfs:label "observes"^^xsd:string ;
 .
 sosa-core:phenomenonTime
   rdf:type owl:ObjectProperty ;
   meta:domainIncludes sosa-core:Observation ;
-  rdfs:comment "The time that the Result of an Observation applies to the FeatureOfInterest - not necessarily the same as the result-time."^^xsd:string ;
+  meta:domainIncludes sosa-core:Actuation ;
+  rdfs:comment "The time that the Result of an Observation/Actuation applies to the FeatureOfInterest - not necessarily the same as the result-time."^^xsd:string ;
   rdfs:label "phenomenon time" ;
 .
 sosa-core:resultTime
   rdf:type owl:DatatypeProperty ;
   meta:domainIncludes sosa-core:Observation ;
-  rdfs:comment "The result time is the time when the Procedure associated with the Observation act was completed."^^xsd:string ;
+  meta:domainIncludes sosa-core:Actuation ;
+  rdfs:comment "The result time is the time when the Observation/Actuation act was completed."^^xsd:string ;
   rdfs:range xsd:dateTime ;
 .
 sosa-core:sampledFeature
   rdf:type owl:ObjectProperty ;
-  meta:domainIncludes sosa-core:SamplingFeature ;
-  rdfs:comment "Relation from a SamplingFeature to the Feature that it is intended to be representative of." ;
+  meta:domainIncludes sosa-core:Sample ;
+  rdfs:comment "Relation from a Sample to the FeatureOfInterest that it is intended to be representative of." ;
   rdfs:label "sampled feature" ;
 .
 sosa-core:usedProcedure
   rdf:type owl:ObjectProperty ;
   meta:domainIncludes sosa-core:Observation ;
+  meta:domainIncludes sosa-core:Actuation ;
   meta:rangeIncludes sosa-core:Procedure ;
-  rdfs:comment "Link to a re-usable Procedure used in making Observation. Typically a sensor or sensor-system, algorithm, computational procedure."^^xsd:string ;
+  rdfs:comment "Link to a re-usable Procedure used in making Observation or Actuation. Typically a sensor or sensor-system, algorithm, computational procedure."^^xsd:string ;
   rdfs:label "observation procedure"@en ;
 .


### PR DESCRIPTION
Removed Activity and changed descriptions that made use of it.

Renamed Observer to Host and adjusted description.

Changed SamplingFeature to Sample and changed description.

Added Actuation.

Reworked the relations to fit the new/changed classes (e.g., they were all restricted to observations only).

If you would like to make changes, please start from this version (it is based on discussions around w3c/sdw-sosa-ssn#58 and w3c/sdw#311).
