### PR TITLE
add back readability spacing for 2ontology alignments (4th time)

### DIFF
--- a/ssn/index.html
+++ b/ssn/index.html
@@ -2016,7 +2016,7 @@ The class ssn:Sensor has been redefined from the old SSN, so the assertion below
 
 <pre class=""> <code>
 &amp;old = "http://purl.oclc.org/NET/ssnx/ssn#"
-&amp;&ssn = "http://www.w3.org/ns/ssn/"
+&amp;ssn = "http://www.w3.org/ns/ssn/"
 &lt;owl:Class rdf:about="&amp;old;Sensor"&gt;
     &lt;rdfs:subClassOf rdf:resource="&amp;ssn;Sensor"/&gt;
 &lt;/owl:Class&gt;

--- a/ssn/index.html
+++ b/ssn/index.html
@@ -1426,7 +1426,7 @@ AFTER "<td>  <span rel="rdfs:isDefinedBy"><a href="http://www.w3.org/ns/ssn"></a
 <a href="#SSNhasMeasurementCapability" title="http://www.w3.org/ns/ssn/hasMeasurementCapability">hasMeasurementCapability</a> <span class="logic">o</span> <a href="#SSNforProperty" title="http://www.w3.org/ns/ssn/forProperty">forProperty</a></tr>
 
 
-<!--END HANDWRITTEN FOR OBSERVES ROLE COMPOSITION - KLT -->	
+<!--END HANDWRITTEN FOR OBSERVES ROLE COMPOSITION - KLT -->
 
 
 
@@ -2012,33 +2012,33 @@ style="font-family: courier;">http://www.w3.org/ns/ssn/</span>
 href="http://www.w3.org/ns/ssn-bc"> here.</a></p>
 
 
-The class ssn:Sensor has been redefined from the old SSN, so the assertion below holds in approximately RDF/XML syntax.
+The class ssn:Sensor has been redefined from the old SSN, so the assertion below holds in (approximately) RDF/XML syntax.
 
 <pre class=""> <code>
 &amp;old = "http://purl.oclc.org/NET/ssnx/ssn#"
 &amp;&ssn = "http://www.w3.org/ns/ssn/"
 &lt;owl:Class rdf:about="&amp;old;Sensor"&gt;
-&lt;rdfs:subClassOf rdf:resource="&amp;ssn;Sensor"/&gt;
+    &lt;rdfs:subClassOf rdf:resource="&amp;ssn;Sensor"/&gt;
 &lt;/owl:Class&gt;
 </code>
 </pre>
 
 All other  SSN class and properties are declared to be equivalent. 
-Therefore, the following pattern applies in approximately RDF/XML syntax.
+Therefore, the following pattern applies in (approximately) RDF/XML syntax.
 <pre class=""> <code>
 &amp;old = "http://purl.oclc.org/NET/ssnx/ssn#"
 &amp;ssn = "http://www.w3.org/ns/ssn/"
 For every owl:ObjectProperty <i>O</i> in SSN but not in {Sensor}, 
-assert the fragment:
-&lt;owl:ObjectProperty rdf:about="&amp;old;<i>O</i>"&gt;
-&lt;owl:equivalentProperty rdf:resource="&amp;ssn;<i>O</i>"&gt;
-&lt;/owl:ObjectProperty&gt;
-Endfor		
+    assert the fragment:
+        &lt;owl:ObjectProperty rdf:about="&amp;old;<i>O</i>"&gt;
+            &lt;owl:equivalentProperty rdf:resource="&amp;ssn;<i>O</i>"&gt;
+        &lt;/owl:ObjectProperty&gt;
+Endfor
 For every owl:Class <i>C</i> in SSN but not in {Sensor}, 
-assert the fragment:
-&lt; owl:Class rdf:about="&amp;old;<i>C</i>"&gt;
-&lt; owl:equivalenClass rdf:resource="&amp;ssn;<i>C</i>"&gt;
-&lt; /owl:Class&gt;
+    assert the fragment:
+        &lt;owl:Class rdf:about="&amp;old;<i>C</i>"&gt;
+            &lt;owl:equivalentClass rdf:resource="&amp;ssn;<i>C</i>"&gt;
+        &lt;/owl:Class&gt;
 Endfor
 </code>
 </pre>
@@ -2115,29 +2115,30 @@ rdfs:subClassOf &lt;http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Design
 
 ###  http://www.w3.org/ns/ssn/FeatureOfInterest
 &lt;http://www.w3.org/ns/ssn/FeatureOfInterest&gt; rdf:type owl:Class ;
-rdfs:subClassOf [ rdf:type owl:Class ;
-owl:unionOf ( &lt;http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Event&gt;
-&lt;http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Object&gt;
-)
-] .
+rdfs:subClassOf 
+    [ rdf:type owl:Class ;
+        owl:unionOf ( &lt;http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Event&gt;
+                      &lt;http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Object&gt;
+                    )
+    ] .
 
 
 ###  http://www.w3.org/ns/ssn/Observation
 &lt;http://www.w3.org/ns/ssn/Observation&gt; rdf:type owl:Class ;
 rdfs:subClassOf &lt;http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Situation&gt; ,
-[ rdf:type owl:Restriction ;
-owl:onProperty &lt;http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#includesEvent&gt; ;
-owl:someValuesFrom &lt;http://www.w3.org/ns/ssn/Stimulus&gt;
-] .
+    [ rdf:type owl:Restriction ;
+            owl:onProperty &lt;http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#includesEvent&gt; ;
+            owl:someValuesFrom &lt;http://www.w3.org/ns/ssn/Stimulus&gt;
+    ] .
 
 
 ###  http://www.w3.org/ns/ssn/ObservationValue
 &lt;http://www.w3.org/ns/ssn/ObservationValue&gt; rdf:type owl:Class ;
 rdfs:subClassOf &lt;http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Region&gt; ,
-[ rdf:type owl:Restriction ;
-owl:onProperty &lt;http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#isRegionFor&gt; ;
-owl:someValuesFrom &lt;http://www.w3.org/ns/ssn/SensorOutput&gt;
-] .
+    [ rdf:type owl:Restriction ;
+        owl:onProperty &lt;http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#isRegionFor&gt; ;
+        owl:someValuesFrom &lt;http://www.w3.org/ns/ssn/SensorOutput&gt;
+    ] .
 
 
 ###  http://www.w3.org/ns/ssn/Platform
@@ -2542,9 +2543,9 @@ Changes since the original (linked here) include
 </li>
 <li> The modularisation as presented here, including the core, is entirely new.
 
-</ol>	  
+</ol> 
 
-<p>	Changes since the FPWD (http://www.w3.org/TR/2016/WD-vocab-ssn-20160531/) include...</p>
+<p>Changes since the FPWD (http://www.w3.org/TR/2016/WD-vocab-ssn-20160531/) include...</p>
 <ol>
 <li>  
 Correction to include some ssn terms that were unintentionally dropped from the FPWD. Correction to remove an asserted subclass of owl:Thing that was introduced into FPWD (these were both by-products of Dolce removal).
@@ -2559,7 +2560,7 @@ Correction to include some ssn terms that were unintentionally dropped from the 
 <li>
 <p class="issue"  data-number="105"> Object properties ssn:isValueOf, ssn:produces and  ssn:featureinObservation, along with a propertychain subproperty of produces and another propertychain subproperty of  hasProperty, were introduced unintentionally in the FPWD. These have been removed here but could be reinstated if there is demand.
 </p>
-</li>	
+</li>
 </ol>
 </section>
 <section  class="appendix"  id="references">


### PR DESCRIPTION
there are no tabs but space characters  have been used
Aim to replace by a better alignment using css if possible.