### PR TITLE
Updated sosa-ssn alignment

### DIFF
--- a/ssn/rdf/sosa.ttl
+++ b/ssn/rdf/sosa.ttl
@@ -134,7 +134,6 @@ sosa:Result
   skos:definition "The Result of an Observation, Actuation, or Sampling. Such result can, for instance, store an observation's value via the hasValue property."@en ;
   skos:example "The value of 20m as the height of a certain tree."@en ;
 .
-.
 sosa:Sample
   rdf:type rdfs:Class ;
   rdf:type owl:Class ;

--- a/ssn/rdf/ssn-sosa.ttl
+++ b/ssn/rdf/ssn-sosa.ttl
@@ -13,70 +13,80 @@
 @prefix ssn-sosa: <http://www.w3.org/ns/ssn-sosa#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
+sosa:ObservableProperty
+  rdfs:comment "ssn:Property is super-class of all properties including those that are not necessarily 'observable'. " ;
+  rdfs:subClassOf ssn:Property ;
+.
 sosa:hasValue
-  rdfs:subPropertyOf ssn:hasValue ;
+  rdfs:comment "Not clear how to relate this to ssn:hasValue, which is an owl:ObjectProperty" ;
 .
 <http://www.w3.org/ns/ssn-sosa>
   rdf:type owl:Ontology ;
   dc:contributor <https://www.w3.org/2000/09/dbwg/details?group=75471&public=1> ;
   dc:creator <http://orcid.org/0000-0002-3884-3420> ;
   dcterms:created "2017-01-24"^^xsd:date ;
+  dcterms:modified "2017-02-08"^^xsd:date ;
   rdfs:comment "An initial mapping from SSN to SOSA" ;
   rdfs:seeAlso <https://www.w3.org/2015/spatial/wiki/Mapping_Table> ;
   owl:imports sosa: ;
   owl:imports ssn: ;
 .
 ssn:FeatureOfInterest
-  rdfs:subClassOf sosa:FeatureOfInterest ;
+  owl:equivalentClass sosa:FeatureOfInterest ;
 .
 ssn:Observation
-  rdfs:subClassOf sosa:Observation ;
+  owl:equivalentClass sosa:Observation ;
 .
 ssn:ObservationValue
   rdfs:subClassOf sosa:Result ;
 .
 ssn:Platform
+  rdfs:comment "Unclear if ssn:Platform is as general as sosa:Platform since sosa:Platform explicitly mentions actuators and sampling devices." ;
   rdfs:subClassOf sosa:Platform ;
 .
 ssn:Process
-  rdfs:subClassOf sosa:Procedure ;
+  rdfs:comment "Relationship with sosa:Procedure unclear" ;
 .
 ssn:Property
-  rdfs:subClassOf sosa:ObservableProperty ;
+  rdfs:comment "ssn:Property is super-class of some properties that are not necessarily 'observable'. Might be best as a super-property of sosa:ObservableProperty" ;
 .
 ssn:Sensor
-  rdfs:subClassOf sosa:Sensor ;
+  owl:equivalentClass sosa:Sensor ;
 .
 ssn:SensorOutput
   rdfs:subClassOf sosa:Result ;
 .
 ssn:attachedSystem
-  rdfs:subPropertyOf sosa:hosts ;
+  owl:equivalentProperty sosa:hosts ;
 .
 ssn:featureOfInterest
-  rdfs:subPropertyOf sosa:hasFeatureOfInterest ;
+  owl:equivalentProperty sosa:hasFeatureOfInterest ;
 .
 ssn:madeObservation
-  rdfs:subPropertyOf sosa:madeObservation ;
+  owl:equivalentProperty sosa:madeObservation ;
 .
 ssn:observationResult
+  rdfs:comment "sosa:hasResult also applies to actuation and sampling" ;
   rdfs:subPropertyOf sosa:hasResult ;
 .
 ssn:observationResultTime
+  rdfs:comment "sosa:resultTime also applies to actuation and sampling" ;
   rdfs:subPropertyOf sosa:resultTime ;
 .
 ssn:observationSamplingTime
-  rdfs:subPropertyOf sosa:phenomenonTime ;
+  rdfs:comment "Appears to be equivalent to sosa:phenomenonTime. Looks like SSN used a pre-standard version of O&M when selecting local-names." ;
+  owl:equivalentProperty sosa:phenomenonTime ;
 .
 ssn:observedProperty
-  rdfs:subPropertyOf sosa:observedProperty ;
+  owl:equivalentProperty sosa:observedProperty ;
 .
 ssn:observes
-  rdfs:subPropertyOf sosa:observes ;
+  owl:equivalentProperty sosa:observes ;
 .
 ssn:onPlatform
-  rdfs:subPropertyOf sosa:hostedBy ;
+  owl:equivalentProperty sosa:hostedBy ;
 .
 ssn:sensingMethodUsed
+  rdfs:comment "sosa:usedProcedure also applies to actuation and sampling" ;
   rdfs:subPropertyOf sosa:usedProcedure ;
 .

--- a/ssn/ssn_separated/ssn.ttl
+++ b/ssn/ssn_separated/ssn.ttl
@@ -123,8 +123,8 @@ ssn:deploymentProcessPart rdf:type owl:ObjectProperty ;
 
 ###  http://www.w3.org/ns/ssn/detects
 ssn:detects rdf:type owl:ObjectProperty ;
-            rdfs:comment "A relation from a Sensor to the Stimulus that the Sensor can detect.   
-The Stimulus itself will be serving as a proxy for (see isProxyOf) some observable property." ;
+            rdfs:comment """A relation from a Sensor to the Stimulus that the Sensor can detect.   
+The Stimulus itself will be serving as a proxy for (see isProxyOf) some observable property.""" ;
             rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
             rdfs:label "detects" ;
             rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" .


### PR DESCRIPTION
I updated the ssn-sosa.ttl graph to reflect refined understanding from the last week's email discussions. 

Note that owl:equivalentClass/Property relations indicate potential opportunities to streamline SSN by adopting the SOSA resources directly, alongside an import of SOSA. 

Included comments for sub-class and sub-property relationships to explain why. 
