### PR TITLE
Removed duplicate entry for LOCN

### DIFF
--- a/bp/index.html
+++ b/bp/index.html
@@ -1461,12 +1461,11 @@ a:Dataset a dcat:Dataset ;
               etc.)</li>
             <li>BBC's <a href="http://www.bbc.co.uk/ontologies/coreconcepts#terms_Place"
               >Place</a></li>
-            <li><a href="https://www.w3.org/ns/locn#">ISA Programme Location Core Vocabulary</a></li>
+            <li><a href="https://www.w3.org/ns/locn#">ISA Programme Location Core Vocabulary (LOCN)</a></li>
             <li><a href="http://sw-portal.deri.org/ontologies/swportal#">SWPortal ontology</a>
               includes definition of location</li>
             <li><a href="https://www.w3.org/2006/vcard/ns#">VCard ontology</a> includes definition of
               location</li>
-            <li><a href="https://www.w3.org/ns/locn">LOCN</a></li>
             <li><a href="https://www.w3.org/2005/Incubator/geo/XGR-geo-20071023/">GeoRSS OWL</a></li>
             <li>stSPARQL from <a href="http://strabon.di.uoa.gr/">Strabon</a> system (see
               publications <a href="http://www.strabon.di.uoa.gr/files/iswc-strabon.pdf"


### PR DESCRIPTION
LOCN was included twice in the list of spatial vocabularies.