### PR TITLE
implemented resolution 10 to 13 of call 28-02-17

### DIFF
--- a/ssn/integrated/oldssn.ttl
+++ b/ssn/integrated/oldssn.ttl
@@ -86,13 +86,6 @@ rdfs:seeAlso rdf:type owl:AnnotationProperty .
 #    Object Properties
 #################################################################
 
-###  http://www.w3.org/ns/ssn/attachedSystem
-ssn:attachedSystem rdf:type owl:ObjectProperty ;
-                   owl:inverseOf ssn:onPlatform ;
-                   rdfs:comment "Relation between a Platform and any Systems (e.g., Sensors) that are attached to the Platform." ;
-                   rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                   rdfs:label "attached system" ;
-                   rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#PlatformSite" .
 
 
 ###  http://www.w3.org/ns/ssn/deployedOnPlatform
@@ -216,23 +209,6 @@ ssn:hasOutput rdf:type owl:ObjectProperty ;
               rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Model#Process" .
 
 
-###  http://www.w3.org/ns/ssn/hasProperty
-ssn:hasProperty rdf:type owl:ObjectProperty ;
-                owl:inverseOf ssn:isPropertyOf ;
-                rdfs:comment "Relation between a FeatureOfInterest and a Property of that feature." ;
-                rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                rdfs:label "has property" ;
-                rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" .
-
-
-###  http://www.w3.org/ns/ssn/hasSubSystem
-ssn:hasSubSystem rdf:type owl:ObjectProperty ;
-                 rdfs:comment "Relation between a system and its component parts (has-part)." ;
-                 rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                 rdfs:label "has subsystem" ;
-                 rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Model#System" .
-
-
 ###  http://www.w3.org/ns/ssn/hasSurvivalProperty
 ssn:hasSurvivalProperty rdf:type owl:ObjectProperty ;
                         rdfs:subPropertyOf ssn:hasProperty ;
@@ -298,15 +274,6 @@ ssn:isProducedBy rdf:type owl:ObjectProperty ;
                  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
                  rdfs:label "is produced by" ;
                  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Model#Process" .
-
-
-###  http://www.w3.org/ns/ssn/isPropertyOf
-ssn:isPropertyOf rdf:type owl:ObjectProperty ;
-                 rdfs:comment "Relation between a FeatureOfInterest and a Property (a Quality observable by a sensor) of that feature." ;
-                 rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                 rdfs:label "is property of" ;
-                 rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" .
-
 
 ###  http://www.w3.org/ns/ssn/isProxyFor
 ssn:isProxyFor rdf:type owl:ObjectProperty ;
@@ -395,14 +362,6 @@ ssn:ofFeature rdf:type owl:ObjectProperty ;
               rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
               rdfs:label "of feature" ;
               rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" .
-
-
-###  http://www.w3.org/ns/ssn/onPlatform
-ssn:onPlatform rdf:type owl:ObjectProperty ;
-               rdfs:comment "Relation between a System (e.g., a Sensor) and a Platform.  The relation locates the sensor relative to other described entities entities: i.e., the Sensor s1's location is Platform p1.  More precise locations for sensors in space (relative to other entities, where attached to another entity, or in 3D space) are made using DOLCE's Regions (SpaceRegion)." ;
-               rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-               rdfs:label "on platform" ;
-               rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#PlatformSite" .
 
 
 ###  http://www.w3.org/ns/ssn/qualityOfObservation
@@ -507,16 +466,6 @@ ssn:DetectionLimit rdf:type owl:Class ;
                    rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
                    rdfs:label "Detection Limit" ;
                    rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Sensor#MeasuringCapability" .
-
-
-###  http://www.w3.org/ns/ssn/Device
-ssn:Device rdf:type owl:Class ;
-           rdfs:subClassOf ssn:System ;
-           dc:source "http://www.w3.org/2005/Incubator/ssn/" ;
-           rdfs:comment "A device is a physical piece of technology - a system in a box. Devices may of course be built of smaller devices and software components (i.e. systems have components)." ;
-           rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-           rdfs:label "Device" ;
-           rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Device#Device" .
 
 
 ###  http://www.w3.org/ns/ssn/Drift
@@ -688,24 +637,6 @@ Measurement result in VIM is the measured value plus any other relevant informat
                 rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" .
 
 
-###  http://www.w3.org/ns/ssn/ObservationValue
-ssn:ObservationValue rdf:type owl:Class ;
-                     dc:source """skos:exactMatch 'measured quantity value' [VIM 2.10]
-                                  http://www.bipm.org/utils/common/documents/jcgm/JCGM_200_2008.pdf
-
-skos:exactMatch 'observed value' [SensorML OGC-0700]
-http://www.opengeospatial.org/standards/sensorml 
-
-skos:closeMatch 'observation result' [O&M]
-http://www.opengeospatial.org/standards/om 
-
-O&M conflates what we have as SensorOutput and ObservationValue into observation result, though the OGC standard does say \"result contains a value\" and \"a result which has a value\", which fits naturally with the model here.""" ;
-                     rdfs:comment "The value of the result of an Observation.  An Observation has a result which is the output of some sensor, the result is an information object that encodes some value for a Feature." ;
-                     rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                     rdfs:label "Observation Value" ;
-                     rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Base#Data" .
-
-
 ###  http://www.w3.org/ns/ssn/OperatingPowerRange
 ssn:OperatingPowerRange rdf:type owl:Class ;
                         rdfs:subClassOf ssn:OperatingProperty ;
@@ -752,24 +683,6 @@ ssn:Output rdf:type owl:Class ;
            rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
            rdfs:label "Output" ;
            rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Model#Process" .
-
-
-###  http://www.w3.org/ns/ssn/Platform
-ssn:Platform rdf:type owl:Class ;
-             rdfs:subClassOf [ rdf:type owl:Restriction ;
-                               owl:onProperty ssn:attachedSystem ;
-                               owl:allValuesFrom ssn:System
-                             ] ,
-                             [ rdf:type owl:Restriction ;
-                               owl:onProperty ssn:inDeployment ;
-                               owl:allValuesFrom ssn:Deployment
-                             ] ;
-             dc:source """skos:exactMatch 'platform' [SensorML OGC-0700]
-                                  http://www.opengeospatial.org/standards/sensorml""" ;
-             rdfs:comment "An Entity to which other Entities can be attached - particuarly Sensors and other Platforms.  For example, a post might act as a Platform, a buoy might act as a Platform, or a fish might act as a Platform for an attached sensor." ;
-             rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-             rdfs:label "Platform" ;
-             rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#PlatformSite" .
 
 
 ###  http://www.w3.org/ns/ssn/Precision
@@ -869,37 +782,6 @@ ssn:Sensitivity rdf:type owl:Class ;
                 rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Sensor#MeasuringCapability" .
 
 
-###  http://www.w3.org/ns/ssn/Sensor
-ssn:Sensor rdf:type owl:Class ;
-           rdfs:subClassOf [ rdf:type owl:Restriction ;
-                             owl:onProperty ssn:implements ;
-                             owl:someValuesFrom ssn:Sensing
-                           ] ,
-                           [ rdf:type owl:Restriction ;
-                             owl:onProperty ssn:detects ;
-                             owl:allValuesFrom ssn:Stimulus
-                           ] ,
-                           [ rdf:type owl:Restriction ;
-                             owl:onProperty ssn:hasMeasurementCapability ;
-                             owl:allValuesFrom ssn:MeasurementCapability
-                           ] ,
-                           [ rdf:type owl:Restriction ;
-                             owl:onProperty ssn:observes ;
-                             owl:allValuesFrom ssn:Property
-                           ] ;
-           dc:source """skos:exactMatch 'sensor' [SensorML OGC-0700]
-		                    http://www.opengeospatial.org/standards/sensorml 
-
-                                skos:closeMatch 'observation procedure' [O&M] 
-                                http://www.opengeospatial.org/standards/om 
-
-O&M allows sensors, methods, instruments, systems, algorithms and process chains as the processUsed of an observation; this ontology allows a similar range of things (any thing that can do sensing), just they are all grouped under the term sensor (which is thus wider than the O&M concept).""" ;
-           rdfs:comment "A sensor can do (implements) sensing: that is, a sensor is any entity that can follow a sensing method and thus observe some Property of a FeatureOfInterest.  Sensors may be physical devices, computational methods, a laboratory setup with a person following a method, or any other thing that can follow a Sensing Method to observe a Property." ;
-           rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-           rdfs:label "Sensor" ;
-           rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" .
-
-
 ###  http://www.w3.org/ns/ssn/SensorDataSheet
 ssn:SensorDataSheet rdf:type owl:Class ;
                     dc:source "http://www.w3.org/2005/Incubator/ssn/" ;
@@ -923,28 +805,6 @@ ssn:SensorInput rdf:type owl:Class ;
                 rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
                 rdfs:label "Sensor Input" ;
                 rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" .
-
-
-###  http://www.w3.org/ns/ssn/SensorOutput
-ssn:SensorOutput rdf:type owl:Class ;
-                 rdfs:subClassOf [ rdf:type owl:Restriction ;
-                                   owl:onProperty ssn:hasValue ;
-                                   owl:someValuesFrom ssn:ObservationValue
-                                 ] ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty ssn:isProducedBy ;
-                                   owl:someValuesFrom ssn:Sensor
-                                 ] ;
-                 dc:source """http://www.w3.org/2005/Incubator/ssn/
-
-                                  skos:closeMatch 'observation result' [O&M] 
-                                  http://www.opengeospatial.org/standards/om 
-
-See comments at ObservationValue.""" ;
-                 rdfs:comment "A sensor outputs a piece of information (an observed value), the value itself being represented by an ObservationValue." ;
-                 rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-                 rdfs:label "Sensor Output" ;
-                 rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" .
 
 
 ###  http://www.w3.org/ns/ssn/Stimulus
@@ -982,39 +842,6 @@ ssn:SurvivalRange rdf:type owl:Class ;
                   rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
                   rdfs:label "Survival Range" ;
                   rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#OperatingRestriction" .
-
-
-###  http://www.w3.org/ns/ssn/System
-ssn:System rdf:type owl:Class ;
-           rdfs:subClassOf [ rdf:type owl:Restriction ;
-                             owl:onProperty ssn:hasSubSystem ;
-                             owl:someValuesFrom ssn:System
-                           ] ,
-                           [ rdf:type owl:Restriction ;
-                             owl:onProperty ssn:hasDeployment ;
-                             owl:allValuesFrom ssn:Deployment
-                           ] ,
-                           [ rdf:type owl:Restriction ;
-                             owl:onProperty ssn:hasOperatingRange ;
-                             owl:allValuesFrom ssn:OperatingRange
-                           ] ,
-                           [ rdf:type owl:Restriction ;
-                             owl:onProperty ssn:hasSubSystem ;
-                             owl:allValuesFrom ssn:System
-                           ] ,
-                           [ rdf:type owl:Restriction ;
-                             owl:onProperty ssn:hasSurvivalRange ;
-                             owl:allValuesFrom ssn:SurvivalRange
-                           ] ,
-                           [ rdf:type owl:Restriction ;
-                             owl:onProperty ssn:onPlatform ;
-                             owl:allValuesFrom ssn:Platform
-                           ] ;
-           dc:source "http://www.w3.org/2005/Incubator/ssn/" ;
-           rdfs:comment "System is a unit of abstraction for pieces of infrastructure for sensing. A system has components, its subsystems, which are other systems." ;
-           rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-           rdfs:label "System" ;
-           rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Model#System" .
 
 
 ###  http://www.w3.org/ns/ssn/SystemLifetime

--- a/ssn/integrated/sosa.ttl
+++ b/ssn/integrated/sosa.ttl
@@ -50,25 +50,75 @@ sosa:FeatureOfInterest a rdfs:Class , owl:Class ;
   skos:example "When measuring the height of a tree, the height is the ObservedProperty, 20m may be the Result of the Observation, and the tree is the FeatureOfInterest. A window is a FeatureOfInterest for an automatic window control Actuator"@en ;
   rdfs:isDefinedBy sosa: .
 
-sosa:ObservableProperty a rdfs:Class , owl:Class ;
-  rdfs:label "Observable Property"@en ;
-  skos:definition """An observable quality of a FeatureOfInterest."""@en ;
+  sosa:ObservableProperty a rdfs:Class , owl:Class ;
+    rdfs:label "Observable Property"@en ;
+    skos:definition """An observable quality of a FeatureOfInterest."""@en ;
+    rdfs:isDefinedBy sosa: .
+
+  sosa:ActuatableProperty a rdfs:Class , owl:Class ;
+    rdfs:label "Actuatable Property"@en ;
+    skos:definition "An actuatable property, i.e., characteristic, of a FeatureOfInterest."@en ;
+    skos:example "A window actuator acts by changing the state between a frame and a window. The ability of the window to be opened and closed is its ActuatableProperty."@en 
+    rdfs:isDefinedBy sosa: .
+
+
+## Platform 
+
+sosa:Platform a rdfs:Class , owl:Class ;
+  rdfs:label "Platform"@en ;
+  skos:definition "A Platform is an entity that hosts other entities, particularly Sensors, Actuators and other Platforms."@en ;
+  skos:example "A post, buoy, vehicle, ship, aircraft, satellite, cell-phone, human or animal may act as platforms for (technical or biological) sensors or actuators."@en ;
   rdfs:isDefinedBy sosa: .
 
-sosa:ActuatableProperty a rdfs:Class , owl:Class ;
-  rdfs:label "Actuatable Property"@en ;
-  skos:definition "An actuatable property, i.e., characteristic, of a FeatureOfInterest."@en ;
-  skos:example "A window actuator acts by changing the state between a frame and a window. The ability of the window to be opened and closed is its ActuatableProperty."@en 
+  sosa:isHostedBy a owl:ObjectProperty ;
+    rdfs:label "is hosted by"@en ;
+    skos:definition "Relation between a Sensor or Actuator and the Platform that it is mounted on or hosted by."@en ;
+    schema:domainIncludes sosa:Actuator ;
+    schema:domainIncludes sosa:Sensor ;
+    schema:rangeIncludes sosa:Platform ;
+    owl:inverseOf sosa:hosts ;
+    rdfs:isDefinedBy sosa: .
+
+  sosa:hosts a owl:ObjectProperty ;
+    rdfs:label "hosts"@en ;
+    skos:definition "Relation between a Platform and a Sensor or Actuator hosted or mounted on it."@en ;
+    schema:domainIncludes sosa:Platform ;
+    schema:rangeIncludes sosa:Actuator ;
+    schema:rangeIncludes sosa:Sensor ;
+    owl:inverseOf sosa:isHostedBy ;
+    rdfs:isDefinedBy sosa: .
+
+
+## Sensor and Actuator
+
+sosa:Sensor a rdfs:Class , owl:Class ;
+  rdfs:label "Sensor"@en ;
+  skos:definition """Device, agent (including humans), or software (simulation) involved in, or implementing, a (Sensing) Procedure. Sensors respond to a stimulus, e.g., a change in the environment, or input data composed from the results of prior observations, and generate a Result. Sensors can be mounted on Platforms."""@en ;
+  skos:example "Accelerometers, gyroscopes, barometers, magnetometers, and so forth a sensors that are typically mounted on a modern smart phone (which acts as Platform). Other examples of sensors include the human eyes."@en ;
   rdfs:isDefinedBy sosa: .
+
+sosa:Actuator a rdfs:Class , owl:Class ;
+  rdfs:label "Actuator"@en ;
+  skos:definition "A device that is used by, or implements, an (Actuation) Procedure that changes the state of the world."@en ;
+  skos:example "A window actuators for automatic window control."@en ;
+  rdfs:isDefinedBy sosa: .
+
 
 ## Observation
 
-sosa:Observation a owl:Class .
-
+sosa:Observation a rdfs:Class , owl:Class ;
+  rdfs:label "Observation"@en ;
+  skos:definition """Activity of carrying out an (Observation) Procedure to estimate or calculate a value of a Property of a FeatureOfInterest. Links to a Platform or Sensor to describe what made the Observation and how; links to an ObservableProperty to describe what the result is an estimate of, and to a FeatureOfInterest to detail what that property was associated with. The Result is the output of the observation."""@en ;
+  skos:example """The activity of estimating the intensity of an Earthquake using the Mercalli intensity scale is an Observation as is measuring the moment magnitude, i.e., the energy released by said earthquake."""@en ;
+  rdfs:isDefinedBy sosa: .
 
 ## Actuation
 
-sosa:Actuation a owl:Class .
+sosa:Actuation a rdfs:Class , owl:Class ;
+  rdfs:label "Actuation"@en ;
+  skos:definition """An Actuation carries out an (Actuation) Procedure to change the state of the world using an Actuator."""@en ;
+  skos:example """The activity of automatically closing a window if the temperature in a room drops below 20 degree Celsius. The activity is the Actuation and the device that closes the window is the Actuator. The Procedure is the rule, plan, or specification that defines the conditions that triggers the Actuation, here a drop in temperature. """@en ;
+  rdfs:isDefinedBy sosa: .
 
 
 ## SensorOutput, ObservationValue, Result

--- a/ssn/integrated/ssn.ttl
+++ b/ssn/integrated/ssn.ttl
@@ -40,13 +40,13 @@ ssn: a owl:Ontology ;
 ## Features of interest and Property
 
 #sosa:FeatureOfInterest
-#  rdfs:subClassOf [ owl:onProperty ssn:hasProperty ; owl:someValuesFrom ssn:Property ] ; # TODO: need resolution, is it ssn:hasProperty, or sosa:hasProperty ?
-#  rdfs:subClassOf [ owl:onProperty ssn:hasProperty ; owl:allValuesFrom ssn:Property ]  . # TODO: need resolution, is it ssn:hasProperty, or sosa:hasProperty ?
+#  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:hasProperty ; owl:someValuesFrom ssn:Property ] ; # TODO: need resolution, is it ssn:hasProperty, or sosa:hasProperty ?
+#  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:hasProperty ; owl:allValuesFrom ssn:Property ]  . # TODO: need resolution, is it ssn:hasProperty, or sosa:hasProperty ?
 
 ssn:Property a owl:Class ;
   rdfs:label "Property"@en ;
   skos:definition """A Quality of a FeatureOfInterest. An aspect of an entity that is intrinsic to and cannot exist without the entity."""@en ;
-#  rdfs:subClassOf [ owl:onProperty sosa:isPropertyOf ; owl:someValuesFrom sosa:FeatureOfInterest ] ; # TODO: need resolution, see https://www.w3.org/2015/spatial/wiki/Link_between_FeatureOfInterest_and_xxxProperty
+#  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:isPropertyOf ; owl:someValuesFrom sosa:FeatureOfInterest ] ; # TODO: need resolution, see https://www.w3.org/2015/spatial/wiki/Link_between_FeatureOfInterest_and_xxxProperty
   rdfs:isDefinedBy ssn: .
 
   ssn:hasProperty a owl:ObjectProperty ; # TODO: need resolution, see https://www.w3.org/2015/spatial/wiki/Link_between_FeatureOfInterest_and_xxxProperty
@@ -71,11 +71,11 @@ ssn:Property a owl:Class ;
 ssn:System a owl:Class ;
   rdfs:label "System"@en ;
   skos:definition """System is a unit of abstraction for pieces of infrastructure for sensing. A system has components, its subsystems, which are other systems."""@en ; # TODO: update with: "A system may have components" ? 
-  rdfs:subClassOf [ owl:onProperty sosa:isHostedBy ; owl:allValuesFrom sosa:Platform ] ;
-  rdfs:subClassOf [ owl:onProperty ssn:hasSubSystem ; owl:allValuesFrom ssn:System ] ;
-#  rdfs:subClassOf [ owl:onProperty ssn:hasDeployment ; owl:allValuesFrom ssn:Deployment ] ;
-#  rdfs:subClassOf [ owl:onProperty ssn:hasOperatingRange ; owl:allValuesFrom ssn:OperatingRange ] ;
-#  rdfs:subClassOf [ owl:onProperty ssn:hasSurvivalRange ; owl:allValuesFrom ssn:SurvivalRange ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:isHostedBy ; owl:allValuesFrom sosa:Platform ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:hasSubSystem ; owl:allValuesFrom ssn:System ] ;
+#  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:hasDeployment ; owl:allValuesFrom ssn:Deployment ] ;
+#  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:hasOperatingRange ; owl:allValuesFrom ssn:OperatingRange ] ;
+#  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:hasSurvivalRange ; owl:allValuesFrom ssn:SurvivalRange ] ;
   rdfs:isDefinedBy ssn: .
 
   ssn:hasSubSystem a owl:ObjectProperty ;
@@ -87,22 +87,22 @@ ssn:System a owl:Class ;
 ## Platforms
 
 sosa:Platform 
-  rdfs:subClassOf [ owl:onProperty sosa:hosts ; owl:allValuesFrom ssn:System ] .
-#  rdfs:subClassOf [ owl:onProperty ssn:inDeployment ; owl:allValuesFrom ssn:Deployment ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hosts ; owl:allValuesFrom ssn:System ] .
+#  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:inDeployment ; owl:allValuesFrom ssn:Deployment ] ;
 
 
 ## Sensor, Actuator
 
 sosa:Sensor rdfs:subClassOf ssn:System .
-#  rdfs:subClassOf [ owl:onProperty ssn:implements ; owl:someValuesFrom ssn:Sensing ] ;
-#  rdfs:subClassOf [ owl:onProperty ssn:detects ; owl:allValuesFrom ssn:Stimulus ] ;
-#  rdfs:subClassOf [ owl:onProperty ssn:hasMeasurementCapability ; owl:allValuesFrom ssn:MeasurementCapability ] ;
-#  rdfs:subClassOf [ owl:onProperty ssn:observes ; owl:allValuesFrom ssn:Property ] .
+#  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:implements ; owl:someValuesFrom ssn:Sensing ] ;
+#  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:detects ; owl:allValuesFrom ssn:Stimulus ] ;
+#  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:hasMeasurementCapability ; owl:allValuesFrom ssn:MeasurementCapability ] ;
+#  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:observes ; owl:allValuesFrom ssn:Property ] .
 
 sosa:Actuator rdfs:subClassOf ssn:System .
-#  rdfs:subClassOf [ owl:onProperty ssn:implements ; owl:someValuesFrom ssn:Acting ] ;
-#  rdfs:subClassOf [ owl:onProperty ssn:hasActuationCapability ; owl:allValuesFrom ssn:ActuationCapability ] ;
-#  rdfs:subClassOf [ owl:onProperty ssn:actsOn ; owl:allValuesFrom ssn:Property ] .
+#  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:implements ; owl:someValuesFrom ssn:Acting ] ;
+#  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:hasActuationCapability ; owl:allValuesFrom ssn:ActuationCapability ] ;
+#  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:actsOn ; owl:allValuesFrom ssn:Property ] .
 
 
 
@@ -110,7 +110,7 @@ sosa:Actuator rdfs:subClassOf ssn:System .
 
 
 # what would be the equivalent axiom for sosa:Result ?
-# it should be somehow equivalent to  rdfs:subClassOf [ owl:onProperty oldssn:isProducedBy ; owl:someValuesFrom oldssn:Sensor ] ;
+# it should be somehow equivalent to  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty oldssn:isProducedBy ; owl:someValuesFrom oldssn:Sensor ] ;
 # but more general, because Actuators can also generate results. 
 
-sosa:Result rdfs:subClassOf [ owl:onProperty sosa:isResultOf ; owl:someValuesFrom ???ssn:ProcedureExecutor??? ] ;
+sosa:Result rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:isResultOf ; owl:someValuesFrom ???ssn:ProcedureExecutor??? ] ;

--- a/ssn/integrated/ssn.ttl
+++ b/ssn/integrated/ssn.ttl
@@ -46,12 +46,64 @@ ssn: a owl:Ontology ;
 ssn:Property a owl:Class ;
   rdfs:label "Property"@en ;
   skos:definition """A Quality of a FeatureOfInterest. An aspect of an entity that is intrinsic to and cannot exist without the entity."""@en ;
-#  rdfs:subClassOf [ owl:onProperty sosa:isPropertyOf ; owl:someValuesFrom sosa:FeatureOfInterest ] ; # TODO: need resolution, is it ssn:isPropertyOf, or sosa:isPropertyOf ?
+#  rdfs:subClassOf [ owl:onProperty sosa:isPropertyOf ; owl:someValuesFrom sosa:FeatureOfInterest ] ; # TODO: need resolution, see https://www.w3.org/2015/spatial/wiki/Link_between_FeatureOfInterest_and_xxxProperty
   rdfs:isDefinedBy ssn: .
+
+  ssn:hasProperty a owl:ObjectProperty ; # TODO: need resolution, see https://www.w3.org/2015/spatial/wiki/Link_between_FeatureOfInterest_and_xxxProperty
+    rdfs:label "has property"@en ;
+    skos:definition """Relation between a FeatureOfInterest and a Property of that feature."""@en ;
+    owl:inverseOf ssn:isPropertyOf ;
+    rdfs:isDefinedBy ssn: .
+
+  ssn:isPropertyOf a owl:ObjectProperty ; # TODO: need resolution, see https://www.w3.org/2015/spatial/wiki/Link_between_FeatureOfInterest_and_xxxProperty
+    rdfs:label "is property of"@en ;
+    skos:definition """Relation between a FeatureOfInterest and a Property (a Quality observable by a sensor) of that feature."""@en ;
+    owl:inverseOf ssn:hasProperty ;
+    rdfs:isDefinedBy ssn: .
 
   sosa:ObservableProperty rdfs:subClassOf ssn:Property .
 
   sosa:ActuatableProperty rdfs:subClassOf ssn:Property .
+
+
+## Systems
+
+ssn:System a owl:Class ;
+  rdfs:label "System"@en ;
+  skos:definition """System is a unit of abstraction for pieces of infrastructure for sensing. A system has components, its subsystems, which are other systems."""@en ; # TODO: update with: "A system may have components" ? 
+  rdfs:subClassOf [ owl:onProperty sosa:isHostedBy ; owl:allValuesFrom sosa:Platform ] ;
+  rdfs:subClassOf [ owl:onProperty ssn:hasSubSystem ; owl:allValuesFrom ssn:System ] ;
+#  rdfs:subClassOf [ owl:onProperty ssn:hasDeployment ; owl:allValuesFrom ssn:Deployment ] ;
+#  rdfs:subClassOf [ owl:onProperty ssn:hasOperatingRange ; owl:allValuesFrom ssn:OperatingRange ] ;
+#  rdfs:subClassOf [ owl:onProperty ssn:hasSurvivalRange ; owl:allValuesFrom ssn:SurvivalRange ] ;
+  rdfs:isDefinedBy ssn: .
+
+  ssn:hasSubSystem a owl:ObjectProperty ;
+    rdfs:label "has subsystem"@en ;
+    skos:definition """Relation between a system and its component parts (has-part)."""@en ;
+    rdfs:isDefinedBy ssn: .
+
+
+## Platforms
+
+sosa:Platform 
+  rdfs:subClassOf [ owl:onProperty sosa:hosts ; owl:allValuesFrom ssn:System ] .
+#  rdfs:subClassOf [ owl:onProperty ssn:inDeployment ; owl:allValuesFrom ssn:Deployment ] ;
+
+
+## Sensor, Actuator
+
+sosa:Sensor rdfs:subClassOf ssn:System .
+#  rdfs:subClassOf [ owl:onProperty ssn:implements ; owl:someValuesFrom ssn:Sensing ] ;
+#  rdfs:subClassOf [ owl:onProperty ssn:detects ; owl:allValuesFrom ssn:Stimulus ] ;
+#  rdfs:subClassOf [ owl:onProperty ssn:hasMeasurementCapability ; owl:allValuesFrom ssn:MeasurementCapability ] ;
+#  rdfs:subClassOf [ owl:onProperty ssn:observes ; owl:allValuesFrom ssn:Property ] .
+
+sosa:Actuator rdfs:subClassOf ssn:System .
+#  rdfs:subClassOf [ owl:onProperty ssn:implements ; owl:someValuesFrom ssn:Acting ] ;
+#  rdfs:subClassOf [ owl:onProperty ssn:hasActuationCapability ; owl:allValuesFrom ssn:ActuationCapability ] ;
+#  rdfs:subClassOf [ owl:onProperty ssn:actsOn ; owl:allValuesFrom ssn:Property ] .
+
 
 
 ## SensorOutput, ObservationValue, Result

--- a/ssn/integrated/ssnx.ttl
+++ b/ssn/integrated/ssnx.ttl
@@ -181,8 +181,8 @@ oldssn:SensorOutput a owl:Class ;
   
   See comments at ObservationValue.""" ;
   rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" ;
-  rdfs:subClassOf [ owl:onProperty oldssn:hasValue ; owl:someValuesFrom oldssn:ObservationValue ] .
-  rdfs:subClassOf [ owl:onProperty oldssn:isProducedBy ; owl:someValuesFrom oldssn:Sensor ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty oldssn:hasValue ; owl:someValuesFrom oldssn:ObservationValue ] .
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty oldssn:isProducedBy ; owl:someValuesFrom oldssn:Sensor ] ;
   owl:deprecated true ;
   rdfs:subClassOf sosa:Result ;
   rdfs:isDefinedBy <http://purl.oclc.org/NET/ssnx/ssn> ;

--- a/ssn/integrated/ssnx.ttl
+++ b/ssn/integrated/ssnx.ttl
@@ -109,7 +109,7 @@ oldssn:System a owl:Class ;
     skos:definition """Relation between a system and its component parts (has-part)."""@en ;
     rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Model#System" ;
     owl:deprecated true ;
-    owl:equivalentClass ssn:hasSubSystem ;
+    owl:equivalentProperty ssn:hasSubSystem ;
     rdfs:isDefinedBy <http://purl.oclc.org/NET/ssnx/ssn> .
 
 
@@ -143,12 +143,12 @@ oldssn:Platform a owl:Class ;
 
   oldssn:Device rdf:type owl:Class ;
     rdfs:label "Device"@en ;
-    dc:source "http://www.w3.org/2005/Incubator/ssn/" ;
-    rdfs:comment "A device is a physical piece of technology - a system in a box. Devices may of course be built of smaller devices and software components (i.e. systems have components)." ;
-    rdfs:subClassOf ssn:System ;
-    rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-    rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Device#Device" .
-
+    skos:definition "A device is a physical piece of technology - a system in a box. Devices may of course be built of smaller devices and software components (i.e. systems have components)." ;
+    dcterms:source "http://www.w3.org/2005/Incubator/ssn/" ;
+    rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Device#Device" ;
+    owl:deprecated true ;
+    rdfs:equivalentClass ssn:Device ;
+    rdfs:isDefinedBy <http://purl.oclc.org/NET/ssnx/ssn> .
 
 
 ## Sensor, Actuator

--- a/ssn/integrated/ssnx.ttl
+++ b/ssn/integrated/ssnx.ttl
@@ -76,6 +76,98 @@ oldssn:Property a owl:Class ;
   owl:equivalentClass ssn:Property ;
   rdfs:isDefinedBy <http://purl.oclc.org/NET/ssnx/ssn> .
   
+  oldssn:hasProperty a owl:ObjectProperty ;
+    rdfs:label "has property"@en ;
+    skos:definition """Relation between a FeatureOfInterest and a Property of that feature."""@en ;
+    rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" ;
+    owl:deprecated true ;
+    owl:equivalentProperty ssn:hasProperty ; ### or sosa:hasProperty? see https://www.w3.org/2015/spatial/wiki/Link_between_FeatureOfInterest_and_xxxProperty
+    rdfs:isDefinedBy <http://purl.oclc.org/NET/ssnx/ssn> .
+
+  oldssn:isPropertyOf a owl:ObjectProperty ;
+    rdfs:label "is property of"@en ;
+    skos:definition """Relation between a FeatureOfInterest and a Property (a Quality observable by a sensor) of that feature."""@en ;
+    rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" ;
+    owl:deprecated true ;
+    owl:equivalentProperty ssn:isPropertyOf ; ### or sosa:isPropertyOf? see https://www.w3.org/2015/spatial/wiki/Link_between_FeatureOfInterest_and_xxxProperty
+    rdfs:isDefinedBy <http://purl.oclc.org/NET/ssnx/ssn> .
+
+
+## Systems
+
+oldssn:System a owl:Class ;
+  rdfs:label "System"@en ;
+  skos:definition """System is a unit of abstraction for pieces of infrastructure for sensing. A system has components, its subsystems, which are other systems."""@en ; # TODO: update with: "A system may have components" ? 
+  dcterms:source "http://www.w3.org/2005/Incubator/ssn/" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Model#System" ;
+  owl:deprecated true ;
+  owl:equivalentClass ssn:System ;
+  rdfs:isDefinedBy <http://purl.oclc.org/NET/ssnx/ssn> .
+
+  oldssn:hasSubSystem a owl:ObjectProperty ;
+    rdfs:label "has subsystem"@en ;
+    skos:definition """Relation between a system and its component parts (has-part)."""@en ;
+    rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Model#System" ;
+    owl:deprecated true ;
+    owl:equivalentClass ssn:hasSubSystem ;
+    rdfs:isDefinedBy <http://purl.oclc.org/NET/ssnx/ssn> .
+
+
+## Platforms
+
+oldssn:Platform a owl:Class ;
+  rdfs:label "Platform"@en ;
+  skos:definition """An Entity to which other Entities can be attached - particuarly Sensors and other Platforms.  For example, a post might act as a Platform, a buoy might act as a Platform, or a fish might act as a Platform for an attached sensor."""@en ;
+  dcterms:source """skos:exactMatch 'platform' [SensorML OGC-0700]
+  http://www.opengeospatial.org/standards/sensorml""" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#PlatformSite" ;
+  owl:deprecated true ;
+  owl:equivalentClass sosa:Platform ;
+  rdfs:isDefinedBy <http://purl.oclc.org/NET/ssnx/ssn> .
+
+  oldssn:onPlatform a owl:ObjectProperty ;
+    rdfs:label "on platform"@en ;
+    skos:definition """Relation between a System (e.g., a Sensor) and a Platform.  The relation locates the sensor relative to other described entities entities: i.e., the Sensor s1's location is Platform p1.  More precise locations for sensors in space (relative to other entities, where attached to another entity, or in 3D space) are made using DOLCE's Regions (SpaceRegion)."""@en ; # TODO: remove DOLCE ?
+    rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#PlatformSite" ;
+    owl:deprecated true ;
+    owl:equivalentProperty sosa:isHostedBy ;
+    rdfs:isDefinedBy <http://purl.oclc.org/NET/ssnx/ssn> .
+
+  oldssn:attachedSystem a owl:ObjectProperty ;
+    rdfs:label "attached system"@en ;
+    skos:definition """Relation between a Platform and any Systems (e.g., Sensors) that are attached to the Platform."""@en ;
+    rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Deploy#PlatformSite" .
+    owl:deprecated true ;
+    owl:equivalentProperty sosa:hosts ;
+    rdfs:isDefinedBy <http://purl.oclc.org/NET/ssnx/ssn> .
+
+  oldssn:Device rdf:type owl:Class ;
+    rdfs:label "Device"@en ;
+    dc:source "http://www.w3.org/2005/Incubator/ssn/" ;
+    rdfs:comment "A device is a physical piece of technology - a system in a box. Devices may of course be built of smaller devices and software components (i.e. systems have components)." ;
+    rdfs:subClassOf ssn:System ;
+    rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+    rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Device#Device" .
+
+
+
+## Sensor, Actuator
+
+oldssn:Sensor a owl:Class ;
+  rdfs:label "Sensor"@en ;
+  skos:definition """A sensor can do (implements) sensing: that is, a sensor is any entity that can follow a sensing method and thus observe some Property of a FeatureOfInterest.  Sensors may be physical devices, computational methods, a laboratory setup with a person following a method, or any other thing that can follow a Sensing Method to observe a Property."""@en ;
+  dcterms:source """skos:exactMatch 'sensor' [SensorML OGC-0700]
+  http://www.opengeospatial.org/standards/sensorml 
+
+  skos:closeMatch 'observation procedure' [O&M] 
+  http://www.opengeospatial.org/standards/om 
+
+O&M allows sensors, methods, instruments, systems, algorithms and process chains as the processUsed of an observation; this ontology allows a similar range of things (any thing that can do sensing), just they are all grouped under the term sensor (which is thus wider than the O&M concept).""" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" .
+  owl:deprecated true ;
+  owl:equivalentClass sosa:Sensor ;
+  rdfs:isDefinedBy <http://purl.oclc.org/NET/ssnx/ssn> .
+
 
 ## SensorOutput, ObservationValue, Result
 

--- a/ssn/ssn_separated/ssn.ttl
+++ b/ssn/ssn_separated/ssn.ttl
@@ -637,7 +637,7 @@ ssn:Observation rdf:type owl:Class ;
                                 ] ,
                                 [ rdf:type owl:Restriction ;
                                   owl:onProperty ssn:observationResult ;
-                                  owl:allValuesFrom sosa:SensorOutput
+                                  owl:allValuesFrom ssn:SensorOutput
                                 ] ,
                                 [ rdf:type owl:Restriction ;
                                   owl:onProperty sosa:isObservedBy ;
@@ -914,7 +914,7 @@ sosa:Actuator rdfs:subClassOf ssn:System .
 
 
 ###  http://www.w3.org/ns/ssn/SensorDataSheet
-sosa:SensorDataSheet rdf:type owl:Class ;
+ssn:SensorDataSheet rdf:type owl:Class ;
                     dc:source "http://www.w3.org/2005/Incubator/ssn/" ;
                     rdfs:comment """A data sheet records properties of a sensor.  A data sheet might describe for example the accuracy in various conditions, the power use, the types of connectors that the sensor has, etc.  
 
@@ -925,7 +925,7 @@ Generally a sensor's properties are recorded directly (with hasMeasurementCapabi
 
 
 ###  http://www.w3.org/ns/ssn/SensorInput
-sosa:SensorInput rdf:type owl:Class ;
+ssn:SensorInput rdf:type owl:Class ;
                 owl:equivalentClass ssn:Stimulus ;
                 rdfs:subClassOf [ rdf:type owl:Restriction ;
                                   owl:onProperty ssn:isProxyFor ;
@@ -939,7 +939,7 @@ sosa:SensorInput rdf:type owl:Class ;
 
 
 ###  http://www.w3.org/ns/ssn/SensorOutput
-sosa:SensorOutput rdf:type owl:Class ;
+ssn:SensorOutput rdf:type owl:Class ;
                  rdfs:subClassOf [ rdf:type owl:Restriction ;
                                    owl:onProperty ssn:hasValue ;
                                    owl:someValuesFrom ssn:ObservationValue

--- a/ssn/ssn_separated/ssn.ttl
+++ b/ssn/ssn_separated/ssn.ttl
@@ -539,8 +539,8 @@ ssn:Drift rdf:type owl:Class ;
 
 ###  http://www.w3.org/ns/ssn/FeatureOfInterest
 #sosa:FeatureOfInterest
-#  rdfs:subClassOf [ owl:onProperty ssn:hasProperty ; owl:someValuesFrom ssn:Property ] ; # TODO: need resolution, is it ssn:hasProperty, or ssn:hasProperty ?
-#  rdfs:subClassOf [ owl:onProperty ssn:hasProperty ; owl:allValuesFrom ssn:Property ]  . # TODO: need resolution, is it ssn:hasProperty, or ssn:hasProperty ?
+#  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:hasProperty ; owl:someValuesFrom ssn:Property ] ; # TODO: need resolution, is it ssn:hasProperty, or ssn:hasProperty ?
+#  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:hasProperty ; owl:allValuesFrom ssn:Property ]  . # TODO: need resolution, is it ssn:hasProperty, or ssn:hasProperty ?
 
 ###  http://www.w3.org/ns/ssn/Frequency
 ssn:Frequency rdf:type owl:Class ;
@@ -768,8 +768,8 @@ ssn:Output rdf:type owl:Class ;
 
 ###  http://www.w3.org/ns/ssn/Platform
 sosa:Platform 
-  rdfs:subClassOf [ owl:onProperty sosa:hosts ; owl:allValuesFrom ssn:System ] .
-#  rdfs:subClassOf [ owl:onProperty ssn:inDeployment ; owl:allValuesFrom ssn:Deployment ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hosts ; owl:allValuesFrom ssn:System ] .
+#  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:inDeployment ; owl:allValuesFrom ssn:Deployment ] ;
              dc:source """skos:exactMatch 'platform' [SensorML OGC-0700]
                                   http://www.opengeospatial.org/standards/sensorml""" ;
              rdfs:comment "An Entity to which other Entities can be attached - particuarly Sensors and other Platforms.  For example, a post might act as a Platform, a buoy might act as a Platform, or a fish might act as a Platform for an attached sensor." ;
@@ -812,7 +812,7 @@ ssn:Process rdf:type owl:Class ;
 
 ###  http://www.w3.org/ns/ssn/Property
 ssn:Property rdf:type owl:Class ;
-#  rdfs:subClassOf [ owl:onProperty sosa:isPropertyOf ; owl:someValuesFrom sosa:FeatureOfInterest ] ; # TODO: need resolution, see https://www.w3.org/2015/spatial/wiki/Link_between_FeatureOfInterest_and_xxxProperty
+#  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:isPropertyOf ; owl:someValuesFrom sosa:FeatureOfInterest ] ; # TODO: need resolution, see https://www.w3.org/2015/spatial/wiki/Link_between_FeatureOfInterest_and_xxxProperty
              rdfs:comment "A Quality of a FeatureOfInterest. An aspect of an entity that is intrinsic to and cannot exist without the entity." ;
              rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
              rdfs:label "Property" ;
@@ -889,10 +889,10 @@ ssn:Sensitivity rdf:type owl:Class ;
 
 ###  http://www.w3.org/ns/ssn/Sensor
 sosa:Sensor rdf:type owl:Class ;
-#  rdfs:subClassOf [ owl:onProperty ssn:implements ; owl:someValuesFrom ssn:Sensing ] ;
-#  rdfs:subClassOf [ owl:onProperty ssn:detects ; owl:allValuesFrom ssn:Stimulus ] ;
-#  rdfs:subClassOf [ owl:onProperty ssn:hasMeasurementCapability ; owl:allValuesFrom ssn:MeasurementCapability ] ;
-#  rdfs:subClassOf [ owl:onProperty ssn:observes ; owl:allValuesFrom ssn:Property ] .
+#  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:implements ; owl:someValuesFrom ssn:Sensing ] ;
+#  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:detects ; owl:allValuesFrom ssn:Stimulus ] ;
+#  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:hasMeasurementCapability ; owl:allValuesFrom ssn:MeasurementCapability ] ;
+#  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:observes ; owl:allValuesFrom ssn:Property ] .
            dc:source """skos:exactMatch 'sensor' [SensorML OGC-0700]
 		                    http://www.opengeospatial.org/standards/sensorml 
 
@@ -907,9 +907,9 @@ O&M allows sensors, methods, instruments, systems, algorithms and process chains
 
 
 sosa:Actuator rdfs:subClassOf ssn:System .
-#  rdfs:subClassOf [ owl:onProperty ssn:implements ; owl:someValuesFrom ssn:Acting ] ;
-#  rdfs:subClassOf [ owl:onProperty ssn:hasActuationCapability ; owl:allValuesFrom ssn:ActuationCapability ] ;
-#  rdfs:subClassOf [ owl:onProperty ssn:actsOn ; owl:allValuesFrom ssn:Property ] .
+#  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:implements ; owl:someValuesFrom ssn:Acting ] ;
+#  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:hasActuationCapability ; owl:allValuesFrom ssn:ActuationCapability ] ;
+#  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:actsOn ; owl:allValuesFrom ssn:Property ] .
 
 
 
@@ -999,11 +999,11 @@ ssn:SurvivalRange rdf:type owl:Class ;
 
 ###  http://www.w3.org/ns/ssn/System
 ssn:System rdf:type owl:Class ;
-  rdfs:subClassOf [ owl:onProperty sosa:isHostedBy ; owl:allValuesFrom sosa:Platform ] ;
-  rdfs:subClassOf [ owl:onProperty ssn:hasSubSystem ; owl:allValuesFrom ssn:System ] ;
-#  rdfs:subClassOf [ owl:onProperty ssn:hasDeployment ; owl:allValuesFrom ssn:Deployment ] ;
-#  rdfs:subClassOf [ owl:onProperty ssn:hasOperatingRange ; owl:allValuesFrom ssn:OperatingRange ] ;
-#  rdfs:subClassOf [ owl:onProperty ssn:hasSurvivalRange ; owl:allValuesFrom ssn:SurvivalRange ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:isHostedBy ; owl:allValuesFrom sosa:Platform ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:hasSubSystem ; owl:allValuesFrom ssn:System ] ;
+#  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:hasDeployment ; owl:allValuesFrom ssn:Deployment ] ;
+#  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:hasOperatingRange ; owl:allValuesFrom ssn:OperatingRange ] ;
+#  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:hasSurvivalRange ; owl:allValuesFrom ssn:SurvivalRange ] ;
   dc:source "http://www.w3.org/2005/Incubator/ssn/" ;
   rdfs:comment "System is a unit of abstraction for pieces of infrastructure for sensing. A system has components, its subsystems, which are other systems." ; # TODO: update with: "A system may have components" ? 
   rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;

--- a/ssn/ssn_separated/ssn.ttl
+++ b/ssn/ssn_separated/ssn.ttl
@@ -478,7 +478,7 @@ ssn:Deployment rdf:type owl:Class ;
                rdfs:subClassOf ssn:DeploymentRelatedProcess ,
                                [ rdf:type owl:Restriction ;
                                  owl:onProperty ssn:deployedOnPlatform ;
-                                 owl:allValuesFrom ssn:Platform
+                                 owl:allValuesFrom sosa:Platform
                                ] ,
                                [ rdf:type owl:Restriction ;
                                  owl:onProperty ssn:deployedSystem ;
@@ -637,11 +637,11 @@ ssn:Observation rdf:type owl:Class ;
                                 ] ,
                                 [ rdf:type owl:Restriction ;
                                   owl:onProperty ssn:observationResult ;
-                                  owl:allValuesFrom ssn:SensorOutput
+                                  owl:allValuesFrom sosa:SensorOutput
                                 ] ,
                                 [ rdf:type owl:Restriction ;
                                   owl:onProperty sosa:isObservedBy ;
-                                  owl:allValuesFrom ssn:Sensor
+                                  owl:allValuesFrom sosa:Sensor
                                 ] ,
                                 [ rdf:type owl:Restriction ;
                                   owl:onProperty ssn:observedProperty ;
@@ -671,7 +671,7 @@ ssn:Observation rdf:type owl:Class ;
                                 [ rdf:type owl:Restriction ;
                                   owl:onProperty sosa:isObservedBy ;
                                   owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                  owl:onClass ssn:Sensor
+                                  owl:onClass sosa:Sensor
                                 ] ,
                                 [ rdf:type owl:Restriction ;
                                   owl:onProperty ssn:observedProperty ;
@@ -767,15 +767,9 @@ ssn:Output rdf:type owl:Class ;
 
 
 ###  http://www.w3.org/ns/ssn/Platform
-ssn:Platform rdf:type owl:Class ;
-             rdfs:subClassOf [ rdf:type owl:Restriction ;
-                               owl:onProperty ssn:attachedSystem ;
-                               owl:allValuesFrom ssn:System
-                             ] ,
-                             [ rdf:type owl:Restriction ;
-                               owl:onProperty ssn:inDeployment ;
-                               owl:allValuesFrom ssn:Deployment
-                             ] ;
+sosa:Platform 
+  rdfs:subClassOf [ owl:onProperty sosa:hosts ; owl:allValuesFrom ssn:System ] .
+#  rdfs:subClassOf [ owl:onProperty ssn:inDeployment ; owl:allValuesFrom ssn:Deployment ] ;
              dc:source """skos:exactMatch 'platform' [SensorML OGC-0700]
                                   http://www.opengeospatial.org/standards/sensorml""" ;
              rdfs:comment "An Entity to which other Entities can be attached - particuarly Sensors and other Platforms.  For example, a post might act as a Platform, a buoy might act as a Platform, or a fish might act as a Platform for an attached sensor." ;
@@ -818,10 +812,7 @@ ssn:Process rdf:type owl:Class ;
 
 ###  http://www.w3.org/ns/ssn/Property
 ssn:Property rdf:type owl:Class ;
-             rdfs:subClassOf [ rdf:type owl:Restriction ;
-                               owl:onProperty ssn:isPropertyOf ;
-                               owl:someValuesFrom sosa:FeatureOfInterest
-                             ] ;
+#  rdfs:subClassOf [ owl:onProperty sosa:isPropertyOf ; owl:someValuesFrom sosa:FeatureOfInterest ] ; # TODO: need resolution, see https://www.w3.org/2015/spatial/wiki/Link_between_FeatureOfInterest_and_xxxProperty
              rdfs:comment "A Quality of a FeatureOfInterest. An aspect of an entity that is intrinsic to and cannot exist without the entity." ;
              rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
              rdfs:label "Property" ;
@@ -829,6 +820,7 @@ ssn:Property rdf:type owl:Class ;
 
 sosa:ObservableProperty rdfs:subClassOf ssn:Property .
 
+sosa:ActuatableProperty rdfs:subClassOf ssn:Property .
 
 ###  http://www.w3.org/ns/ssn/Resolution
 ssn:Resolution rdf:type owl:Class ;
@@ -876,7 +868,7 @@ ssn:Sensing rdf:type owl:Class ;
 ###  http://www.w3.org/ns/ssn/SensingDevice
 ssn:SensingDevice rdf:type owl:Class ;
                   rdfs:subClassOf ssn:Device ,
-                                  ssn:Sensor ;
+                                  sosa:Sensor ;
                   dc:source "http://www.w3.org/2005/Incubator/ssn/" ;
                   rdfs:comment "A sensing device is a device that implements sensing." ;
                   rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
@@ -896,23 +888,11 @@ ssn:Sensitivity rdf:type owl:Class ;
 
 
 ###  http://www.w3.org/ns/ssn/Sensor
-ssn:Sensor rdf:type owl:Class ;
-           rdfs:subClassOf [ rdf:type owl:Restriction ;
-                             owl:onProperty ssn:implements ;
-                             owl:someValuesFrom ssn:Sensing
-                           ] ,
-                           [ rdf:type owl:Restriction ;
-                             owl:onProperty ssn:detects ;
-                             owl:allValuesFrom ssn:Stimulus
-                           ] ,
-                           [ rdf:type owl:Restriction ;
-                             owl:onProperty ssn:hasMeasurementCapability ;
-                             owl:allValuesFrom ssn:MeasurementCapability
-                           ] ,
-                           [ rdf:type owl:Restriction ;
-                             owl:onProperty ssn:observes ;
-                             owl:allValuesFrom ssn:Property
-                           ] ;
+sosa:Sensor rdf:type owl:Class ;
+#  rdfs:subClassOf [ owl:onProperty ssn:implements ; owl:someValuesFrom ssn:Sensing ] ;
+#  rdfs:subClassOf [ owl:onProperty ssn:detects ; owl:allValuesFrom ssn:Stimulus ] ;
+#  rdfs:subClassOf [ owl:onProperty ssn:hasMeasurementCapability ; owl:allValuesFrom ssn:MeasurementCapability ] ;
+#  rdfs:subClassOf [ owl:onProperty ssn:observes ; owl:allValuesFrom ssn:Property ] .
            dc:source """skos:exactMatch 'sensor' [SensorML OGC-0700]
 		                    http://www.opengeospatial.org/standards/sensorml 
 
@@ -926,8 +906,15 @@ O&M allows sensors, methods, instruments, systems, algorithms and process chains
            rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" .
 
 
+sosa:Actuator rdfs:subClassOf ssn:System .
+#  rdfs:subClassOf [ owl:onProperty ssn:implements ; owl:someValuesFrom ssn:Acting ] ;
+#  rdfs:subClassOf [ owl:onProperty ssn:hasActuationCapability ; owl:allValuesFrom ssn:ActuationCapability ] ;
+#  rdfs:subClassOf [ owl:onProperty ssn:actsOn ; owl:allValuesFrom ssn:Property ] .
+
+
+
 ###  http://www.w3.org/ns/ssn/SensorDataSheet
-ssn:SensorDataSheet rdf:type owl:Class ;
+sosa:SensorDataSheet rdf:type owl:Class ;
                     dc:source "http://www.w3.org/2005/Incubator/ssn/" ;
                     rdfs:comment """A data sheet records properties of a sensor.  A data sheet might describe for example the accuracy in various conditions, the power use, the types of connectors that the sensor has, etc.  
 
@@ -938,7 +925,7 @@ Generally a sensor's properties are recorded directly (with hasMeasurementCapabi
 
 
 ###  http://www.w3.org/ns/ssn/SensorInput
-ssn:SensorInput rdf:type owl:Class ;
+sosa:SensorInput rdf:type owl:Class ;
                 owl:equivalentClass ssn:Stimulus ;
                 rdfs:subClassOf [ rdf:type owl:Restriction ;
                                   owl:onProperty ssn:isProxyFor ;
@@ -952,14 +939,14 @@ ssn:SensorInput rdf:type owl:Class ;
 
 
 ###  http://www.w3.org/ns/ssn/SensorOutput
-ssn:SensorOutput rdf:type owl:Class ;
+sosa:SensorOutput rdf:type owl:Class ;
                  rdfs:subClassOf [ rdf:type owl:Restriction ;
                                    owl:onProperty ssn:hasValue ;
                                    owl:someValuesFrom ssn:ObservationValue
                                  ] ,
                                  [ rdf:type owl:Restriction ;
                                    owl:onProperty ssn:isProducedBy ;
-                                   owl:someValuesFrom ssn:Sensor
+                                   owl:someValuesFrom sosa:Sensor
                                  ] ;
                  dc:source """http://www.w3.org/2005/Incubator/ssn/
 
@@ -1012,31 +999,16 @@ ssn:SurvivalRange rdf:type owl:Class ;
 
 ###  http://www.w3.org/ns/ssn/System
 ssn:System rdf:type owl:Class ;
-           rdfs:subClassOf [ rdf:type owl:Restriction ;
-                             owl:onProperty ssn:hasDeployment ;
-                             owl:allValuesFrom ssn:Deployment
-                           ] ,
-                           [ rdf:type owl:Restriction ;
-                             owl:onProperty ssn:hasOperatingRange ;
-                             owl:allValuesFrom ssn:OperatingRange
-                           ] ,
-                           [ rdf:type owl:Restriction ;
-                             owl:onProperty ssn:hasSubSystem ;
-                             owl:allValuesFrom ssn:System
-                           ] ,
-                           [ rdf:type owl:Restriction ;
-                             owl:onProperty ssn:hasSurvivalRange ;
-                             owl:allValuesFrom ssn:SurvivalRange
-                           ] ,
-                           [ rdf:type owl:Restriction ;
-                             owl:onProperty ssn:onPlatform ;
-                             owl:allValuesFrom ssn:Platform
-                           ] ;
-           dc:source "http://www.w3.org/2005/Incubator/ssn/" ;
-           rdfs:comment "System is a unit of abstraction for pieces of infrastructure for sensing. A system has components, its subsystems, which are other systems." ;
-           rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-           rdfs:label "System" ;
-           rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Model#System" .
+  rdfs:subClassOf [ owl:onProperty sosa:isHostedBy ; owl:allValuesFrom sosa:Platform ] ;
+  rdfs:subClassOf [ owl:onProperty ssn:hasSubSystem ; owl:allValuesFrom ssn:System ] ;
+#  rdfs:subClassOf [ owl:onProperty ssn:hasDeployment ; owl:allValuesFrom ssn:Deployment ] ;
+#  rdfs:subClassOf [ owl:onProperty ssn:hasOperatingRange ; owl:allValuesFrom ssn:OperatingRange ] ;
+#  rdfs:subClassOf [ owl:onProperty ssn:hasSurvivalRange ; owl:allValuesFrom ssn:SurvivalRange ] ;
+  dc:source "http://www.w3.org/2005/Incubator/ssn/" ;
+  rdfs:comment "System is a unit of abstraction for pieces of infrastructure for sensing. A system has components, its subsystems, which are other systems." ; # TODO: update with: "A system may have components" ? 
+  rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+  rdfs:label "System" ;
+  rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Model#System" .
 
 
 ###  http://www.w3.org/ns/ssn/SystemLifetime


### PR DESCRIPTION
Implementation of resolutions: 

- Actuators and Sensors in SSN are made subclass of System
- There is a property in SSN that allows Sensors or Actuators to be “attached” to a Platform, pending a decision on the name
- have a generic property in SOSA that allows attaching of Sensors/Actuators to Platforms and name it hosts/isHostedBy
- have the same property in SSN that allows attaching of Sensors/Actuators and Systems to Platforms and name it hosts/isHostedBy as defined in SOSA

see inline comments in https://github.com/w3c/sdw/pull/592/files to check this pull request.