### PR TITLE
SSN - remove comment about predecessors

### DIFF
--- a/ssn/index.html
+++ b/ssn/index.html
@@ -114,14 +114,14 @@ released at this time to solicit public comment.</p>
 <h2>Introduction</h2>
 <p> Sensor observations are a major source of data published on the Web. Nonetheless, publishing, searching, reusing, and integrating this data requires more than just the observation values. Of equal importance is information about the studied feature of interest, such as a river, the observed property, such as flow velocity, and the sampling strategy, such as the specific locations at which the velocity was measured. The sampling location, instrumentation, and information about the deployment of the sensors on a platform may also be required for proper interpretation. OGC's Sensor Web Enablement standards [<a href="#bib-OM">O&amp;M</a>, <a href="#bib-SensorML">SensorML</a>] provide a means to annotate sensors and their observations. However, these standards are not yet integrated and aligned with W3C Semantic Web technologies and Linked Data in particular, that are a key driver for creating and maintaining a global and densely interconnected graph of data. The W3C Semantic Sensor Network Incubator Group (SSN) addressed these issues by developing an ontology that spans multiple OGC standards and other specifications. </p>
 <p>
-Unlike its predecessors, the SSN is designed to offer four identifiable and coherent perspectives or use cases for sensing, each of which may be used either independently or in concert with the others. These perspectives are
+The SSN is designed to offer four identifiable and coherent perspectives or use cases for sensing, each of which may be used either independently or in concert with the others. These perspectives are
 <dl>
 <dt>Sensors</dt> <dd>with a focus on what senses, how it senses, and what is sensed;</dd>
 <dt>Data</dt> <dd>with a focus on observations and metadata;</dd>
 <dt>Systems</dt> <dd>with a focus on systems of sensors; and</dd>
 <dt>Features</dt> <dd>with a  focus on physical features, properties of them,  what can  sense them, and  what observations of them are made.</dd>
 </dl>
-<p  class="issue"  data-number="110">It would be worth clarifying that SWE evolving from way back in 2002 provides distinct provider- and consumer-focused standards; SensorML (dealing with sensors) and O&M (dealing with observations and data).</p>
+<p  class="issue"  data-number="110">It would be worth clarifying that SWE evolving from way back in 2002 provides distinct provider- and consumer-focused standards; SensorML (dealing with sensors) and O&M (dealing with observations and data), as well as an explicit treatment of sampling and the relation with feature-of-interest.</p>
 
 
 <p>Based on this initial work, the following document specifies a revised, modularized, and extended version of the SSN.</p>

--- a/ssn/index.html
+++ b/ssn/index.html
@@ -2271,6 +2271,11 @@ This means that the classes represent concepts from the application domain, so c
 
 <p  class="issue"  data-number="111">Complete SOSA/SSN to O&amp;M mapping table should be included in the SSN document and an alignment ontology provided.</p>
 
+<p class="note">An RDF representation of a preliminary SOSA-O&amp;M alignment is at <a href="https://github.com/w3c/sdw/blob/gh-pages/ssn/rdf/sosa-om.ttl">https://github.com/w3c/sdw/blob/gh-pages/ssn/rdf/sosa-om.ttl</a> . URIs from the official ISO/TC 211 OWL implementation are used to identify the UML elements from ISO 19156/OGC O&amp;M. </p>
+
+<p class="note">An RDF representation of a preliminary SOSA-om-lite alignment is at from <a href="https://github.com/w3c/sdw/blob/gh-pages/ssn/rdf/sosa-oml.ttl">https://github.com/w3c/sdw/blob/gh-pages/ssn/rdf/sosa-oml.ttl</a> . </p>
+
+
 </section>
 
 


### PR DESCRIPTION
Remove slightly misleading comment about predecessors; 
clarify viewpoints provided by OGC SWE