### PR TITLE
Some proposals for SSN to import & reuse SOSA classes and properties

### DIFF
--- a/ssn/ssn_separated/ssn.ttl
+++ b/ssn/ssn_separated/ssn.ttl
@@ -178,10 +178,10 @@ ssn:FeatureOfInterest
       owl:onProperty ssn:hasProperty ;
       owl:someValuesFrom ssn:Property ;
     ] ;
-  skos:changeNote """--
+  skos:definition "The feature whose ObservableProperty is being observed by a Sensor to arrive at a Result" ;
+  skos:editorialNote """--
 Replace with sosa:FeatureOfInterest ?
 --""" ;
-  skos:definition "The feature whose ObservableProperty is being observed by a Sensor to arrive at a Result" ;
   skos:example "For example, when measuring the height of a tree, the height is the ObservedProperty, 20m may be the Result of the Observation, and the tree is the FeatureOfInterest." ;
 .
 ssn:Frequency
@@ -370,7 +370,7 @@ O&M conflates what we have as SensorOutput and ObservationValue into observation
   rdfs:label "Observation Value" ;
   rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Base#Data" ;
   rdfs:subClassOf <http://www.w3.org/ns/sosa/Result> ;
-  skos:changeNote """--
+  skos:editorialNote """--
 sub-class of sosa:Result, which also includes results of actuation and sampling activities
 --""" ;
 .
@@ -489,10 +489,10 @@ ssn:Property
       owl:onProperty ssn:isPropertyOf ;
       owl:someValuesFrom ssn:FeatureOfInterest ;
     ] ;
-  skos:changeNote """--
+  skos:definition "An observable Quality of a Thing; typically a FeatureOfInterest." ;
+  skos:editorialNote """--
 Replace by sosa:ObservableProperty
 --""" ;
-  skos:definition "An observable Quality of a Thing; typically a FeatureOfInterest." ;
 .
 ssn:Resolution
   rdf:type owl:Class ;
@@ -727,7 +727,7 @@ ssn:attachedSystem
   rdfs:label "attached system" ;
   rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#PlatformSite" ;
   owl:inverseOf ssn:onPlatform ;
-  skos:changeNote """--
+  skos:editorialNote """--
 Replace by sosa:hosts
 --""" ;
 .
@@ -776,10 +776,10 @@ ssn:featureOfInterest
   rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
   rdfs:label "feature of interest" ;
   rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" ;
-  skos:changeNote """--
+  skos:definition "A relation between an Observation and the entity whose quality was observed. " ;
+  skos:editorialNote """--
 Replace by sosa:hasFeatureOfInterest ?
 --""" ;
-  skos:definition "A relation between an Observation and the entity whose quality was observed. " ;
   skos:example "For example, in an Observation of the weight of a person, the FeatureOfInterest is the person and the quality is weight." ;
 .
 ssn:forProperty
@@ -934,10 +934,10 @@ ssn:madeObservation
   rdfs:label "made observation" ;
   rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Observation#Observation" ;
   owl:inverseOf ssn:observedBy ;
-  skos:changeNote """--
+  skos:definition "Relation between a Sensor and an Observations it has made." ;
+  skos:editorialNote """--
 Replace by sosa:madeObservation ?
 --""" ;
-  skos:definition "Relation between a Sensor and an Observations it has made." ;
 .
 ssn:observationResult
   rdf:type owl:ObjectProperty ;
@@ -948,7 +948,7 @@ ssn:observationResult
   rdfs:label "observation result" ;
   rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" ;
   rdfs:subPropertyOf <http://www.w3.org/ns/sosa/hasResult> ;
-  skos:changeNote """--
+  skos:editorialNote """--
 sub-property of sosa:hasResult (which also includes actuation and sample preparation activities)
 --""" ;
 .
@@ -961,7 +961,7 @@ ssn:observationResultTime
   rdfs:label "observation result time" ;
   rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Observation#Observation" ;
   rdfs:subPropertyOf <http://www.w3.org/ns/sosa/resultTime> ;
-  skos:changeNote """--
+  skos:editorialNote """--
 sub-property of sosa:resultTime - which also includes result of actuation and sampling activities
 --""" ;
 .
@@ -973,10 +973,10 @@ ssn:observationSamplingTime
   rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
   rdfs:label "observation sampling time" ;
   rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Observation#Observation" ;
-  skos:changeNote """--
+  skos:definition "The time that the Result of an Observation/Actuation applies to the FeatureOfInterest. Not necessarily the same as the result-time. May be an interval or an instant, or some other compound temporal entity." ;
+  skos:editorialNote """--
 Replace by sosa:phenomenonTime ?
 --""" ;
-  skos:definition "The time that the Result of an Observation/Actuation applies to the FeatureOfInterest. Not necessarily the same as the result-time. May be an interval or an instant, or some other compound temporal entity." ;
 .
 ssn:observedBy
   rdf:type owl:ObjectProperty ;
@@ -992,10 +992,10 @@ ssn:observedProperty
   rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
   rdfs:label "observed property" ;
   rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" ;
-  skos:changeNote """--
+  skos:definition "Relation linking an Observation to the Property that was observed. The observedProperty should be a Property (hasProperty) of the FeatureOfInterest (linked by featureOfInterest) of this observation." ;
+  skos:editorialNote """--
 Replace by sosa:observedProeprty ?
 --""" ;
-  skos:definition "Relation linking an Observation to the Property that was observed. The observedProperty should be a Property (hasProperty) of the FeatureOfInterest (linked by featureOfInterest) of this observation." ;
 .
 ssn:observes
   rdf:type owl:ObjectProperty ;
@@ -1013,10 +1013,10 @@ Note that, given the DUL modelling of Qualities, a sensor defined with 'observes
       ssn:madeObservation
       ssn:observedProperty
     ) ;
-  skos:changeNote """--
+  skos:definition "Relation between a Sensor and an ObservableProperty." ;
+  skos:editorialNote """--
 Replace by sosa:observes ?
 --""" ;
-  skos:definition "Relation between a Sensor and an ObservableProperty." ;
 .
 ssn:ofFeature
   rdf:type owl:ObjectProperty ;
@@ -1031,10 +1031,10 @@ ssn:onPlatform
   rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
   rdfs:label "on platform" ;
   rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#PlatformSite" ;
-  skos:changeNote """--
+  skos:definition "Relation between a Sensor or Actuator and the Platform that it is mounted on or hosted by." ;
+  skos:editorialNote """--
 Replace by sosa:hostedBy ?
 --""" ;
-  skos:definition "Relation between a Sensor or Actuator and the Platform that it is mounted on or hosted by." ;
 .
 ssn:qualityOfObservation
   rdf:type owl:ObjectProperty ;
@@ -1054,7 +1054,7 @@ ssn:sensingMethodUsed
   rdfs:label "sensing method used" ;
   rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" ;
   rdfs:subPropertyOf <http://www.w3.org/ns/sosa/usedProcedure> ;
-  skos:changeNote """--
+  skos:editorialNote """--
 Sub-property of sosa:usedProcedure - whcih also includes actuation and sampling activities
 --""" ;
 .

--- a/ssn/ssn_separated/ssn.ttl
+++ b/ssn/ssn_separated/ssn.ttl
@@ -1,689 +1,275 @@
+# baseURI: http://www.w3.org/ns/ssn/
+# imports: http://www.w3.org/2004/02/skos/core
+# imports: http://www.w3.org/ns/sosa/
+# prefix: ssn
+
 @prefix : <http://www.w3.org/ns/ssn/> .
 @prefix cc: <http://creativecommons.org/ns#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix ssn: <http://www.w3.org/ns/ssn/> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@base <http://www.w3.org/ns/ssn/> .
 
-<http://www.w3.org/ns/ssn/> rdf:type owl:Ontology ;
-                             dc:creator "W3C Semantic Sensor Network Incubator Group"^^xsd:string ;
-                             dct:modified "2016-09-08" ;
-                             rdfs:comment "New modular version of the SSN ontology independent of DUL."^^xsd:string ,
-                                          " Please report any errors to the Semantic Sensor Network Incubator Activity via the public W3C list public-xg-ssn@w3.org"^^xsd:string ;
-                             rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/" ;
-                             dc:title "Semantic Sensor Network Ontology" ;
-                             dct:modified "2011-06-20" ;
-                             dc:identifier "http://www.w3.org/ns/ssn" ;
-                             cc:license <http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231.html> ;
-                             rdfs:comment "This ontology is developed by the W3C Semantic Sensor Networks Incubator Group (SSN-XG). The concepts and structure of the ontology were discussed in the group's meetings and on the mailing list. For more information on the group's activities see: http://www.w3.org/2005/Incubator/ssn/"^^xsd:string ;
-                             dc:rights "Copyright 2009 - 2011 W3C." ;
-                             rdfs:comment "This ontology describes sensors and observations, and related concepts.  It does not describe domain concepts, time, locations, etc. these are intended to be included from other ontologies via OWL imports."^^xsd:string ;
-                             dct:created "2009-12-02" .
-
-#################################################################
-#    Annotation properties
-#################################################################
-
-###  http://creativecommons.org/ns#license
-cc:license rdf:type owl:AnnotationProperty .
-
-
-###  http://purl.org/dc/elements/1.1/creator
-dc:creator rdf:type owl:AnnotationProperty .
-
-
-###  http://purl.org/dc/elements/1.1/date
-dc:date rdf:type owl:AnnotationProperty .
-
-
-###  http://purl.org/dc/elements/1.1/identifier
-dc:identifier rdf:type owl:AnnotationProperty .
-
-
-###  http://purl.org/dc/elements/1.1/rights
-dc:rights rdf:type owl:AnnotationProperty .
-
-
-###  http://purl.org/dc/elements/1.1/source
-dc:source rdf:type owl:AnnotationProperty .
-
-
-###  http://purl.org/dc/elements/1.1/title
-dc:title rdf:type owl:AnnotationProperty .
-
-
-###  http://purl.org/dc/terms/created
-dct:created rdf:type owl:AnnotationProperty .
-
-
-###  http://purl.org/dc/terms/modified
-dct:modified rdf:type owl:AnnotationProperty .
-
-
-###  http://www.w3.org/2000/01/rdf-schema#comment
-rdfs:comment rdf:type owl:AnnotationProperty .
-
-
-###  http://www.w3.org/2000/01/rdf-schema#isDefinedBy
-rdfs:isDefinedBy rdf:type owl:AnnotationProperty .
-
-
-###  http://www.w3.org/2000/01/rdf-schema#label
-rdfs:label rdf:type owl:AnnotationProperty .
-
-
-###  http://www.w3.org/2000/01/rdf-schema#seeAlso
-rdfs:seeAlso rdf:type owl:AnnotationProperty .
-
-
-#################################################################
-#    Object Properties
-#################################################################
-
-###  http://www.w3.org/ns/ssn/attachedSystem
-ssn:attachedSystem rdf:type owl:ObjectProperty ;
-                   owl:inverseOf ssn:onPlatform ;
-                   rdfs:comment "Relation between a Platform and any Systems (e.g., Sensors) that are attached to the Platform." ;
-                   rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                   rdfs:label "attached system" ;
-                   rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#PlatformSite" .
-
-
-###  http://www.w3.org/ns/ssn/deployedOnPlatform
-ssn:deployedOnPlatform rdf:type owl:ObjectProperty ;
-                       owl:inverseOf ssn:inDeployment ;
-                       rdfs:comment "Relation between a deployment and the platform on which the system is deployed." ;
-                       rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                       rdfs:label "deployed on platform" ;
-                       rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#Deployment" .
-
-
-###  http://www.w3.org/ns/ssn/deployedSystem
-ssn:deployedSystem rdf:type owl:ObjectProperty ;
-                   owl:inverseOf ssn:hasDeployment ;
-                   rdfs:comment "Relation between a deployment and the deployed system." ;
-                   rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                   rdfs:label "deployed system" ;
-                   rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#Deployment" .
-
-
-###  http://www.w3.org/ns/ssn/deploymentProcessPart
-ssn:deploymentProcessPart rdf:type owl:ObjectProperty ;
-                          rdfs:comment "Relation between a deployment process and its constituent processes (has-part)." ;
-                          rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                          rdfs:label "deployment process part" ;
-                          rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#Deployment" .
-
-
-###  http://www.w3.org/ns/ssn/detects
-ssn:detects rdf:type owl:ObjectProperty ;
-            rdfs:comment """A relation from a sensor to the Stimulus that the sensor can detect.   
-The Stimulus itself will be serving as a proxy for (see isProxyOf) some observable property.""" ;
-            rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-            rdfs:label "detects" ;
-            rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" .
-
-
-###  http://www.w3.org/ns/ssn/endTime
-ssn:endTime rdf:type owl:ObjectProperty ;
-            rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-            rdfs:label "end time" ;
-            rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Base#Time" .
-
-
-###  http://www.w3.org/ns/ssn/featureOfInterest
-ssn:featureOfInterest rdf:type owl:ObjectProperty ;
-                      dc:source """skos:exactMatch 'featureOfInterest' [O&M - ISO/DIS 19156] 
-		                    http://portal.opengeospatial.org/files/?artifact_id=41579""" ;
-                      rdfs:comment "A relation between an observation and the entity whose quality was observed.   For example, in an observation of the weight of a person, the feature of interest is the person and the quality is weight." ;
-                      rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                      rdfs:label "feature of interest" ;
-                      rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" .
-
-
-###  http://www.w3.org/ns/ssn/forProperty
-ssn:forProperty rdf:type owl:ObjectProperty ;
-                rdfs:comment "A relation between some aspect of a sensing entity and a property.  For example, from a sensor to the properties it can observe, or from a deployment to the properties it was installed to observe.  Also from a measurement capability to the property the capability is described for.  Used in conjunction with ofFeature." ;
-                rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                rdfs:label "for property" ;
-                rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" .
-
-
-###  http://www.w3.org/ns/ssn/hasDeployment
-ssn:hasDeployment rdf:type owl:ObjectProperty ;
-                  rdfs:comment "Relation between a System and a Deployment, recording that the System or Sensor was deployed in that Deployment." ;
-                  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                  rdfs:label "has deployment" ;
-                  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#Deployment" .
-
-
-###  http://www.w3.org/ns/ssn/hasInput
-ssn:hasInput rdf:type owl:ObjectProperty ;
-             rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-             rdfs:label "has input" ;
-             rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Model#Process" .
-
-
-###  http://www.w3.org/ns/ssn/hasMeasurementCapability
-ssn:hasMeasurementCapability rdf:type owl:ObjectProperty ;
-                             rdfs:subPropertyOf ssn:hasProperty ;
-                             rdfs:comment "Relation from a Sensor to a MeasurementCapability describing the measurement properties of the sensor." ;
-                             rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                             rdfs:label "has measurement capability" ;
-                             rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Sensor#MeasuringCapability" .
-
-
-###  http://www.w3.org/ns/ssn/hasMeasurementProperty
-ssn:hasMeasurementProperty rdf:type owl:ObjectProperty ;
-                           rdfs:subPropertyOf ssn:hasProperty ;
-                           rdfs:comment "Relation from a MeasurementCapability to a MeasurementProperty such as accuracy (see notes for MeasurementCapability)." ;
-                           rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                           rdfs:label "has measurement property" ;
-                           rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Sensor#MeasuringCapability" .
-
-
-###  http://www.w3.org/ns/ssn/hasOperatingProperty
-ssn:hasOperatingProperty rdf:type owl:ObjectProperty ;
-                         rdfs:subPropertyOf ssn:hasProperty ;
-                         rdfs:comment "Relation from an OperatingRange to a Property such as battery lifetime." ;
-                         rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                         rdfs:label "has operating property" ;
-                         rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#OperatingRestriction" .
-
-
-###  http://www.w3.org/ns/ssn/hasOperatingRange
-ssn:hasOperatingRange rdf:type owl:ObjectProperty ;
-                      rdfs:subPropertyOf ssn:hasProperty ;
-                      rdfs:comment "Relation from a System to an OperatingRange describing the normal operating environment of the System." ;
-                      rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                      rdfs:label "has operating range" ;
-                      rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#OperatingRestriction" .
-
-
-###  http://www.w3.org/ns/ssn/hasOutput
-ssn:hasOutput rdf:type owl:ObjectProperty ;
-              rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-              rdfs:label "has output" ;
-              rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Model#Process" .
-
-
-###  http://www.w3.org/ns/ssn/hasProperty
-ssn:hasProperty rdf:type owl:ObjectProperty ;
-                owl:inverseOf ssn:isPropertyOf ;
-                rdfs:comment "Relation between a FeatureOfInterest and a Property of that feature." ;
-                rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                rdfs:label "has property" ;
-                rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" .
-
-
-###  http://www.w3.org/ns/ssn/hasSubSystem
-ssn:hasSubSystem rdf:type owl:ObjectProperty ;
-                 rdfs:comment "Relation between a system and its component parts (has-part)." ;
-                 rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                 rdfs:label "has subsystem" ;
-                 rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Model#System" .
-
-
-###  http://www.w3.org/ns/ssn/hasSurvivalProperty
-ssn:hasSurvivalProperty rdf:type owl:ObjectProperty ;
-                        rdfs:subPropertyOf ssn:hasProperty ;
-                        rdfs:comment "Relation from a SurvivalRange of a System to a Property describing the survival range of the system. For example, to the temperature range that a system can withstand before being considered damaged." ;
-                        rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                        rdfs:label "has survival property" ;
-                        rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#OperatingRestriction" .
-
-
-###  http://www.w3.org/ns/ssn/hasSurvivalRange
-ssn:hasSurvivalRange rdf:type owl:ObjectProperty ;
-                     rdfs:subPropertyOf ssn:hasProperty ;
-                     rdfs:comment "Relation from a System to a SurvivalRange." ;
-                     rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                     rdfs:label "has survival range" ;
-                     rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#OperatingRestriction" .
-
-
-###  http://www.w3.org/ns/ssn/hasValue
-ssn:hasValue rdf:type owl:ObjectProperty ;
-             rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-             rdfs:label "has value" ;
-             rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Base#Data" .
-
-
-###  http://www.w3.org/ns/ssn/implementedBy
-ssn:implementedBy rdf:type owl:ObjectProperty ;
-                  owl:inverseOf ssn:implements ;
-                  rdfs:comment "Relation between the description of an algorithm, procedure or method and an entity that implements that method in some executable way.  For example, between a scientific measuring method and a sensor that senses via that method." ;
-                  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                  rdfs:label "implemented by" ;
-                  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" .
-
-
-###  http://www.w3.org/ns/ssn/implements
-ssn:implements rdf:type owl:ObjectProperty ;
-               rdfs:comment "Relation between an entity that implements a method in some executable way and the description of an algorithm, procedure or method.  For example, between a Sensor and the scientific measuring method that the Sensor uses to observe a Property." ;
-               rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-               rdfs:label "implements" ;
-               rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" .
-
-
-###  http://www.w3.org/ns/ssn/inCondition
-ssn:inCondition rdf:type owl:ObjectProperty ;
-                rdfs:comment "Describes the prevailing environmental conditions for MeasurementCapabilites, OperatingConditions and SurvivalRanges.  Used for example to say that a sensor has a particular accuracy in particular conditions.  See also MeasurementCapability." ;
-                rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                rdfs:label "in condition" ;
-                rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Base#ConstraintBlock" .
-
-
-###  http://www.w3.org/ns/ssn/inDeployment
-ssn:inDeployment rdf:type owl:ObjectProperty ;
-                 rdfs:comment "Relation between a Platform and a Deployment, meaning that the subject was used as a platform for a system or sensor in the particular deployment. For example, between a buoy and a deployment identifier. " ;
-                 rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                 rdfs:label "in deployment" ;
-                 rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#Deployment" .
-
-
-###  http://www.w3.org/ns/ssn/isProducedBy
-ssn:isProducedBy rdf:type owl:ObjectProperty ;
-                 rdfs:comment "Relation between a producer and a produced entity. For example, between a sensor and the produced output." ;
-                 rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                 rdfs:label "is produced by" ;
-                 rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Model#Process" .
-
-
-###  http://www.w3.org/ns/ssn/isPropertyOf
-ssn:isPropertyOf rdf:type owl:ObjectProperty ;
-                 rdfs:comment "Relation between a FeatureOfInterest and a Property (a Quality observable by a sensor) of that feature." ;
-                 rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                 rdfs:label "is property of" ;
-                 rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" .
-
-
-###  http://www.w3.org/ns/ssn/isProxyFor
-ssn:isProxyFor rdf:type owl:ObjectProperty ;
-               rdfs:comment "A relation from a Stimulus to the Property that the Stimulus is serving as a proxy for.  For example, the expansion of quicksilver is a stimulus that serves as a proxy for temperature. An increase or decrease in the velocity of spinning cups on a wind sensor is serving as a proxy for wind speed." ;
-               rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-               rdfs:label "is proxy for" ;
-               rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" .
-
-
-###  http://www.w3.org/ns/ssn/madeObservation
-ssn:madeObservation rdf:type owl:ObjectProperty ;
-                    owl:inverseOf ssn:observedBy ;
-                    rdfs:comment "Relation between a Sensor and Observations it has made." ;
-                    rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                    rdfs:label "made observation" ;
-                    rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Observation#Observation" .
-
-
-###  http://www.w3.org/ns/ssn/observationResult
-ssn:observationResult rdf:type owl:ObjectProperty ;
-                      dc:source """skos:closeMatch 'result' [O&M - ISO/DIS 19156] 
-		                    http://portal.opengeospatial.org/files/?artifact_id=41579""" ;
-                      rdfs:comment "Relation linking an Observation (i.e., a description of the context, the Situation, in which the observation was made) and a Result, which contains a value representing the value associated with the observed Property." ;
-                      rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                      rdfs:label "observation result" ;
-                      rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" .
-
-
-###  http://www.w3.org/ns/ssn/observationResultTime
-ssn:observationResultTime rdf:type owl:ObjectProperty ;
-                          dc:source "http://www.opengeospatial.org/standards/om" ;
-                          rdfs:comment "The result time is the time when the procedure associated with the observation act was applied." ,
-                                       "The result time shall describe the time when the result became available, typically when the procedure associated with the observation was completed For some observations this is identical to the phenomenonTime. However, there are important cases where they differ.[O&M]" ;
-                          rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                          rdfs:label "observation result time" ;
-                          rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Observation#Observation" .
-
-
-###  http://www.w3.org/ns/ssn/observationSamplingTime
-ssn:observationSamplingTime rdf:type owl:ObjectProperty ;
-                            dc:source "http://www.opengeospatial.org/standards/om" ;
-                            rdfs:comment "Rebadged as phenomenon time in [O&M]. The phenomenon time shall describe the time that the result applies to the property of the feature-of-interest. This is often the time of interaction by a sampling procedure or observation procedure with a real-world feature." ,
-                                         "The sampling time is the time that the result applies to the feature-of-interest. This is the time usually required for geospatial analysis of the result." ;
-                            rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                            rdfs:label "observation sampling time" ;
-                            rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Observation#Observation" .
-
-
-###  http://www.w3.org/ns/ssn/observedBy
-ssn:observedBy rdf:type owl:ObjectProperty ;
-               rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-    		   rdfs:label "observed by" ;
-               rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" .
-
-
-###  http://www.w3.org/ns/ssn/observedProperty
-ssn:observedProperty rdf:type owl:ObjectProperty ;
-                     dc:source """skos:exactMatch 'observedProperty' [O&M - ISO/DIS 19156] 
-		                    http://portal.opengeospatial.org/files/?artifact_id=41579""" ;
-                     rdfs:comment "Relation linking an Observation to the Property that was observed.  The observedProperty should be a Property (hasProperty) of the FeatureOfInterest (linked by featureOfInterest) of this observation." ;
-                     rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                     rdfs:label "observed property" ;
-                     rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" .
-
-
-###  http://www.w3.org/ns/ssn/observes
-ssn:observes rdf:type owl:ObjectProperty ;
-             owl:propertyChainAxiom ( ssn:hasMeasurementCapability
-                                      ssn:forProperty
-                                    ) ,
-                                    ( ssn:madeObservation
-                                      ssn:observedProperty
-                                    ) ;
-             rdfs:comment """Relation between a Sensor and a Property that the sensor can observe.
-
-Note that, given the DUL modelling of Qualities, a sensor defined with 'observes only Windspeed' technically links the sensor to particular instances of Windspeed, not to the concept itself - OWL can't express concept-concept relations, only individual-individual.  The property composition ensures that if an observation is made of a particular quality then one can infer that the sensor observes that quality.""" ;
-             rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-             rdfs:label "observes" ;
-             rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Sensor#Measuring" .
-
-
-###  http://www.w3.org/ns/ssn/ofFeature
-ssn:ofFeature rdf:type owl:ObjectProperty ;
-              rdfs:comment "A relation between some aspect of a sensing entity and a feature.  For example, from a sensor to the features it can observe properties of, or from a deployment to the features it was installed to observe.  Also from a measurement capability to the feature the capability is described for.  (Used in conjunction with forProperty)." ;
-              rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-              rdfs:label "of feature" ;
-              rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" .
-
-
-###  http://www.w3.org/ns/ssn/onPlatform
-ssn:onPlatform rdf:type owl:ObjectProperty ;
-               rdfs:comment "Relation between a System (e.g., a Sensor) and a Platform.  The relation locates the sensor relative to other described entities entities: i.e., the Sensor s1's location is Platform p1.  More precise locations for sensors in space (relative to other entities, where attached to another entity, or in 3D space) are made using DOLCE's Regions (SpaceRegion)." ;
-               rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-               rdfs:label "on platform" ;
-               rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#PlatformSite" .
-
-
-###  http://www.w3.org/ns/ssn/qualityOfObservation
-ssn:qualityOfObservation rdf:type owl:ObjectProperty ;
-                         rdfs:subPropertyOf ssn:hasProperty ;
-                         dc:source """skos:exactMatch 'resultQuality' [O&M - ISO/DIS 19156] 
-		                    http://portal.opengeospatial.org/files/?artifact_id=41579""" ;
-                         rdfs:comment "Relation linking an Observation to the adjudged quality of the result.  This is of course complimentary to the MeasurementCapability information recorded for the Sensor that made the Observation." ;
-                         rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                         rdfs:label "quality of observation" ;
-                         rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Observation#Observation" .
-
-
-###  http://www.w3.org/ns/ssn/sensingMethodUsed
-ssn:sensingMethodUsed rdf:type owl:ObjectProperty ;
-                      dc:source "http://www.bipm.org/en/committees/jc/jcgm/wg2.html" ;
-                      rdfs:comment "A (measurement) procedure is a detailed description of a measurement according to one or more measurement principles and to a given measurement method, based on a measurement model and including any calculation to obtain a measurement result [VIM 2.6]" ;
-                      rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                      rdfs:label "sensing method used" ;
-                      rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" .
-
-
-###  http://www.w3.org/ns/ssn/startTime
-ssn:startTime rdf:type owl:ObjectProperty ;
-              rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-              rdfs:label "start time" ;
-              rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Base#Time" .
-
-
-#################################################################
-#    Classes
-#################################################################
-
-###  http://www.w3.org/ns/ssn/Accuracy
-ssn:Accuracy rdf:type owl:Class ;
-             rdfs:subClassOf ssn:MeasurementProperty ;
-             dc:source """skos:exactMatch 'measurement accuracy/accuracy' [VIM 2.13] 
+cc:license
+  rdf:type owl:AnnotationProperty ;
+.
+dc:creator
+  rdf:type owl:AnnotationProperty ;
+.
+dc:date
+  rdf:type owl:AnnotationProperty ;
+.
+dc:identifier
+  rdf:type owl:AnnotationProperty ;
+.
+dc:rights
+  rdf:type owl:AnnotationProperty ;
+.
+dc:source
+  rdf:type owl:AnnotationProperty ;
+.
+dc:title
+  rdf:type owl:AnnotationProperty ;
+.
+dct:created
+  rdf:type owl:AnnotationProperty ;
+.
+dct:modified
+  rdf:type owl:AnnotationProperty ;
+.
+rdfs:comment
+  rdf:type owl:AnnotationProperty ;
+.
+rdfs:isDefinedBy
+  rdf:type owl:AnnotationProperty ;
+.
+rdfs:label
+  rdf:type owl:AnnotationProperty ;
+.
+rdfs:seeAlso
+  rdf:type owl:AnnotationProperty ;
+.
+ssn:
+  rdf:type owl:Ontology ;
+  cc:license <http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231.html> ;
+  dc:creator "W3C Semantic Sensor Network Incubator Group" ;
+  dc:identifier "http://www.w3.org/ns/ssn" ;
+  dc:rights "Copyright 2009 - 2011 W3C." ;
+  dc:title "Semantic Sensor Network Ontology" ;
+  dct:created "2009-12-02" ;
+  dct:modified "2011-06-20" ;
+  dct:modified "2016-09-08" ;
+  rdfs:comment " Please report any errors to the Semantic Sensor Network Incubator Activity via the public W3C list public-xg-ssn@w3.org" ;
+  rdfs:comment "New modular version of the SSN ontology independent of DUL." ;
+  rdfs:comment "This ontology describes sensors and observations, and related concepts.  It does not describe domain concepts, time, locations, etc. these are intended to be included from other ontologies via OWL imports." ;
+  rdfs:comment "This ontology is developed by the W3C Semantic Sensor Networks Incubator Group (SSN-XG). The concepts and structure of the ontology were discussed in the group's meetings and on the mailing list. For more information on the group's activities see: http://www.w3.org/2005/Incubator/ssn/" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/" ;
+  owl:imports <http://www.w3.org/2004/02/skos/core> ;
+  owl:imports <http://www.w3.org/ns/sosa/> ;
+.
+ssn:Accuracy
+  rdf:type owl:Class ;
+  dc:source """skos:exactMatch 'measurement accuracy/accuracy' [VIM 2.13] 
 		                    http://www.bipm.org/utils/common/documents/jcgm/JCGM_200_2008.pdf""" ;
-             rdfs:comment "The closeness of agreement between the value of an observation and the true value of the observed quality." ;
-             rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-             rdfs:label "Accuracy" ;
-             rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Sensor#MeasuringCapability" .
-
-
-###  http://www.w3.org/ns/ssn/BatteryLifetime
-ssn:BatteryLifetime rdf:type owl:Class ;
-                    rdfs:subClassOf ssn:SurvivalProperty ;
-                    rdfs:comment "Total useful life of a battery." ;
-                    rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                    rdfs:label "Battery Lifetime" ;
-                    rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Energy#EnergyRestriction" .
-
-
-###  http://www.w3.org/ns/ssn/Condition
-ssn:Condition rdf:type owl:Class ;
-              rdfs:subClassOf ssn:Property ;
-              rdfs:comment "Used to specify ranges for qualities that act as conditions on a system/sensor's operation.  For example, wind speed of 10-60m/s is expressed as a condition linking a quality, wind speed, a unit of measurement, metres per second, and a set of values, 10-60, and may be used as the condition on a MeasurementProperty, for example, to state that a sensor has a particular accuracy in that condition." ;
-              rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-              rdfs:label "Condition" ;
-              rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Base#ConstraintBlock" .
-
-
-###  http://www.w3.org/ns/ssn/Deployment
-ssn:Deployment rdf:type owl:Class ;
-               rdfs:subClassOf ssn:DeploymentRelatedProcess ,
-                               [ rdf:type owl:Restriction ;
-                                 owl:onProperty ssn:deployedOnPlatform ;
-                                 owl:allValuesFrom ssn:Platform
-                               ] ,
-                               [ rdf:type owl:Restriction ;
-                                 owl:onProperty ssn:deployedSystem ;
-                                 owl:allValuesFrom ssn:System
-                               ] ;
-               dc:source """skos:closeMatch 'Deployment' [MMI Dev]
+  rdfs:comment "The closeness of agreement between the value of an observation and the true value of the observed quality." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "Accuracy" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Sensor#MeasuringCapability" ;
+  rdfs:subClassOf ssn:MeasurementProperty ;
+.
+ssn:BatteryLifetime
+  rdf:type owl:Class ;
+  rdfs:comment "Total useful life of a battery." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "Battery Lifetime" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Energy#EnergyRestriction" ;
+  rdfs:subClassOf ssn:SurvivalProperty ;
+.
+ssn:Condition
+  rdf:type owl:Class ;
+  rdfs:comment "Used to specify ranges for qualities that act as conditions on a system/sensor's operation.  For example, wind speed of 10-60m/s is expressed as a condition linking a quality, wind speed, a unit of measurement, metres per second, and a set of values, 10-60, and may be used as the condition on a MeasurementProperty, for example, to state that a sensor has a particular accuracy in that condition." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "Condition" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Base#ConstraintBlock" ;
+  rdfs:subClassOf ssn:Property ;
+.
+ssn:Deployment
+  rdf:type owl:Class ;
+  dc:source """skos:closeMatch 'Deployment' [MMI Dev]
                                  http://marinemetadata.org/community/teams/ontdevices""" ;
-               rdfs:comment "The ongoing Process of Entities (for the purposes of this ontology, mainly sensors) deployed for a particular purpose.  For example, a particular Sensor deployed on a Platform, or a whole network of Sensors deployed for an observation campaign.  The deployment may have sub-processes, such as installation, maintenance, addition, and decomissioning and removal." ;
-               rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-               rdfs:label "Deployment" ;
-               rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#Deployment" .
-
-
-###  http://www.w3.org/ns/ssn/DeploymentRelatedProcess
-ssn:DeploymentRelatedProcess rdf:type owl:Class ;
-                             rdfs:subClassOf [ rdf:type owl:Restriction ;
-                                               owl:onProperty ssn:deploymentProcessPart ;
-                                               owl:allValuesFrom ssn:DeploymentRelatedProcess
-                                             ] ;
-                             dc:source "http://www.w3.org/2005/Incubator/ssn/" ;
-                             rdfs:comment "Class to group all the various Processes related to Deployment.  For example, as well as Deployment, installation, maintenance, deployment of further sensors and the like would all be classified under DeploymentRelatedProcess." ;
-                             rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                             rdfs:label "Deployment-related Process" ;
-                             rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#Deployment" .
-
-
-###  http://www.w3.org/ns/ssn/DetectionLimit
-ssn:DetectionLimit rdf:type owl:Class ;
-                   rdfs:subClassOf ssn:MeasurementProperty ;
-                   dc:source """skos:exactMatch 'detection limit' [VIM 4.18] 
+  rdfs:comment "The ongoing Process of Entities (for the purposes of this ontology, mainly sensors) deployed for a particular purpose.  For example, a particular Sensor deployed on a Platform, or a whole network of Sensors deployed for an observation campaign.  The deployment may have sub-processes, such as installation, maintenance, addition, and decomissioning and removal." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "Deployment" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#Deployment" ;
+  rdfs:subClassOf ssn:DeploymentRelatedProcess ;
+  rdfs:subClassOf [
+      rdf:type owl:Restriction ;
+      owl:allValuesFrom ssn:Platform ;
+      owl:onProperty ssn:deployedOnPlatform ;
+    ] ;
+  rdfs:subClassOf [
+      rdf:type owl:Restriction ;
+      owl:allValuesFrom ssn:System ;
+      owl:onProperty ssn:deployedSystem ;
+    ] ;
+.
+ssn:DeploymentRelatedProcess
+  rdf:type owl:Class ;
+  dc:source "http://www.w3.org/2005/Incubator/ssn/" ;
+  rdfs:comment "Class to group all the various Processes related to Deployment.  For example, as well as Deployment, installation, maintenance, deployment of further sensors and the like would all be classified under DeploymentRelatedProcess." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "Deployment-related Process" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#Deployment" ;
+  rdfs:subClassOf [
+      rdf:type owl:Restriction ;
+      owl:allValuesFrom ssn:DeploymentRelatedProcess ;
+      owl:onProperty ssn:deploymentProcessPart ;
+    ] ;
+.
+ssn:DetectionLimit
+  rdf:type owl:Class ;
+  dc:source """skos:exactMatch 'detection limit' [VIM 4.18] 
                                  http://www.bipm.org/utils/common/documents/jcgm/JCGM_200_2008.pdf""" ;
-                   rdfs:comment "An observed value for which the probability of falsely claiming the absence of a component in a material is beta, given a probability alpha of falsely claiming its presence." ;
-                   rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                   rdfs:label "Detection Limit" ;
-                   rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Sensor#MeasuringCapability" .
-
-
-###  http://www.w3.org/ns/ssn/Device
-ssn:Device rdf:type owl:Class ;
-           rdfs:subClassOf ssn:System ;
-           dc:source "http://www.w3.org/2005/Incubator/ssn/" ;
-           rdfs:comment "A device is a physical piece of technology - a system in a box. Devices may of course be built of smaller devices and software components (i.e. systems have components)." ;
-           rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-           rdfs:label "Device" ;
-           rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Device#Device" .
-
-
-###  http://www.w3.org/ns/ssn/Drift
-ssn:Drift rdf:type owl:Class ;
-          rdfs:subClassOf ssn:MeasurementProperty ;
-          dc:source """skos:exactMatch 'instrumental drift' [VIM 4.21]
+  rdfs:comment "An observed value for which the probability of falsely claiming the absence of a component in a material is beta, given a probability alpha of falsely claiming its presence." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "Detection Limit" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Sensor#MeasuringCapability" ;
+  rdfs:subClassOf ssn:MeasurementProperty ;
+.
+ssn:Device
+  rdf:type owl:Class ;
+  dc:source "http://www.w3.org/2005/Incubator/ssn/" ;
+  rdfs:comment "A device is a physical piece of technology - a system in a box. Devices may of course be built of smaller devices and software components (i.e. systems have components)." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "Device" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Device#Device" ;
+  rdfs:subClassOf ssn:System ;
+.
+ssn:Drift
+  rdf:type owl:Class ;
+  dc:source """skos:exactMatch 'instrumental drift' [VIM 4.21]
                                   http://www.bipm.org/utils/common/documents/jcgm/JCGM_200_2008.pdf""" ;
-          rdfs:comment "A continuous or incremental change in the reported values of observations over time for an unchanging quality." ;
-          rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-          rdfs:label "Drift" ;
-          rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Sensor#MeasuringCapability" .
-
-
-###  http://www.w3.org/ns/ssn/FeatureOfInterest
-ssn:FeatureOfInterest rdf:type owl:Class ;
-                      rdfs:subClassOf [ rdf:type owl:Restriction ;
-                                        owl:onProperty ssn:hasProperty ;
-                                        owl:someValuesFrom ssn:Property
-                                      ] ,
-                                      [ rdf:type owl:Restriction ;
-                                        owl:onProperty ssn:hasProperty ;
-                                        owl:allValuesFrom ssn:Property
-                                      ] ;
-                      dc:source """skos:exactMatch 'feature' [O&M] 
+  rdfs:comment "A continuous or incremental change in the reported values of observations over time for an unchanging quality." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "Drift" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Sensor#MeasuringCapability" ;
+  rdfs:subClassOf ssn:MeasurementProperty ;
+.
+ssn:FeatureOfInterest
+  rdf:type owl:Class ;
+  dc:source """skos:exactMatch 'feature' [O&M] 
 		                    http://www.opengeospatial.org/standards/om""" ;
-                      rdfs:comment "A feature is an abstraction of real world phenomena (thing, person, event, etc)." ;
-                      rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                      rdfs:label "Feature of Interest" ;
-                      rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" .
-
-
-###  http://www.w3.org/ns/ssn/Frequency
-ssn:Frequency rdf:type owl:Class ;
-              rdfs:subClassOf ssn:MeasurementProperty ;
-              rdfs:comment "The smallest possible time between one observation and the next." ;
-              rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-              rdfs:label "Frequency" ;
-              rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Sensor#MeasuringCapability" .
-
-
-###  http://www.w3.org/ns/ssn/Input
-ssn:Input rdf:type owl:Class ;
-          owl:disjointWith ssn:Output ;
-          dc:source "http://marinemetadata.org/community/teams/ontdevices" ;
-          rdfs:comment "Any information that is provided to a process for its use [MMI OntDev]" ;
-          rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-          rdfs:label "Input" ;
-          rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Model#Process" .
-
-
-###  http://www.w3.org/ns/ssn/Latency
-ssn:Latency rdf:type owl:Class ;
-            rdfs:subClassOf ssn:MeasurementProperty ;
-            rdfs:comment "The time between a request for an observation and the sensor providing a result." ;
-            rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-            rdfs:label "Latency" ;
-            rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Sensor#MeasuringCapability" .
-
-
-###  http://www.w3.org/ns/ssn/MaintenanceSchedule
-ssn:MaintenanceSchedule rdf:type owl:Class ;
-                        rdfs:subClassOf ssn:OperatingProperty ;
-                        rdfs:comment "Schedule of maintenance for a system or sensor in the specified conditions." ;
-                        rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                        rdfs:label "Maintenance Schedule" ;
-                        rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#OperatingRestriction" .
-
-
-###  http://www.w3.org/ns/ssn/MeasurementCapability
-ssn:MeasurementCapability rdf:type owl:Class ;
-                          rdfs:subClassOf ssn:Property ,
-                                          [ rdf:type owl:Restriction ;
-                                            owl:onProperty ssn:forProperty ;
-                                            owl:allValuesFrom ssn:Property
-                                          ] ,
-                                          [ rdf:type owl:Restriction ;
-                                            owl:onProperty ssn:hasMeasurementProperty ;
-                                            owl:allValuesFrom ssn:MeasurementProperty
-                                          ] ,
-                                          [ rdf:type owl:Restriction ;
-                                            owl:onProperty ssn:inCondition ;
-                                            owl:allValuesFrom ssn:Condition
-                                          ] ;
-                          dc:source """Similar idea to MeasurementCapability in MMI Device Ontology
+  rdfs:comment "A feature is an abstraction of real world phenomena (thing, person, event, etc)." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "Feature of Interest" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" ;
+  rdfs:subClassOf [
+      rdf:type owl:Restriction ;
+      owl:allValuesFrom ssn:Property ;
+      owl:onProperty ssn:hasProperty ;
+    ] ;
+  rdfs:subClassOf [
+      rdf:type owl:Restriction ;
+      owl:onProperty ssn:hasProperty ;
+      owl:someValuesFrom ssn:Property ;
+    ] ;
+  skos:changeNote """--
+Replace with sosa:FeatureOfInterest ?
+--""" ;
+  skos:definition "The feature whose ObservableProperty is being observed by a Sensor to arrive at a Result" ;
+  skos:example "For example, when measuring the height of a tree, the height is the ObservedProperty, 20m may be the Result of the Observation, and the tree is the FeatureOfInterest." ;
+.
+ssn:Frequency
+  rdf:type owl:Class ;
+  rdfs:comment "The smallest possible time between one observation and the next." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "Frequency" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Sensor#MeasuringCapability" ;
+  rdfs:subClassOf ssn:MeasurementProperty ;
+.
+ssn:Input
+  rdf:type owl:Class ;
+  dc:source "http://marinemetadata.org/community/teams/ontdevices" ;
+  rdfs:comment "Any information that is provided to a process for its use [MMI OntDev]" ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "Input" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Model#Process" ;
+  owl:disjointWith ssn:Output ;
+.
+ssn:Latency
+  rdf:type owl:Class ;
+  rdfs:comment "The time between a request for an observation and the sensor providing a result." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "Latency" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Sensor#MeasuringCapability" ;
+  rdfs:subClassOf ssn:MeasurementProperty ;
+.
+ssn:MaintenanceSchedule
+  rdf:type owl:Class ;
+  rdfs:comment "Schedule of maintenance for a system or sensor in the specified conditions." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "Maintenance Schedule" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#OperatingRestriction" ;
+  rdfs:subClassOf ssn:OperatingProperty ;
+.
+ssn:MeasurementCapability
+  rdf:type owl:Class ;
+  dc:source """Similar idea to MeasurementCapability in MMI Device Ontology
                                   http://marinemetadata.org/community/teams/ontdevices
 
 But the two express the relationship between constraints and multiple measurement properties differently.
 
 The conditions linked to a MeasurementCapability are skos:exactMatch to 'influence quantity' [VIM 2.52]
 http://www.bipm.org/utils/common/documents/jcgm/JCGM_200_2008.pdf""" ;
-                          rdfs:comment """Collects together measurement properties (accuracy, range, precision, etc) and the environmental conditions in which those properties hold, representing a specification of a sensor's capability in those conditions.
+  rdfs:comment """Collects together measurement properties (accuracy, range, precision, etc) and the environmental conditions in which those properties hold, representing a specification of a sensor's capability in those conditions.
 
 The conditions specified here are those that affect the measurement properties, while those in OperatingRange represent the sensor's standard operating conditions, including conditions that don't affect the observations.""" ;
-                          rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                          rdfs:label "Measurement Capability" ;
-                          rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Sensor#MeasuringCapability" .
-
-
-###  http://www.w3.org/ns/ssn/MeasurementProperty
-ssn:MeasurementProperty rdf:type owl:Class ;
-                        rdfs:subClassOf ssn:Property ;
-                        rdfs:comment "An identifiable and observable characteristic of a sensor's observations or ability to make observations." ;
-                        rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                        rdfs:label "Measurement Property" ;
-                        rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Sensor#MeasuringCapability" .
-
-
-###  http://www.w3.org/ns/ssn/MeasurementRange
-ssn:MeasurementRange rdf:type owl:Class ;
-                     rdfs:subClassOf ssn:MeasurementProperty ;
-                     dc:source """skos:exactMatch 'measuring interval/measurement range' [VIM 4.7]
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "Measurement Capability" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Sensor#MeasuringCapability" ;
+  rdfs:subClassOf ssn:Property ;
+  rdfs:subClassOf [
+      rdf:type owl:Restriction ;
+      owl:allValuesFrom ssn:Condition ;
+      owl:onProperty ssn:inCondition ;
+    ] ;
+  rdfs:subClassOf [
+      rdf:type owl:Restriction ;
+      owl:allValuesFrom ssn:MeasurementProperty ;
+      owl:onProperty ssn:hasMeasurementProperty ;
+    ] ;
+  rdfs:subClassOf [
+      rdf:type owl:Restriction ;
+      owl:allValuesFrom ssn:Property ;
+      owl:onProperty ssn:forProperty ;
+    ] ;
+.
+ssn:MeasurementProperty
+  rdf:type owl:Class ;
+  rdfs:comment "An identifiable and observable characteristic of a sensor's observations or ability to make observations." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "Measurement Property" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Sensor#MeasuringCapability" ;
+  rdfs:subClassOf ssn:Property ;
+.
+ssn:MeasurementRange
+  rdf:type owl:Class ;
+  dc:source """skos:exactMatch 'measuring interval/measurement range' [VIM 4.7]
                                   http://www.bipm.org/utils/common/documents/jcgm/JCGM_200_2008.pdf""" ;
-                     rdfs:comment "The set of values that the sensor can return as the result of an observation under the defined conditions with the defined measurement properties.  If no conditions are specified or the conditions do not specify a range for the observed qualities, the measurement range is to be taken as the condition for the observed qualities." ;
-                     rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                     rdfs:label "Measurement Range" ;
-                     rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Sensor#MeasuringCapability" .
-
-
-###  http://www.w3.org/ns/ssn/Observation
-ssn:Observation rdf:type owl:Class ;
-                rdfs:subClassOf [ rdf:type owl:Restriction ;
-                                  owl:onProperty ssn:featureOfInterest ;
-                                  owl:allValuesFrom ssn:FeatureOfInterest
-                                ] ,
-                                [ rdf:type owl:Restriction ;
-                                  owl:onProperty ssn:observationResult ;
-                                  owl:allValuesFrom ssn:SensorOutput
-                                ] ,
-                                [ rdf:type owl:Restriction ;
-                                  owl:onProperty ssn:observedBy ;
-                                  owl:allValuesFrom ssn:Sensor
-                                ] ,
-                                [ rdf:type owl:Restriction ;
-                                  owl:onProperty ssn:observedProperty ;
-                                  owl:allValuesFrom ssn:Property
-                                ] ,
-                                [ rdf:type owl:Restriction ;
-                                  owl:onProperty ssn:sensingMethodUsed ;
-                                  owl:allValuesFrom ssn:Sensing
-                                ] ,
-                                [ rdf:type owl:Restriction ;
-                                  owl:onProperty ssn:observationResultTime ;
-                                  owl:minCardinality "0"^^xsd:nonNegativeInteger
-                                ] ,
-                                [ rdf:type owl:Restriction ;
-                                  owl:onProperty ssn:observationSamplingTime ;
-                                  owl:minCardinality "0"^^xsd:nonNegativeInteger
-                                ] ,
-                                [ rdf:type owl:Restriction ;
-                                  owl:onProperty ssn:qualityOfObservation ;
-                                  owl:minCardinality "0"^^xsd:nonNegativeInteger
-                                ] ,
-                                [ rdf:type owl:Restriction ;
-                                  owl:onProperty ssn:featureOfInterest ;
-                                  owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                  owl:onClass ssn:FeatureOfInterest
-                                ] ,
-                                [ rdf:type owl:Restriction ;
-                                  owl:onProperty ssn:observedBy ;
-                                  owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                  owl:onClass ssn:Sensor
-                                ] ,
-                                [ rdf:type owl:Restriction ;
-                                  owl:onProperty ssn:observedProperty ;
-                                  owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                  owl:onClass ssn:Property
-                                ] ,
-                                [ rdf:type owl:Restriction ;
-                                  owl:onProperty ssn:sensingMethodUsed ;
-                                  owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                  owl:onClass ssn:Sensing
-                                ] ;
-                dc:source """skos:closeMatch 'observation' [O&M] 
+  rdfs:comment "The set of values that the sensor can return as the result of an observation under the defined conditions with the defined measurement properties.  If no conditions are specified or the conditions do not specify a range for the observed qualities, the measurement range is to be taken as the condition for the observed qualities." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "Measurement Range" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Sensor#MeasuringCapability" ;
+  rdfs:subClassOf ssn:MeasurementProperty ;
+.
+ssn:Observation
+  rdf:type owl:Class ;
+  dc:source """skos:closeMatch 'observation' [O&M] 
 		                    http://www.opengeospatial.org/standards/om 
 
 Observation in this ontology and O&M are described differently (O&M records an observation as an act/event), but they record the same thing and are essentially interchangeable.  The difference is in the ontological structure of the two, not the data or use.
@@ -694,15 +280,82 @@ Observation here records a Situation (the estimation of the value of a Property)
 skos:closeMatch 'measurement result' [VIM 2.9] http://www.bipm.org/utils/common/documents/jcgm/JCGM_200_2008.pdf
 
 Measurement result in VIM is the measured value plus any other relevant information, which means that measurement result and observation will often be associated to the same data (a value, a time, a property, etc.).""" ;
-                rdfs:comment "An Observation is a Situation in which a Sensing method has been used to estimate or calculate a value of a Property of a FeatureOfInterest.  Links to Sensing and Sensor describe what made the Observation and how; links to Property and Feature detail what was sensed; the result is the output of a Sensor; other metadata details times etc." ;
-                rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                rdfs:label "Observation" ;
-                rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" .
-
-
-###  http://www.w3.org/ns/ssn/ObservationValue
-ssn:ObservationValue rdf:type owl:Class ;
-                     dc:source """skos:exactMatch 'measured quantity value' [VIM 2.10]
+  rdfs:comment "An Observation is a Situation in which a Sensing method has been used to estimate or calculate a value of a Property of a FeatureOfInterest.  Links to Sensing and Sensor describe what made the Observation and how; links to Property and Feature detail what was sensed; the result is the output of a Sensor; other metadata details times etc." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "Observation" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" ;
+  rdfs:subClassOf [
+      rdf:type owl:Restriction ;
+      owl:allValuesFrom ssn:FeatureOfInterest ;
+      owl:onProperty ssn:featureOfInterest ;
+    ] ;
+  rdfs:subClassOf [
+      rdf:type owl:Restriction ;
+      owl:allValuesFrom ssn:Property ;
+      owl:onProperty ssn:observedProperty ;
+    ] ;
+  rdfs:subClassOf [
+      rdf:type owl:Restriction ;
+      owl:allValuesFrom ssn:Sensing ;
+      owl:onProperty ssn:sensingMethodUsed ;
+    ] ;
+  rdfs:subClassOf [
+      rdf:type owl:Restriction ;
+      owl:allValuesFrom ssn:Sensor ;
+      owl:onProperty ssn:observedBy ;
+    ] ;
+  rdfs:subClassOf [
+      rdf:type owl:Restriction ;
+      owl:allValuesFrom ssn:SensorOutput ;
+      owl:onProperty ssn:observationResult ;
+    ] ;
+  rdfs:subClassOf [
+      rdf:type owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+      owl:onProperty ssn:observationResultTime ;
+    ] ;
+  rdfs:subClassOf [
+      rdf:type owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+      owl:onProperty ssn:observationSamplingTime ;
+    ] ;
+  rdfs:subClassOf [
+      rdf:type owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+      owl:onProperty ssn:qualityOfObservation ;
+    ] ;
+  rdfs:subClassOf [
+      rdf:type owl:Restriction ;
+      owl:onClass ssn:FeatureOfInterest ;
+      owl:onProperty ssn:featureOfInterest ;
+      owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+    ] ;
+  rdfs:subClassOf [
+      rdf:type owl:Restriction ;
+      owl:onClass ssn:Property ;
+      owl:onProperty ssn:observedProperty ;
+      owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+    ] ;
+  rdfs:subClassOf [
+      rdf:type owl:Restriction ;
+      owl:onClass ssn:Sensing ;
+      owl:onProperty ssn:sensingMethodUsed ;
+      owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+    ] ;
+  rdfs:subClassOf [
+      rdf:type owl:Restriction ;
+      owl:onClass ssn:Sensor ;
+      owl:onProperty ssn:observedBy ;
+      owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+    ] ;
+  skos:definition "Activity of carrying out an (Observation) Procedure to estimate or calculate a value of a Property of a FeatureOfInterest. Links to a Platform or Sensor to describe what made the Observation and how; links to an ObservableProperty to describe what the result is an estimate of, and to a FeatureOfInterest to detail what that property was associated with. The Result is the output." ;
+  skos:editorialNote """--
+Replace with sosa:Observation ?
+--""" ;
+.
+ssn:ObservationValue
+  rdf:type owl:Class ;
+  dc:source """skos:exactMatch 'measured quantity value' [VIM 2.10]
                                   http://www.bipm.org/utils/common/documents/jcgm/JCGM_200_2008.pdf
 
 skos:exactMatch 'observed value' [SensorML OGC-0700]
@@ -712,344 +365,702 @@ skos:closeMatch 'observation result' [O&M]
 http://www.opengeospatial.org/standards/om 
 
 O&M conflates what we have as SensorOutput and ObservationValue into observation result, though the OGC standard does say \"result contains a value\" and \"a result which has a value\", which fits naturally with the model here.""" ;
-                     rdfs:comment "The value of the result of an Observation.  An Observation has a result which is the output of some sensor, the result is an information object that encodes some value for a Feature." ;
-                     rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                     rdfs:label "Observation Value" ;
-                     rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Base#Data" .
-
-
-###  http://www.w3.org/ns/ssn/OperatingPowerRange
-ssn:OperatingPowerRange rdf:type owl:Class ;
-                        rdfs:subClassOf ssn:OperatingProperty ;
-                        rdfs:comment "Power range in which system or sensor is expected to operate." ;
-                        rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                        rdfs:label "Operating Power Range" ;
-                        rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Energy#EnergyRestriction" .
-
-
-###  http://www.w3.org/ns/ssn/OperatingProperty
-ssn:OperatingProperty rdf:type owl:Class ;
-                      rdfs:subClassOf ssn:Property ;
-                      rdfs:comment "An identifiable characteristic of the environmental and other conditions in which the sensor is intended to operate.  May include power ranges, power sources, standard configurations, attachments and the like." ;
-                      rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                      rdfs:label "Operating Property" ;
-                      rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#OperatingRestriction" .
-
-
-###  http://www.w3.org/ns/ssn/OperatingRange
-ssn:OperatingRange rdf:type owl:Class ;
-                   rdfs:subClassOf ssn:Property ,
-                                   [ rdf:type owl:Restriction ;
-                                     owl:onProperty ssn:hasOperatingProperty ;
-                                     owl:allValuesFrom ssn:OperatingProperty
-                                   ] ,
-                                   [ rdf:type owl:Restriction ;
-                                     owl:onProperty ssn:inCondition ;
-                                     owl:allValuesFrom ssn:Condition
-                                   ] ;
-                   dc:source """skos:broaderMatch 'reference operating condition' [VIM 4.11]
+  rdfs:comment "The value of the result of an Observation.  An Observation has a result which is the output of some sensor, the result is an information object that encodes some value for a Feature." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "Observation Value" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Base#Data" ;
+  rdfs:subClassOf <http://www.w3.org/ns/sosa/Result> ;
+  skos:changeNote """--
+sub-class of sosa:Result, which also includes results of actuation and sampling activities
+--""" ;
+.
+ssn:OperatingPowerRange
+  rdf:type owl:Class ;
+  rdfs:comment "Power range in which system or sensor is expected to operate." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "Operating Power Range" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Energy#EnergyRestriction" ;
+  rdfs:subClassOf ssn:OperatingProperty ;
+.
+ssn:OperatingProperty
+  rdf:type owl:Class ;
+  rdfs:comment "An identifiable characteristic of the environmental and other conditions in which the sensor is intended to operate.  May include power ranges, power sources, standard configurations, attachments and the like." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "Operating Property" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#OperatingRestriction" ;
+  rdfs:subClassOf ssn:Property ;
+.
+ssn:OperatingRange
+  rdf:type owl:Class ;
+  dc:source """skos:broaderMatch 'reference operating condition' [VIM 4.11]
                                   http://www.bipm.org/utils/common/documents/jcgm/JCGM_200_2008.pdf
 
 The difference is that here we also allow for qualities that aren't VIM influence quantities [VIM 2.52] - for example, a quantity that alters the power requirements, but doesn't affect the measurement properties - conditions specified in MeasurementCapability should be influence quantities.""" ;
-                   rdfs:comment "The environmental conditions and characteristics of a system or sensor's normal operating environment.  Can be used to specify for example the standard environmental conditions in which the sensor is expected to operate (a Condition with no OperatingProperty), or how the environmental and other operating properties relate: i.e., that the maintenance schedule or power requirements differ according to the conditions." ;
-                   rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                   rdfs:label "Operating Range" ;
-                   rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#OperatingRestriction" .
-
-
-###  http://www.w3.org/ns/ssn/Output
-ssn:Output rdf:type owl:Class ;
-           dc:source "http://marinemetadata.org/community/teams/ontdevices" ;
-           rdfs:comment "Any information that is reported from a process. [MMI OntDev]" ;
-           rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-           rdfs:label "Output" ;
-           rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Model#Process" .
-
-
-###  http://www.w3.org/ns/ssn/Platform
-ssn:Platform rdf:type owl:Class ;
-             rdfs:subClassOf [ rdf:type owl:Restriction ;
-                               owl:onProperty ssn:attachedSystem ;
-                               owl:allValuesFrom ssn:System
-                             ] ,
-                             [ rdf:type owl:Restriction ;
-                               owl:onProperty ssn:inDeployment ;
-                               owl:allValuesFrom ssn:Deployment
-                             ] ;
-             dc:source """skos:exactMatch 'platform' [SensorML OGC-0700]
+  rdfs:comment "The environmental conditions and characteristics of a system or sensor's normal operating environment.  Can be used to specify for example the standard environmental conditions in which the sensor is expected to operate (a Condition with no OperatingProperty), or how the environmental and other operating properties relate: i.e., that the maintenance schedule or power requirements differ according to the conditions." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "Operating Range" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#OperatingRestriction" ;
+  rdfs:subClassOf ssn:Property ;
+  rdfs:subClassOf [
+      rdf:type owl:Restriction ;
+      owl:allValuesFrom ssn:Condition ;
+      owl:onProperty ssn:inCondition ;
+    ] ;
+  rdfs:subClassOf [
+      rdf:type owl:Restriction ;
+      owl:allValuesFrom ssn:OperatingProperty ;
+      owl:onProperty ssn:hasOperatingProperty ;
+    ] ;
+.
+ssn:Output
+  rdf:type owl:Class ;
+  dc:source "http://marinemetadata.org/community/teams/ontdevices" ;
+  rdfs:comment "Any information that is reported from a process. [MMI OntDev]" ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "Output" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Model#Process" ;
+.
+ssn:Platform
+  rdf:type owl:Class ;
+  dc:source """skos:exactMatch 'platform' [SensorML OGC-0700]
                                   http://www.opengeospatial.org/standards/sensorml""" ;
-             rdfs:comment "An Entity to which other Entities can be attached - particuarly Sensors and other Platforms.  For example, a post might act as a Platform, a buoy might act as a Platform, or a fish might act as a Platform for an attached sensor." ;
-             rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-             rdfs:label "Platform" ;
-             rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#PlatformSite" .
-
-
-###  http://www.w3.org/ns/ssn/Precision
-ssn:Precision rdf:type owl:Class ;
-              rdfs:subClassOf ssn:MeasurementProperty ;
-              dc:source """skos:exactMatch 'measurement precision/precision' [VIM 2.15]
+  rdfs:comment "An Entity to which other Entities can be attached - particuarly Sensors and other Platforms.  For example, a post might act as a Platform, a buoy might act as a Platform, or a fish might act as a Platform for an attached sensor." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "Platform" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#PlatformSite" ;
+  rdfs:subClassOf [
+      rdf:type owl:Restriction ;
+      owl:allValuesFrom ssn:Deployment ;
+      owl:onProperty ssn:inDeployment ;
+    ] ;
+  rdfs:subClassOf [
+      rdf:type owl:Restriction ;
+      owl:allValuesFrom ssn:System ;
+      owl:onProperty ssn:attachedSystem ;
+    ] ;
+  skos:definition "A device, (computational) system, or agent (including humans). A platform carries at least one Sensor, Actuator, or Sampling Device to produce observations, actuations, or samples, by following a Procedure. In case of virtual sensors, a platform can be a computing system which hosts software implementations, e.g., simulations" ;
+  skos:editorialNote """--
+Replace by sosa:Platform ?
+--""" ;
+.
+ssn:Precision
+  rdf:type owl:Class ;
+  dc:source """skos:exactMatch 'measurement precision/precision' [VIM 2.15]
                                    http://www.bipm.org/utils/common/documents/jcgm/JCGM_200_2008.pdf""" ;
-              rdfs:comment "The closeness of agreement between replicate observations on an unchanged or similar quality value: i.e., a measure of a sensor's ability to consistently reproduce an observation." ;
-              rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-              rdfs:label "Precision" ;
-              rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Sensor#MeasuringCapability" .
-
-
-###  http://www.w3.org/ns/ssn/Process
-ssn:Process rdf:type owl:Class ;
-            rdfs:subClassOf [ rdf:type owl:Restriction ;
-                              owl:onProperty ssn:hasOutput ;
-                              owl:someValuesFrom ssn:Output
-                            ] ,
-                            [ rdf:type owl:Restriction ;
-                              owl:onProperty ssn:hasInput ;
-                              owl:allValuesFrom ssn:Input
-                            ] ,
-                            [ rdf:type owl:Restriction ;
-                              owl:onProperty ssn:hasOutput ;
-                              owl:allValuesFrom ssn:Output
-                            ] ;
-            dc:source "http://www.w3.org/2005/Incubator/ssn/" ;
-            rdfs:comment "A process has an output and possibly inputs and, for a composite process, describes the temporal and dataflow dependencies and relationships amongst its parts. [SSN XG]" ;
-            rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-            rdfs:label "Process" ;
-            rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Model#Process" .
-
-
-###  http://www.w3.org/ns/ssn/Property
-ssn:Property rdf:type owl:Class ;
-             rdfs:subClassOf [ rdf:type owl:Restriction ;
-                               owl:onProperty ssn:isPropertyOf ;
-                               owl:someValuesFrom ssn:FeatureOfInterest
-                             ] ;
-             dc:source """skos:exactMatch 'property' [O&M] 
+  rdfs:comment "The closeness of agreement between replicate observations on an unchanged or similar quality value: i.e., a measure of a sensor's ability to consistently reproduce an observation." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "Precision" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Sensor#MeasuringCapability" ;
+  rdfs:subClassOf ssn:MeasurementProperty ;
+.
+ssn:Process
+  rdf:type owl:Class ;
+  dc:source "http://www.w3.org/2005/Incubator/ssn/" ;
+  rdfs:comment "A process has an output and possibly inputs and, for a composite process, describes the temporal and dataflow dependencies and relationships amongst its parts. [SSN XG]" ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "Process" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Model#Process" ;
+  rdfs:subClassOf [
+      rdf:type owl:Restriction ;
+      owl:allValuesFrom ssn:Input ;
+      owl:onProperty ssn:hasInput ;
+    ] ;
+  rdfs:subClassOf [
+      rdf:type owl:Restriction ;
+      owl:allValuesFrom ssn:Output ;
+      owl:onProperty ssn:hasOutput ;
+    ] ;
+  rdfs:subClassOf [
+      rdf:type owl:Restriction ;
+      owl:onProperty ssn:hasOutput ;
+      owl:someValuesFrom ssn:Output ;
+    ] ;
+.
+ssn:Property
+  rdf:type owl:Class ;
+  dc:source """skos:exactMatch 'property' [O&M] 
 		                    http://www.opengeospatial.org/standards/om""" ;
-             rdfs:comment "An observable Quality of an Event or Object.  That is, not a Quality of an abstract entity, but rather an aspect of an entity that is intrinsic to and cannot exist without the entity and that is observable by a sensor." ;
-             rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-             rdfs:label "Property" ;
-             rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" .
-
-
-###  http://www.w3.org/ns/ssn/Resolution
-ssn:Resolution rdf:type owl:Class ;
-               rdfs:subClassOf ssn:MeasurementProperty ;
-               dc:source """skos:exactMatch 'resolution' [VIM 4.14]
+  rdfs:comment "An observable Quality of an Event or Object.  That is, not a Quality of an abstract entity, but rather an aspect of an entity that is intrinsic to and cannot exist without the entity and that is observable by a sensor." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "Property" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" ;
+  rdfs:subClassOf [
+      rdf:type owl:Restriction ;
+      owl:onProperty ssn:isPropertyOf ;
+      owl:someValuesFrom ssn:FeatureOfInterest ;
+    ] ;
+  skos:changeNote """--
+Replace by sosa:ObservableProperty
+--""" ;
+  skos:definition "An observable Quality of a Thing; typically a FeatureOfInterest." ;
+.
+ssn:Resolution
+  rdf:type owl:Class ;
+  dc:source """skos:exactMatch 'resolution' [VIM 4.14]
                                   http://www.bipm.org/utils/common/documents/jcgm/JCGM_200_2008.pdf""" ;
-               rdfs:comment "The smallest difference in the value of a quality being observed that would result in perceptably different values of observation results." ;
-               rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-               rdfs:label "Resolution" ;
-               rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Sensor#MeasuringCapability" .
-
-
-###  http://www.w3.org/ns/ssn/ResponseTime
-ssn:ResponseTime rdf:type owl:Class ;
-                 rdfs:subClassOf ssn:MeasurementProperty ;
-                 dc:source """skos:exactMatch 'step response time' [VIM 4.23]
+  rdfs:comment "The smallest difference in the value of a quality being observed that would result in perceptably different values of observation results." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "Resolution" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Sensor#MeasuringCapability" ;
+  rdfs:subClassOf ssn:MeasurementProperty ;
+.
+ssn:ResponseTime
+  rdf:type owl:Class ;
+  dc:source """skos:exactMatch 'step response time' [VIM 4.23]
                                   http://www.bipm.org/utils/common/documents/jcgm/JCGM_200_2008.pdf""" ;
-                 rdfs:comment "The time between a (step) change in the value of an observed quality and a sensor (possibly with specified error) 'settling' on an observed value." ;
-                 rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                 rdfs:label "Response Time" ;
-                 rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Sensor#MeasuringCapability" .
-
-
-###  http://www.w3.org/ns/ssn/Selectivity
-ssn:Selectivity rdf:type owl:Class ;
-                rdfs:subClassOf ssn:MeasurementProperty ;
-                dc:source """skos:exactMatch 'selectivity' [VIM 4.13]
+  rdfs:comment "The time between a (step) change in the value of an observed quality and a sensor (possibly with specified error) 'settling' on an observed value." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "Response Time" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Sensor#MeasuringCapability" ;
+  rdfs:subClassOf ssn:MeasurementProperty ;
+.
+ssn:Selectivity
+  rdf:type owl:Class ;
+  dc:source """skos:exactMatch 'selectivity' [VIM 4.13]
                                  http://www.bipm.org/utils/common/documents/jcgm/JCGM_200_2008.pdf""" ;
-                rdfs:comment "Selectivity is a property of a sensor whereby it provides observed values for one or more qualities such that the values of each quality are independent of other qualities in the phenomenon, body, or substance being investigated." ;
-                rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                rdfs:label "Selectivity" ;
-                rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Sensor#MeasuringCapability" .
-
-
-###  http://www.w3.org/ns/ssn/Sensing
-ssn:Sensing rdf:type owl:Class ;
-            rdfs:subClassOf ssn:Process ;
-            dc:source "http://www.w3.org/2005/Incubator/ssn/" ;
-            rdfs:comment "Sensing is a process that results in the estimation, or calculation, of the value of a phenomenon." ;
-            rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-            rdfs:label "Sensing" ;
-            rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" .
-
-
-###  http://www.w3.org/ns/ssn/SensingDevice
-ssn:SensingDevice rdf:type owl:Class ;
-                  rdfs:subClassOf ssn:Device ,
-                                  ssn:Sensor ;
-                  dc:source "http://www.w3.org/2005/Incubator/ssn/" ;
-                  rdfs:comment "A sensing device is a device that implements sensing." ;
-                  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                  rdfs:label "Sensing Device" ;
-                  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Sensor#Measuring" .
-
-
-###  http://www.w3.org/ns/ssn/Sensitivity
-ssn:Sensitivity rdf:type owl:Class ;
-                rdfs:subClassOf ssn:MeasurementProperty ;
-                dc:source """skos:exactMatch 'sensitivity' [VIM 4.12]
+  rdfs:comment "Selectivity is a property of a sensor whereby it provides observed values for one or more qualities such that the values of each quality are independent of other qualities in the phenomenon, body, or substance being investigated." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "Selectivity" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Sensor#MeasuringCapability" ;
+  rdfs:subClassOf ssn:MeasurementProperty ;
+.
+ssn:Sensing
+  rdf:type owl:Class ;
+  dc:source "http://www.w3.org/2005/Incubator/ssn/" ;
+  rdfs:comment "Sensing is a process that results in the estimation, or calculation, of the value of a phenomenon." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "Sensing" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" ;
+  rdfs:subClassOf ssn:Process ;
+.
+ssn:SensingDevice
+  rdf:type owl:Class ;
+  dc:source "http://www.w3.org/2005/Incubator/ssn/" ;
+  rdfs:comment "A sensing device is a device that implements sensing." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "Sensing Device" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Sensor#Measuring" ;
+  rdfs:subClassOf ssn:Device ;
+  rdfs:subClassOf ssn:Sensor ;
+.
+ssn:Sensitivity
+  rdf:type owl:Class ;
+  dc:source """skos:exactMatch 'sensitivity' [VIM 4.12]
                                   http://www.bipm.org/utils/common/documents/jcgm/JCGM_200_2008.pdf""" ;
-                rdfs:comment "Sensitivity is the quotient of the change in a result of sensor and the corresponding change in a value of a quality being observed." ;
-                rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                rdfs:label "Sensitivity" ;
-                rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Sensor#MeasuringCapability" .
-
-
-###  http://www.w3.org/ns/ssn/Sensor
-ssn:Sensor rdf:type owl:Class ;
-           rdfs:subClassOf [ rdf:type owl:Restriction ;
-                             owl:onProperty ssn:implements ;
-                             owl:someValuesFrom ssn:Sensing
-                           ] ,
-                           [ rdf:type owl:Restriction ;
-                             owl:onProperty ssn:detects ;
-                             owl:allValuesFrom ssn:Stimulus
-                           ] ,
-                           [ rdf:type owl:Restriction ;
-                             owl:onProperty ssn:hasMeasurementCapability ;
-                             owl:allValuesFrom ssn:MeasurementCapability
-                           ] ,
-                           [ rdf:type owl:Restriction ;
-                             owl:onProperty ssn:observes ;
-                             owl:allValuesFrom ssn:Property
-                           ] ;
-           dc:source """skos:exactMatch 'sensor' [SensorML OGC-0700]
+  rdfs:comment "Sensitivity is the quotient of the change in a result of sensor and the corresponding change in a value of a quality being observed." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "Sensitivity" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Sensor#MeasuringCapability" ;
+  rdfs:subClassOf ssn:MeasurementProperty ;
+.
+ssn:Sensor
+  rdf:type owl:Class ;
+  dc:source """skos:exactMatch 'sensor' [SensorML OGC-0700]
 		                    http://www.opengeospatial.org/standards/sensorml 
 
                                 skos:closeMatch 'observation procedure' [O&M] 
                                 http://www.opengeospatial.org/standards/om 
 
 O&M allows sensors, methods, instruments, systems, algorithms and process chains as the processUsed of an observation; this ontology allows a similar range of things (any thing that can do sensing), just they are all grouped under the term sensor (which is thus wider than the O&M concept).""" ;
-           rdfs:comment "A sensor can do (implements) sensing: that is, a sensor is any entity that can follow a sensing method and thus observe some Property of a FeatureOfInterest.  Sensors may be physical devices, computational methods, a laboratory setup with a person following a method, or any other thing that can follow a Sensing Method to observe a Property." ;
-           rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-           rdfs:label "Sensor" ;
-           rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" .
-
-
-###  http://www.w3.org/ns/ssn/SensorDataSheet
-ssn:SensorDataSheet rdf:type owl:Class ;
-                    dc:source "http://www.w3.org/2005/Incubator/ssn/" ;
-                    rdfs:comment """A data sheet records properties of a sensor.  A data sheet might describe for example the accuracy in various conditions, the power use, the types of connectors that the sensor has, etc.  
+  rdfs:comment "A sensor can do (implements) sensing: that is, a sensor is any entity that can follow a sensing method and thus observe some Property of a FeatureOfInterest.  Sensors may be physical devices, computational methods, a laboratory setup with a person following a method, or any other thing that can follow a Sensing Method to observe a Property." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "Sensor" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" ;
+  rdfs:subClassOf [
+      rdf:type owl:Restriction ;
+      owl:allValuesFrom ssn:MeasurementCapability ;
+      owl:onProperty ssn:hasMeasurementCapability ;
+    ] ;
+  rdfs:subClassOf [
+      rdf:type owl:Restriction ;
+      owl:allValuesFrom ssn:Property ;
+      owl:onProperty ssn:observes ;
+    ] ;
+  rdfs:subClassOf [
+      rdf:type owl:Restriction ;
+      owl:allValuesFrom ssn:Stimulus ;
+      owl:onProperty ssn:detects ;
+    ] ;
+  rdfs:subClassOf [
+      rdf:type owl:Restriction ;
+      owl:onProperty ssn:implements ;
+      owl:someValuesFrom ssn:Sensing ;
+    ] ;
+  skos:definition "Device, agent (including humans), or software (simulation) involved in, or implementing, a (Sensing) Procedure. Sensors responds to a stimulus, e.g., a change in the environment, and generate a Result. Sensors can be mounted on Platforms, e.g., a modern smart phone hosts multiple sensors." ;
+  skos:editorialNote """--
+Replace with sosa:Sensor ?
+--""" ;
+.
+ssn:SensorDataSheet
+  rdf:type owl:Class ;
+  dc:source "http://www.w3.org/2005/Incubator/ssn/" ;
+  rdfs:comment """A data sheet records properties of a sensor.  A data sheet might describe for example the accuracy in various conditions, the power use, the types of connectors that the sensor has, etc.  
 
 Generally a sensor's properties are recorded directly (with hasMeasurementCapability, for example), but the data sheet can be used for example to record the manufacturer's specifications versus observed capabilites, or if more is known than the manufacturer specifies, etc.  The data sheet is an information object about the sensor's properties, rather than a direct link to the actual properties themselves.""" ;
-                    rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                    rdfs:label "Sensor Data Sheet" ;
-                    rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Sensor#Measuring" .
-
-
-###  http://www.w3.org/ns/ssn/SensorInput
-ssn:SensorInput rdf:type owl:Class ;
-                owl:equivalentClass ssn:Stimulus ;
-                rdfs:subClassOf [ rdf:type owl:Restriction ;
-                                  owl:onProperty ssn:isProxyFor ;
-                                  owl:allValuesFrom ssn:Property
-                                ] ;
-                dc:source "http://www.w3.org/2005/Incubator/ssn/" ;
-                rdfs:comment "An Event in the real world that 'triggers' the sensor.  The properties associated to the stimulus may be different to eventual observed property.  The event, not the object, triggers the sensor." ;
-                rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                rdfs:label "Sensor Input" ;
-                rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" .
-
-
-###  http://www.w3.org/ns/ssn/SensorOutput
-ssn:SensorOutput rdf:type owl:Class ;
-                 rdfs:subClassOf [ rdf:type owl:Restriction ;
-                                   owl:onProperty ssn:hasValue ;
-                                   owl:someValuesFrom ssn:ObservationValue
-                                 ] ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty ssn:isProducedBy ;
-                                   owl:someValuesFrom ssn:Sensor
-                                 ] ;
-                 dc:source """http://www.w3.org/2005/Incubator/ssn/
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "Sensor Data Sheet" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Sensor#Measuring" ;
+.
+ssn:SensorInput
+  rdf:type owl:Class ;
+  dc:source "http://www.w3.org/2005/Incubator/ssn/" ;
+  rdfs:comment "An Event in the real world that 'triggers' the sensor.  The properties associated to the stimulus may be different to eventual observed property.  The event, not the object, triggers the sensor." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "Sensor Input" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" ;
+  rdfs:subClassOf [
+      rdf:type owl:Restriction ;
+      owl:allValuesFrom ssn:Property ;
+      owl:onProperty ssn:isProxyFor ;
+    ] ;
+  owl:equivalentClass ssn:Stimulus ;
+.
+ssn:SensorOutput
+  rdf:type owl:Class ;
+  dc:source """http://www.w3.org/2005/Incubator/ssn/
 
                                   skos:closeMatch 'observation result' [O&M] 
                                   http://www.opengeospatial.org/standards/om 
 
 See comments at ObservationValue.""" ;
-                 rdfs:comment "A sensor outputs a piece of information (an observed value), the value itself being represented by an ObservationValue." ;
-                 rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                 rdfs:label "Sensor Output" ;
-                 rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" .
-
-
-###  http://www.w3.org/ns/ssn/Stimulus
-ssn:Stimulus rdf:type owl:Class ;
-             dc:source "http://www.w3.org/2005/Incubator/ssn/" ;
-             rdfs:comment "An Event in the real world that 'triggers' the sensor.  The properties associated to the stimulus may be different to the eventual observed property.  It is the event, not the object, that triggers the sensor." ;
-             rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-             rdfs:label "Stimulus" ;
-             rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" .
-
-
-###  http://www.w3.org/ns/ssn/SurvivalProperty
-ssn:SurvivalProperty rdf:type owl:Class ;
-                     rdfs:subClassOf ssn:Property ;
-                     rdfs:comment "An identifiable characteristic that represents the extent of the sensor's useful life.  Might include for example total battery life or number of recharges, or, for sensors that are used only a fixed number of times, the number of observations that can be made before the sensing capability is depleted." ;
-                     rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                     rdfs:label "Survival Property" ;
-                     rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#OperatingRestriction" .
-
-
-###  http://www.w3.org/ns/ssn/SurvivalRange
-ssn:SurvivalRange rdf:type owl:Class ;
-                  rdfs:subClassOf ssn:Property ,
-                                  [ rdf:type owl:Restriction ;
-                                    owl:onProperty ssn:hasSurvivalProperty ;
-                                    owl:allValuesFrom ssn:SurvivalProperty
-                                  ] ,
-                                  [ rdf:type owl:Restriction ;
-                                    owl:onProperty ssn:inCondition ;
-                                    owl:allValuesFrom ssn:Condition
-                                  ] ;
-                  dc:source """skos:narrowerMatch 'limiting operating condition' [VIM 4.10]
+  rdfs:comment "A sensor outputs a piece of information (an observed value), the value itself being represented by an ObservationValue." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "Sensor Output" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" ;
+  rdfs:subClassOf [
+      rdf:type owl:Restriction ;
+      owl:onProperty ssn:hasValue ;
+      owl:someValuesFrom ssn:ObservationValue ;
+    ] ;
+  rdfs:subClassOf [
+      rdf:type owl:Restriction ;
+      owl:onProperty ssn:isProducedBy ;
+      owl:someValuesFrom ssn:Sensor ;
+    ] ;
+.
+ssn:Stimulus
+  rdf:type owl:Class ;
+  dc:source "http://www.w3.org/2005/Incubator/ssn/" ;
+  rdfs:comment "An Event in the real world that 'triggers' the sensor.  The properties associated to the stimulus may be different to the eventual observed property.  It is the event, not the object, that triggers the sensor." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "Stimulus" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" ;
+.
+ssn:SurvivalProperty
+  rdf:type owl:Class ;
+  rdfs:comment "An identifiable characteristic that represents the extent of the sensor's useful life.  Might include for example total battery life or number of recharges, or, for sensors that are used only a fixed number of times, the number of observations that can be made before the sensing capability is depleted." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "Survival Property" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#OperatingRestriction" ;
+  rdfs:subClassOf ssn:Property ;
+.
+ssn:SurvivalRange
+  rdf:type owl:Class ;
+  dc:source """skos:narrowerMatch 'limiting operating condition' [VIM 4.10]
                                   http://www.bipm.org/utils/common/documents/jcgm/JCGM_200_2008.pdf""" ;
-                  rdfs:comment "The conditions a sensor can be exposed to without damage: i.e., the sensor continues to operate as defined using MeasurementCapability.  If, however, the SurvivalRange is violated, the sensor is 'damaged' and MeasurementCapability specifications may no longer hold." ;
-                  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                  rdfs:label "Survival Range" ;
-                  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#OperatingRestriction" .
+  rdfs:comment "The conditions a sensor can be exposed to without damage: i.e., the sensor continues to operate as defined using MeasurementCapability.  If, however, the SurvivalRange is violated, the sensor is 'damaged' and MeasurementCapability specifications may no longer hold." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "Survival Range" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#OperatingRestriction" ;
+  rdfs:subClassOf ssn:Property ;
+  rdfs:subClassOf [
+      rdf:type owl:Restriction ;
+      owl:allValuesFrom ssn:Condition ;
+      owl:onProperty ssn:inCondition ;
+    ] ;
+  rdfs:subClassOf [
+      rdf:type owl:Restriction ;
+      owl:allValuesFrom ssn:SurvivalProperty ;
+      owl:onProperty ssn:hasSurvivalProperty ;
+    ] ;
+.
+ssn:System
+  rdf:type owl:Class ;
+  dc:source "http://www.w3.org/2005/Incubator/ssn/" ;
+  rdfs:comment "System is a unit of abstraction for pieces of infrastructure for sensing. A system has components, its subsystems, which are other systems." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "System" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Model#System" ;
+  rdfs:subClassOf [
+      rdf:type owl:Restriction ;
+      owl:allValuesFrom ssn:Deployment ;
+      owl:onProperty ssn:hasDeployment ;
+    ] ;
+  rdfs:subClassOf [
+      rdf:type owl:Restriction ;
+      owl:allValuesFrom ssn:OperatingRange ;
+      owl:onProperty ssn:hasOperatingRange ;
+    ] ;
+  rdfs:subClassOf [
+      rdf:type owl:Restriction ;
+      owl:allValuesFrom ssn:Platform ;
+      owl:onProperty ssn:onPlatform ;
+    ] ;
+  rdfs:subClassOf [
+      rdf:type owl:Restriction ;
+      owl:allValuesFrom ssn:SurvivalRange ;
+      owl:onProperty ssn:hasSurvivalRange ;
+    ] ;
+  rdfs:subClassOf [
+      rdf:type owl:Restriction ;
+      owl:allValuesFrom ssn:System ;
+      owl:onProperty ssn:hasSubSystem ;
+    ] ;
+  rdfs:subClassOf [
+      rdf:type owl:Restriction ;
+      owl:onProperty ssn:hasSubSystem ;
+      owl:someValuesFrom ssn:System ;
+    ] ;
+.
+ssn:SystemLifetime
+  rdf:type owl:Class ;
+  rdfs:comment "Total useful life of a sensor or system (expressed as total life since manufacture, time in use, number of operations, etc.)." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "System Lifetime" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#OperatingRestriction" ;
+  rdfs:subClassOf ssn:SurvivalProperty ;
+.
+ssn:attachedSystem
+  rdf:type owl:ObjectProperty ;
+  rdfs:comment "Relation between a Platform and any Systems (e.g., Sensors) that are attached to the Platform." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "attached system" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#PlatformSite" ;
+  owl:inverseOf ssn:onPlatform ;
+  skos:changeNote """--
+Replace by sosa:hosts
+--""" ;
+.
+ssn:deployedOnPlatform
+  rdf:type owl:ObjectProperty ;
+  rdfs:comment "Relation between a deployment and the platform on which the system is deployed." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "deployed on platform" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#Deployment" ;
+  owl:inverseOf ssn:inDeployment ;
+.
+ssn:deployedSystem
+  rdf:type owl:ObjectProperty ;
+  rdfs:comment "Relation between a deployment and the deployed system." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "deployed system" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#Deployment" ;
+  owl:inverseOf ssn:hasDeployment ;
+.
+ssn:deploymentProcessPart
+  rdf:type owl:ObjectProperty ;
+  rdfs:comment "Relation between a deployment process and its constituent processes (has-part)." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "deployment process part" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#Deployment" ;
+.
+ssn:detects
+  rdf:type owl:ObjectProperty ;
+  rdfs:comment """A relation from a sensor to the Stimulus that the sensor can detect.   
+The Stimulus itself will be serving as a proxy for (see isProxyOf) some observable property.""" ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "detects" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" ;
+.
+ssn:endTime
+  rdf:type owl:ObjectProperty ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "end time" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Base#Time" ;
+.
+ssn:featureOfInterest
+  rdf:type owl:ObjectProperty ;
+  dc:source """skos:exactMatch 'featureOfInterest' [O&M - ISO/DIS 19156] 
+		                    http://portal.opengeospatial.org/files/?artifact_id=41579""" ;
+  rdfs:comment "A relation between an observation and the entity whose quality was observed.   For example, in an observation of the weight of a person, the feature of interest is the person and the quality is weight." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "feature of interest" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" ;
+  skos:changeNote """--
+Replace by sosa:hasFeatureOfInterest ?
+--""" ;
+  skos:definition "A relation between an Observation and the entity whose quality was observed. " ;
+  skos:example "For example, in an Observation of the weight of a person, the FeatureOfInterest is the person and the quality is weight." ;
+.
+ssn:forProperty
+  rdf:type owl:ObjectProperty ;
+  rdfs:comment "A relation between some aspect of a sensing entity and a property.  For example, from a sensor to the properties it can observe, or from a deployment to the properties it was installed to observe.  Also from a measurement capability to the property the capability is described for.  Used in conjunction with ofFeature." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "for property" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" ;
+.
+ssn:hasDeployment
+  rdf:type owl:ObjectProperty ;
+  rdfs:comment "Relation between a System and a Deployment, recording that the System or Sensor was deployed in that Deployment." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "has deployment" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#Deployment" ;
+.
+ssn:hasInput
+  rdf:type owl:ObjectProperty ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "has input" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Model#Process" ;
+.
+ssn:hasMeasurementCapability
+  rdf:type owl:ObjectProperty ;
+  rdfs:comment "Relation from a Sensor to a MeasurementCapability describing the measurement properties of the sensor." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "has measurement capability" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Sensor#MeasuringCapability" ;
+  rdfs:subPropertyOf ssn:hasProperty ;
+.
+ssn:hasMeasurementProperty
+  rdf:type owl:ObjectProperty ;
+  rdfs:comment "Relation from a MeasurementCapability to a MeasurementProperty such as accuracy (see notes for MeasurementCapability)." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "has measurement property" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Sensor#MeasuringCapability" ;
+  rdfs:subPropertyOf ssn:hasProperty ;
+.
+ssn:hasOperatingProperty
+  rdf:type owl:ObjectProperty ;
+  rdfs:comment "Relation from an OperatingRange to a Property such as battery lifetime." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "has operating property" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#OperatingRestriction" ;
+  rdfs:subPropertyOf ssn:hasProperty ;
+.
+ssn:hasOperatingRange
+  rdf:type owl:ObjectProperty ;
+  rdfs:comment "Relation from a System to an OperatingRange describing the normal operating environment of the System." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "has operating range" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#OperatingRestriction" ;
+  rdfs:subPropertyOf ssn:hasProperty ;
+.
+ssn:hasOutput
+  rdf:type owl:ObjectProperty ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "has output" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Model#Process" ;
+.
+ssn:hasProperty
+  rdf:type owl:ObjectProperty ;
+  rdfs:comment "Relation between a FeatureOfInterest and a Property of that feature." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "has property" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" ;
+  owl:inverseOf ssn:isPropertyOf ;
+.
+ssn:hasSubSystem
+  rdf:type owl:ObjectProperty ;
+  rdfs:comment "Relation between a system and its component parts (has-part)." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "has subsystem" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Model#System" ;
+.
+ssn:hasSurvivalProperty
+  rdf:type owl:ObjectProperty ;
+  rdfs:comment "Relation from a SurvivalRange of a System to a Property describing the survival range of the system. For example, to the temperature range that a system can withstand before being considered damaged." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "has survival property" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#OperatingRestriction" ;
+  rdfs:subPropertyOf ssn:hasProperty ;
+.
+ssn:hasSurvivalRange
+  rdf:type owl:ObjectProperty ;
+  rdfs:comment "Relation from a System to a SurvivalRange." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "has survival range" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#OperatingRestriction" ;
+  rdfs:subPropertyOf ssn:hasProperty ;
+.
+ssn:hasValue
+  rdf:type owl:ObjectProperty ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "has value" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Base#Data" ;
+.
+ssn:implementedBy
+  rdf:type owl:ObjectProperty ;
+  rdfs:comment "Relation between the description of an algorithm, procedure or method and an entity that implements that method in some executable way.  For example, between a scientific measuring method and a sensor that senses via that method." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "implemented by" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" ;
+  owl:inverseOf ssn:implements ;
+.
+ssn:implements
+  rdf:type owl:ObjectProperty ;
+  rdfs:comment "Relation between an entity that implements a method in some executable way and the description of an algorithm, procedure or method.  For example, between a Sensor and the scientific measuring method that the Sensor uses to observe a Property." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "implements" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" ;
+.
+ssn:inCondition
+  rdf:type owl:ObjectProperty ;
+  rdfs:comment "Describes the prevailing environmental conditions for MeasurementCapabilites, OperatingConditions and SurvivalRanges.  Used for example to say that a sensor has a particular accuracy in particular conditions.  See also MeasurementCapability." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "in condition" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Base#ConstraintBlock" ;
+.
+ssn:inDeployment
+  rdf:type owl:ObjectProperty ;
+  rdfs:comment "Relation between a Platform and a Deployment, meaning that the subject was used as a platform for a system or sensor in the particular deployment. For example, between a buoy and a deployment identifier. " ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "in deployment" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#Deployment" ;
+.
+ssn:isProducedBy
+  rdf:type owl:ObjectProperty ;
+  rdfs:comment "Relation between a producer and a produced entity. For example, between a sensor and the produced output." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "is produced by" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Model#Process" ;
+.
+ssn:isPropertyOf
+  rdf:type owl:ObjectProperty ;
+  rdfs:comment "Relation between a FeatureOfInterest and a Property (a Quality observable by a sensor) of that feature." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "is property of" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" ;
+.
+ssn:isProxyFor
+  rdf:type owl:ObjectProperty ;
+  rdfs:comment "A relation from a Stimulus to the Property that the Stimulus is serving as a proxy for.  For example, the expansion of quicksilver is a stimulus that serves as a proxy for temperature. An increase or decrease in the velocity of spinning cups on a wind sensor is serving as a proxy for wind speed." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "is proxy for" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" ;
+.
+ssn:madeObservation
+  rdf:type owl:ObjectProperty ;
+  rdfs:comment "Relation between a Sensor and Observations it has made." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "made observation" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Observation#Observation" ;
+  owl:inverseOf ssn:observedBy ;
+  skos:changeNote """--
+Replace by sosa:madeObservation ?
+--""" ;
+  skos:definition "Relation between a Sensor and an Observations it has made." ;
+.
+ssn:observationResult
+  rdf:type owl:ObjectProperty ;
+  dc:source """skos:closeMatch 'result' [O&M - ISO/DIS 19156] 
+		                    http://portal.opengeospatial.org/files/?artifact_id=41579""" ;
+  rdfs:comment "Relation linking an Observation (i.e., a description of the context, the Situation, in which the observation was made) and a Result, which contains a value representing the value associated with the observed Property." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "observation result" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" ;
+  rdfs:subPropertyOf <http://www.w3.org/ns/sosa/hasResult> ;
+  skos:changeNote """--
+sub-property of sosa:hasResult (which also includes actuation and sample preparation activities)
+--""" ;
+.
+ssn:observationResultTime
+  rdf:type owl:ObjectProperty ;
+  dc:source "http://www.opengeospatial.org/standards/om" ;
+  rdfs:comment "The result time is the time when the procedure associated with the observation act was applied." ;
+  rdfs:comment "The result time shall describe the time when the result became available, typically when the procedure associated with the observation was completed For some observations this is identical to the phenomenonTime. However, there are important cases where they differ.[O&M]" ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "observation result time" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Observation#Observation" ;
+  rdfs:subPropertyOf <http://www.w3.org/ns/sosa/resultTime> ;
+  skos:changeNote """--
+sub-property of sosa:resultTime - which also includes result of actuation and sampling activities
+--""" ;
+.
+ssn:observationSamplingTime
+  rdf:type owl:ObjectProperty ;
+  dc:source "http://www.opengeospatial.org/standards/om" ;
+  rdfs:comment "Rebadged as phenomenon time in [O&M]. The phenomenon time shall describe the time that the result applies to the property of the feature-of-interest. This is often the time of interaction by a sampling procedure or observation procedure with a real-world feature." ;
+  rdfs:comment "The sampling time is the time that the result applies to the feature-of-interest. This is the time usually required for geospatial analysis of the result." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "observation sampling time" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Observation#Observation" ;
+  skos:changeNote """--
+Replace by sosa:phenomenonTime ?
+--""" ;
+  skos:definition "The time that the Result of an Observation/Actuation applies to the FeatureOfInterest. Not necessarily the same as the result-time. May be an interval or an instant, or some other compound temporal entity." ;
+.
+ssn:observedBy
+  rdf:type owl:ObjectProperty ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "observed by" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" ;
+.
+ssn:observedProperty
+  rdf:type owl:ObjectProperty ;
+  dc:source """skos:exactMatch 'observedProperty' [O&M - ISO/DIS 19156] 
+		                    http://portal.opengeospatial.org/files/?artifact_id=41579""" ;
+  rdfs:comment "Relation linking an Observation to the Property that was observed.  The observedProperty should be a Property (hasProperty) of the FeatureOfInterest (linked by featureOfInterest) of this observation." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "observed property" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" ;
+  skos:changeNote """--
+Replace by sosa:observedProeprty ?
+--""" ;
+  skos:definition "Relation linking an Observation to the Property that was observed. The observedProperty should be a Property (hasProperty) of the FeatureOfInterest (linked by featureOfInterest) of this observation." ;
+.
+ssn:observes
+  rdf:type owl:ObjectProperty ;
+  rdfs:comment """Relation between a Sensor and a Property that the sensor can observe.
 
-
-###  http://www.w3.org/ns/ssn/System
-ssn:System rdf:type owl:Class ;
-           rdfs:subClassOf [ rdf:type owl:Restriction ;
-                             owl:onProperty ssn:hasSubSystem ;
-                             owl:someValuesFrom ssn:System
-                           ] ,
-                           [ rdf:type owl:Restriction ;
-                             owl:onProperty ssn:hasDeployment ;
-                             owl:allValuesFrom ssn:Deployment
-                           ] ,
-                           [ rdf:type owl:Restriction ;
-                             owl:onProperty ssn:hasOperatingRange ;
-                             owl:allValuesFrom ssn:OperatingRange
-                           ] ,
-                           [ rdf:type owl:Restriction ;
-                             owl:onProperty ssn:hasSubSystem ;
-                             owl:allValuesFrom ssn:System
-                           ] ,
-                           [ rdf:type owl:Restriction ;
-                             owl:onProperty ssn:hasSurvivalRange ;
-                             owl:allValuesFrom ssn:SurvivalRange
-                           ] ,
-                           [ rdf:type owl:Restriction ;
-                             owl:onProperty ssn:onPlatform ;
-                             owl:allValuesFrom ssn:Platform
-                           ] ;
-           dc:source "http://www.w3.org/2005/Incubator/ssn/" ;
-           rdfs:comment "System is a unit of abstraction for pieces of infrastructure for sensing. A system has components, its subsystems, which are other systems." ;
-           rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-           rdfs:label "System" ;
-           rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Model#System" .
-
-
-###  http://www.w3.org/ns/ssn/SystemLifetime
-ssn:SystemLifetime rdf:type owl:Class ;
-                   rdfs:subClassOf ssn:SurvivalProperty ;
-                   rdfs:comment "Total useful life of a sensor or system (expressed as total life since manufacture, time in use, number of operations, etc.)." ;
-                   rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                   rdfs:label "System Lifetime" ;
-                   rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#OperatingRestriction" .
-
-
-###  Generated by the OWL API (version 4.2.5.20160517-0735) https://github.com/owlcs/owlapi
+Note that, given the DUL modelling of Qualities, a sensor defined with 'observes only Windspeed' technically links the sensor to particular instances of Windspeed, not to the concept itself - OWL can't express concept-concept relations, only individual-individual.  The property composition ensures that if an observation is made of a particular quality then one can infer that the sensor observes that quality.""" ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "observes" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Sensor#Measuring" ;
+  owl:propertyChainAxiom (
+      ssn:hasMeasurementCapability
+      ssn:forProperty
+    ) ;
+  owl:propertyChainAxiom (
+      ssn:madeObservation
+      ssn:observedProperty
+    ) ;
+  skos:changeNote """--
+Replace by sosa:observes ?
+--""" ;
+  skos:definition "Relation between a Sensor and an ObservableProperty." ;
+.
+ssn:ofFeature
+  rdf:type owl:ObjectProperty ;
+  rdfs:comment "A relation between some aspect of a sensing entity and a feature.  For example, from a sensor to the features it can observe properties of, or from a deployment to the features it was installed to observe.  Also from a measurement capability to the feature the capability is described for.  (Used in conjunction with forProperty)." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "of feature" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" ;
+.
+ssn:onPlatform
+  rdf:type owl:ObjectProperty ;
+  rdfs:comment "Relation between a System (e.g., a Sensor) and a Platform.  The relation locates the sensor relative to other described entities entities: i.e., the Sensor s1's location is Platform p1.  More precise locations for sensors in space (relative to other entities, where attached to another entity, or in 3D space) are made using DOLCE's Regions (SpaceRegion)." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "on platform" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#PlatformSite" ;
+  skos:changeNote """--
+Replace by sosa:hostedBy ?
+--""" ;
+  skos:definition "Relation between a Sensor or Actuator and the Platform that it is mounted on or hosted by." ;
+.
+ssn:qualityOfObservation
+  rdf:type owl:ObjectProperty ;
+  dc:source """skos:exactMatch 'resultQuality' [O&M - ISO/DIS 19156] 
+		                    http://portal.opengeospatial.org/files/?artifact_id=41579""" ;
+  rdfs:comment "Relation linking an Observation to the adjudged quality of the result.  This is of course complimentary to the MeasurementCapability information recorded for the Sensor that made the Observation." ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "quality of observation" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Observation#Observation" ;
+  rdfs:subPropertyOf ssn:hasProperty ;
+.
+ssn:sensingMethodUsed
+  rdf:type owl:ObjectProperty ;
+  dc:source "http://www.bipm.org/en/committees/jc/jcgm/wg2.html" ;
+  rdfs:comment "A (measurement) procedure is a detailed description of a measurement according to one or more measurement principles and to a given measurement method, based on a measurement model and including any calculation to obtain a measurement result [VIM 2.6]" ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "sensing method used" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" ;
+  rdfs:subPropertyOf <http://www.w3.org/ns/sosa/usedProcedure> ;
+  skos:changeNote """--
+Sub-property of sosa:usedProcedure - whcih also includes actuation and sampling activities
+--""" ;
+.
+ssn:startTime
+  rdf:type owl:ObjectProperty ;
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "start time" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Base#Time" ;
+.


### PR DESCRIPTION
Inserted SKOS annotations (changeNote and definition) drawing attention to where there are opportunities to replace ssn classes and properties with sosa equivalents;

Also a small number of proposed subclasses and sub-properties from sosa
- ssn:ObservationValue subclassOf sosa:Result
- ssn:observationResult subpropertyOf sosa:hasResult
- ssn:sensingMethodUsed subpropertyOf sosa:usedProcedure
- ssn:observationResultTime subpropertyOf sosa:resultTime
because the scope of sosa results also includes actuation and sampling activities