### PR TITLE
changed meta prefix declaration to schema,

### DIFF
--- a/ssn/rdf/sosa.ttl
+++ b/ssn/rdf/sosa.ttl
@@ -3,7 +3,6 @@
 # prefix: sosa
 
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
-@prefix meta: <http://meta.schema.org/> .
 @prefix ns: <http://creativecommons.org/ns#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -18,10 +17,10 @@
 ns:license
   rdf:type owl:AnnotationProperty ;
 .
-meta:domainIncludes
+schema:domainIncludes
   rdf:type owl:AnnotationProperty ;
 .
-meta:rangeIncludes
+schema:rangeIncludes
   rdf:type owl:AnnotationProperty ;
 .
 dc:creator
@@ -158,9 +157,9 @@ sosa:Sensor
 .
 sosa:hasFeatureOfInterest
   rdf:type owl:ObjectProperty ;
-  meta:domainIncludes sosa:Observation ;
-  meta:rangeIncludes sosa:FeatureOfInterest ;
-  meta:rangeIncludes sosa:Sample ;
+  schema:domainIncludes sosa:Observation ;
+  schema:rangeIncludes sosa:FeatureOfInterest ;
+  schema:rangeIncludes sosa:Sample ;
   rdfs:comment "A relation between an Observation and the entity whose quality was observed."@en ;
   rdfs:label "has feature of interest"@en ;
   owl:inverseOf sosa:isFeatureOfInterestOf ;
@@ -169,9 +168,9 @@ sosa:hasFeatureOfInterest
 .
 sosa:hasResult
   rdf:type owl:ObjectProperty ;
-  meta:domainIncludes sosa:Actuation ;
-  meta:domainIncludes sosa:Observation ;
-  meta:rangeIncludes sosa:Result ;
+  schema:domainIncludes sosa:Actuation ;
+  schema:domainIncludes sosa:Observation ;
+  schema:rangeIncludes sosa:Result ;
   rdfs:comment "Relation linking an Observation and a Sensor or Actuator and a Result, which contains a value representing the value associated with the observed Property."@en ;
   rdfs:label "has result"@en ;
   owl:inverseOf sosa:isResultOf ;
@@ -179,8 +178,8 @@ sosa:hasResult
 .
 sosa:hasSample
   rdf:type owl:ObjectProperty ;
-  meta:domainIncludes sosa:FeatureOfInterest ;
-  meta:rangeIncludes sosa:Sample ;
+  schema:domainIncludes sosa:FeatureOfInterest ;
+  schema:rangeIncludes sosa:Sample ;
   rdfs:comment "Relation between a FeatureOfInterest and the Sample used to represent it."@en ;
   rdfs:label "has sample"@en ;
   owl:inverseOf sosa:isSampleOf ;
@@ -188,7 +187,7 @@ sosa:hasSample
 .
 sosa:hasValue
   rdf:type owl:DatatypeProperty ;
-  meta:domainIncludes sosa:Result ;
+  schema:domainIncludes sosa:Result ;
   rdfs:comment "The value of a Result, e.g., 23 or true."@en ;
   rdfs:label "has value"@en ;
   skos:definition "The value of a Result"@en ;
@@ -196,9 +195,9 @@ sosa:hasValue
 .
 sosa:hostedBy
   rdf:type owl:ObjectProperty ;
-  meta:domainIncludes sosa:Actuator ;
-  meta:domainIncludes sosa:Sensor ;
-  meta:rangeIncludes sosa:Platform ;
+  schema:domainIncludes sosa:Actuator ;
+  schema:domainIncludes sosa:Sensor ;
+  schema:rangeIncludes sosa:Platform ;
   rdfs:comment "Relation between a Sensor or Actuator and the Platform that it is mounted on or hosted by."@en ;
   rdfs:label "hosted by"@en ;
   owl:inverseOf sosa:hosts ;
@@ -206,9 +205,9 @@ sosa:hostedBy
 .
 sosa:hosts
   rdf:type owl:ObjectProperty ;
-  meta:domainIncludes sosa:Platform ;
-  meta:rangeIncludes sosa:Actuator ;
-  meta:rangeIncludes sosa:Sensor ;
+  schema:domainIncludes sosa:Platform ;
+  schema:rangeIncludes sosa:Actuator ;
+  schema:rangeIncludes sosa:Sensor ;
   rdfs:comment "Relation between a Platform and a Sensor or Actuator hosted or mounted on it."@en ;
   rdfs:label "hosts"@en ;
   owl:inverseOf sosa:hostedBy ;
@@ -216,8 +215,8 @@ sosa:hosts
 .
 sosa:invokedBy
   rdf:type owl:ObjectProperty ;
-  meta:domainIncludes sosa:Actuation ;
-  meta:rangeIncludes sosa:Actuator ;
+  schema:domainIncludes sosa:Actuation ;
+  schema:rangeIncludes sosa:Actuator ;
   rdfs:comment "Relation linking an Actuation to the Actuator that made that Actuation."@en ;
   rdfs:label "invoked by"@en ;
   owl:inverseOf sosa:invokes ;
@@ -225,16 +224,16 @@ sosa:invokedBy
 .
 sosa:invokes
   rdf:type owl:ObjectProperty ;
-  meta:domainIncludes sosa:Actuator ;
-  meta:rangeIncludes sosa:Actuation ;
+  schema:domainIncludes sosa:Actuator ;
+  schema:rangeIncludes sosa:Actuation ;
   rdfs:comment "Relation between an Actuator and the Actuation it has made."@en ;
   rdfs:label "invokes"@en ;
   skos:definition "Relation between an Actuator and the Actuation it has made."@en ;
 .
 sosa:isFeatureOfInterestOf
   rdf:type owl:ObjectProperty ;
-  meta:domainIncludes sosa:FeatureOfInterest ;
-  meta:rangeIncludes sosa:Observation ;
+  schema:domainIncludes sosa:FeatureOfInterest ;
+  schema:rangeIncludes sosa:Observation ;
   rdfs:comment "A relation between a FeatureOfInterest and an Observation about it."@en ;
   rdfs:label "is feature of interest of"@en ;
   owl:inverseOf sosa:hasFeatureOfInterest ;
@@ -242,8 +241,8 @@ sosa:isFeatureOfInterestOf
 .
 sosa:isObservedBy
   rdf:type owl:ObjectProperty ;
-  meta:domainIncludes sosa:ObservableProperty ;
-  meta:rangeIncludes sosa:Sensor ;
+  schema:domainIncludes sosa:ObservableProperty ;
+  schema:rangeIncludes sosa:Sensor ;
   rdfs:comment "Relation between an ObservableProperty and the Sensor able to observe it."@en ;
   rdfs:label "is observed by"@en ;
   owl:inverseOf sosa:observes ;
@@ -251,9 +250,9 @@ sosa:isObservedBy
 .
 sosa:isResultOf
   rdf:type owl:ObjectProperty ;
-  meta:domainIncludes sosa:Result ;
-  meta:rangeIncludes sosa:Actuation ;
-  meta:rangeIncludes sosa:Observation ;
+  schema:domainIncludes sosa:Result ;
+  schema:rangeIncludes sosa:Actuation ;
+  schema:rangeIncludes sosa:Observation ;
   rdfs:comment "Relation linking a Result to the Observation that created it."@en ;
   rdfs:label "is result of"@en ;
   owl:inverseOf sosa:hasResult ;
@@ -261,8 +260,8 @@ sosa:isResultOf
 .
 sosa:isSampleOf
   rdf:type owl:ObjectProperty ;
-  meta:domainIncludes sosa:Sample ;
-  meta:rangeIncludes sosa:FeatureOfInterest ;
+  schema:domainIncludes sosa:Sample ;
+  schema:rangeIncludes sosa:FeatureOfInterest ;
   rdfs:comment "Relation from a Sample to the FeatureOfInterest that it is intended to be representative of."@en ;
   rdfs:label "is sample of"@en ;
   owl:inverseOf sosa:hasSample ;
@@ -270,24 +269,24 @@ sosa:isSampleOf
 .
 sosa:madeObservation
   rdf:type owl:ObjectProperty ;
-  meta:domainIncludes sosa:Sensor ;
-  meta:rangeIncludes sosa:Observation ;
+  schema:domainIncludes sosa:Sensor ;
+  schema:rangeIncludes sosa:Observation ;
   rdfs:comment "Relation between a Sensor and an Observation it has made."@en ;
   rdfs:label "made observation"@en ;
   skos:definition "Relation between a Sensor and an Observation it has made."@en ;
 .
 sosa:observedProperty
   rdf:type owl:ObjectProperty ;
-  meta:domainIncludes sosa:Observation ;
-  meta:rangeIncludes sosa:ObservableProperty ;
+  schema:domainIncludes sosa:Observation ;
+  schema:rangeIncludes sosa:ObservableProperty ;
   rdfs:comment "Relation linking an Observation to the Property that was observed. The observedProperty should be a Property (hasProperty) of the FeatureOfInterest (linked by featureOfInterest) of this observation."@en ;
   rdfs:label "observed property"@en ;
   skos:definition "Relation linking an Observation to the Property that was observed. The observedProperty should be a Property (hasProperty) of the FeatureOfInterest (linked by featureOfInterest) of this observation."@en ;
 .
 sosa:observes
   rdf:type owl:ObjectProperty ;
-  meta:domainIncludes sosa:Sensor ;
-  meta:rangeIncludes sosa:ObservableProperty ;
+  schema:domainIncludes sosa:Sensor ;
+  schema:rangeIncludes sosa:ObservableProperty ;
   rdfs:comment "Relation between a Sensor and an ObservableProperty that it is capable of sensing."@en ;
   rdfs:label "observes"@en ;
   owl:inverseOf sosa:isObservedBy ;
@@ -295,16 +294,16 @@ sosa:observes
 .
 sosa:phenomenonTime
   rdf:type owl:ObjectProperty ;
-  meta:domainIncludes sosa:Actuation ;
-  meta:domainIncludes sosa:Observation ;
+  schema:domainIncludes sosa:Actuation ;
+  schema:domainIncludes sosa:Observation ;
   rdfs:comment "The time that the Result of an Observation/Actuation applies to the FeatureOfInterest. Not necessarily the same as the result-time. May be an interval or an instant, or some other compound temporal entity."@en ;
   rdfs:label "phenomenon time"@en ;
   skos:definition "The time that the Result of an Observation/Actuation applies to the FeatureOfInterest. Not necessarily the same as the result-time. May be an interval or an instant, or some other compound temporal entity."@en ;
 .
 sosa:resultTime
   rdf:type owl:DatatypeProperty ;
-  meta:domainIncludes sosa:Actuation ;
-  meta:domainIncludes sosa:Observation ;
+  schema:domainIncludes sosa:Actuation ;
+  schema:domainIncludes sosa:Observation ;
   rdfs:comment "The result time is the time when the Observation or Actuation act was completed."@en ;
   rdfs:label "result time"@en ;
   rdfs:range xsd:dateTime ;
@@ -312,9 +311,9 @@ sosa:resultTime
 .
 sosa:usedProcedure
   rdf:type owl:ObjectProperty ;
-  meta:domainIncludes sosa:Actuation ;
-  meta:domainIncludes sosa:Observation ;
-  meta:rangeIncludes sosa:Procedure ;
+  schema:domainIncludes sosa:Actuation ;
+  schema:domainIncludes sosa:Observation ;
+  schema:rangeIncludes sosa:Procedure ;
   rdfs:comment "Relation to link to a re-usable Procedure used in making an Observation or Actuation. Typically a sensor or sensor-system, algorithm, computational Process."@en ;
   rdfs:label "used process"@en ;
   skos:definition "Relation to link to a re-usable Procedure used in making an Observation or Actuation. Typically a sensor or sensor-system, algorithm, computational Process."@en ;


### PR DESCRIPTION
**This requires a vote before merging**

related to https://www.w3.org/2015/spatial/track/issues/72

implementation of the proposal made in https://lists.w3.org/Archives/Public/public-sdw-wg/2017Feb/0249.html 

I suggest:
 - we use prefix: @prefix schema: <http://schema.org/> .
 - we change any mention of meta:domainIncludes into schema:domainIncludes
 - we change any mention of meta:rangeIncludes into schema:rangeIncludes
