### PR TITLE
SOSA - add sosa:Actuation to domain/range of result properties

### DIFF
--- a/ssn/rdf/sosa.ttl
+++ b/ssn/rdf/sosa.ttl
@@ -1,3 +1,7 @@
+# baseURI: http://www.w3.org/ns/sosa/
+# imports: http://www.w3.org/2004/02/skos/core
+# prefix: sosa
+
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix meta: <http://meta.schema.org/> .
 @prefix ns: <http://creativecommons.org/ns#> .
@@ -59,9 +63,11 @@ rdfs:seeAlso
 owl:topObjectProperty
   rdf:type owl:ObjectProperty ;
 .
-<http://www.w3.org/ns/sosa/>
+sosa:
+  rdf:type owl:Ontology ;
   rdfs:comment "This ontology is based on the SSN Ontology by the W3C Semantic Sensor Networks Incubator Group (SSN-XG), together with considerations from the W3C/OGC Spatial Data on the Web Working Group." ;
   rdfs:label "Sensor, Observation, Sample, and Actuator (SOSA) Core Ontology" ;
+  owl:imports <http://www.w3.org/2004/02/skos/core> ;
   skos:historyNote "This version is based on the horizontal/vertical modularization proposed in the W3C/OGC Spatial Data on the Web Working Group: http://w3c.github.io/sdw/ssn/#modularisation" ;
 .
 sosa:Actuation
@@ -154,6 +160,7 @@ sosa:hasFeatureOfInterest
 .
 sosa:hasResult
   rdf:type owl:ObjectProperty ;
+  meta:domainIncludes sosa:Actuation ;
   meta:domainIncludes sosa:Observation ;
   meta:rangeIncludes sosa:Result ;
   rdfs:comment "Relation linking an Observation and a Sensor or Actuator and a Result, which contains a value representing the value associated with the observed Property."@en ;
@@ -236,6 +243,7 @@ sosa:isObservedBy
 sosa:isResultOf
   rdf:type owl:ObjectProperty ;
   meta:domainIncludes sosa:Result ;
+  meta:rangeIncludes sosa:Actuation ;
   meta:rangeIncludes sosa:Observation ;
   rdfs:comment "Relation linking a Result to the Observation that created it."@en ;
   rdfs:label "is result of"@en ;
@@ -301,8 +309,4 @@ sosa:usedProcedure
   rdfs:comment "Relation to link to a re-usable Procedure used in making an Observation or Actuation. Typically a sensor or sensor-system, algorithm, computational Process."@en ;
   rdfs:label "used process"@en ;
   skos:definition "Relation to link to a re-usable Procedure used in making an Observation or Actuation. Typically a sensor or sensor-system, algorithm, computational Process."@en ;
-.
-<http://www.w3.org/ns/sosa/>
-  rdf:type owl:Ontology ;
-  owl:imports <http://www.w3.org/2004/02/skos/core> ;
 .


### PR DESCRIPTION
I noticed that sosa:Actuation had not been included in the domain/range of hasResult/isResultOf properties, where I think it should have been in order that these properties support the general case of observation, actuation or sampling. 