### PR TITLE
changed any mention of owl:inverseOf into schema:inverseOf

### DIFF
--- a/ssn/rdf/sosa.ttl
+++ b/ssn/rdf/sosa.ttl
@@ -163,7 +163,7 @@ sosa:hasFeatureOfInterest
   meta:rangeIncludes sosa:Sample ;
   rdfs:comment "A relation between an Observation and the entity whose quality was observed."@en ;
   rdfs:label "has feature of interest"@en ;
-  owl:inverseOf sosa:isFeatureOfInterestOf ;
+  schema:inverseOf sosa:isFeatureOfInterestOf ;
   skos:definition "A relation between an Observation and the entity whose quality was observed."@en ;
   skos:example "For example, in an Observation of the weight of a person, the FeatureOfInterest is the person and the quality is weight."@en ;
 .
@@ -174,7 +174,7 @@ sosa:hasResult
   meta:rangeIncludes sosa:Result ;
   rdfs:comment "Relation linking an Observation and a Sensor or Actuator and a Result, which contains a value representing the value associated with the observed Property."@en ;
   rdfs:label "has result"@en ;
-  owl:inverseOf sosa:isResultOf ;
+  schema:inverseOf sosa:isResultOf ;
   skos:definition "Relation linking an Observation and a Sensor or Actuator and a Result, which contains a value representing the value associated with the observed Property."@en ;
 .
 sosa:hasSample
@@ -183,7 +183,7 @@ sosa:hasSample
   meta:rangeIncludes sosa:Sample ;
   rdfs:comment "Relation between a FeatureOfInterest and the Sample used to represent it."@en ;
   rdfs:label "has sample"@en ;
-  owl:inverseOf sosa:isSampleOf ;
+  schema:inverseOf sosa:isSampleOf ;
   skos:definition "Relation between a FeatureOfInterest and the Sample used to represent it."@en ;
 .
 sosa:hasValue
@@ -201,7 +201,7 @@ sosa:hostedBy
   meta:rangeIncludes sosa:Platform ;
   rdfs:comment "Relation between a Sensor or Actuator and the Platform that it is mounted on or hosted by."@en ;
   rdfs:label "hosted by"@en ;
-  owl:inverseOf sosa:hosts ;
+  schema:inverseOf sosa:hosts ;
   skos:definition "Relation between a Sensor or Actuator and the Platform that it is mounted on or hosted by."@en ;
 .
 sosa:hosts
@@ -211,7 +211,7 @@ sosa:hosts
   meta:rangeIncludes sosa:Sensor ;
   rdfs:comment "Relation between a Platform and a Sensor or Actuator hosted or mounted on it."@en ;
   rdfs:label "hosts"@en ;
-  owl:inverseOf sosa:hostedBy ;
+  schema:inverseOf sosa:hostedBy ;
   skos:definition "Relation between a Platform and a Sensor or Actuator hosted or mounted on it."@en ;
 .
 sosa:invokedBy
@@ -220,7 +220,7 @@ sosa:invokedBy
   meta:rangeIncludes sosa:Actuator ;
   rdfs:comment "Relation linking an Actuation to the Actuator that made that Actuation."@en ;
   rdfs:label "invoked by"@en ;
-  owl:inverseOf sosa:invokes ;
+  schema:inverseOf sosa:invokes ;
   skos:definition "Relation linking an Actuation to the Actuator that made that Actuation."@en ;
 .
 sosa:invokes
@@ -237,7 +237,7 @@ sosa:isFeatureOfInterestOf
   meta:rangeIncludes sosa:Observation ;
   rdfs:comment "A relation between a FeatureOfInterest and an Observation about it."@en ;
   rdfs:label "is feature of interest of"@en ;
-  owl:inverseOf sosa:hasFeatureOfInterest ;
+  schema:inverseOf sosa:hasFeatureOfInterest ;
   skos:definition "A relation between a FeatureOfInterest and an Observation about it."@en ;
 .
 sosa:isObservedBy
@@ -246,7 +246,7 @@ sosa:isObservedBy
   meta:rangeIncludes sosa:Sensor ;
   rdfs:comment "Relation between an ObservableProperty and the Sensor able to observe it."@en ;
   rdfs:label "is observed by"@en ;
-  owl:inverseOf sosa:observes ;
+  schema:inverseOf sosa:observes ;
   skos:definition "Relation between an ObservableProperty and the Sensor able to observe it."@en ;
 .
 sosa:isResultOf
@@ -256,7 +256,7 @@ sosa:isResultOf
   meta:rangeIncludes sosa:Observation ;
   rdfs:comment "Relation linking a Result to the Observation that created it."@en ;
   rdfs:label "is result of"@en ;
-  owl:inverseOf sosa:hasResult ;
+  schema:inverseOf sosa:hasResult ;
   skos:definition "Relation linking a Result to the Observation that created it."@en ;
 .
 sosa:isSampleOf
@@ -265,7 +265,7 @@ sosa:isSampleOf
   meta:rangeIncludes sosa:FeatureOfInterest ;
   rdfs:comment "Relation from a Sample to the FeatureOfInterest that it is intended to be representative of."@en ;
   rdfs:label "is sample of"@en ;
-  owl:inverseOf sosa:hasSample ;
+  schema:inverseOf sosa:hasSample ;
   skos:definition "Relation from a Sample to the FeatureOfInterest that it is intended to be representative of."@en ;
 .
 sosa:madeObservation
@@ -290,7 +290,7 @@ sosa:observes
   meta:rangeIncludes sosa:ObservableProperty ;
   rdfs:comment "Relation between a Sensor and an ObservableProperty that it is capable of sensing."@en ;
   rdfs:label "observes"@en ;
-  owl:inverseOf sosa:isObservedBy ;
+  schema:inverseOf sosa:isObservedBy ;
   skos:definition "Relation between a Sensor and an ObservableProperty that it is capable of sensing."@en ;
 .
 sosa:phenomenonTime


### PR DESCRIPTION
**This requires a vote before merging**

related to https://www.w3.org/2015/spatial/track/issues/72

just the implementation of the proposal C in https://lists.w3.org/Archives/Public/public-sdw-wg/2017Feb/0247.html

owl:inverseOf is replaced by schema:inverseOf everywhere.