### PR TITLE
Major revision to BP8 + editorial changes

### DIFF
--- a/bp/index.html
+++ b/bp/index.html
@@ -72,6 +72,26 @@
       createRequirementsTable(BPlist); // Call function to create Requirements Table
     }
 
+// @andrea-perego
+function popCrossRefs() {
+  $('a[href^="#"]').each( function () {
+    var href = $(this).attr('href');
+    var id = href.trim().replace('#','');
+    var text = $(this).text();
+    if (text.trim().length == 0 && id.length > 0 && ( $(href).hasClass('example') || $(href).hasClass('practicelab') )) {
+      var label = $('.example:has(#' + id + ') > .example-title, *[id="' + id + '"].example > .example-title, *[id="' + id + '"].illegal-example > .example-title, *[id="' + id + '"].practicelab').text();
+      if (label.trim().length > 0) {
+        $(this).text(label);
+      }
+    }
+  } );
+}
+
+$(document).ready( function() {
+  popCrossRefs();
+});
+// @andrea-perego
+
     </script>
     <style type="text/css">
       #bp-summary ul{
@@ -1297,7 +1317,7 @@ a:Dataset a dcat:Dataset ;
             <p>The URI for the spatial thing, the <em>base</em> URI, should resolve to provide the current information and a link to its version history of snapshots. [[DWBP]] <a href="https://www.w3.org/TR/dwbp/#VersionHistory">Best Practice 8: Provide version history</a> describes how a version history may be implemented. Each snapshot resource within the version history must be uniquely identified; a common approach is to append a date/time stamp to the base URI as a version indicator. [[DWBP]] <a href="https://www.w3.org/TR/dwbp/#VersioningInfo">Best Practice 7: Provide a version indicator</a> provides relevant guidance.</p>
             
             <aside class="example" id="ex-parish-history" title="Changing boundary of Amsterdam">
-              <p>The extent of the City of Amsterdam has changed during the last 200 years. This example, based on <a href="http://www.gemeentegeschiedenis.nl">Gemeentegeschiedenis.nl</a> ("Parish history")</a> (condensed and changed to reflect the recommendations in this best practice), shows how the version history of Amsterdam's boundary can be provided as a series of immutable snapshots in GeoJSON. </p> 
+              <p>The extent of the City of Amsterdam has changed during the last 200 years. This example, based on <a href="http://www.gemeentegeschiedenis.nl">Gemeentegeschiedenis.nl</a> ("Parish history") (condensed and changed to reflect the recommendations in this best practice), shows how the version history of Amsterdam's boundary can be provided as a series of immutable snapshots in GeoJSON.</p> 
               <p>The current information on Amsterdam including the current boundary: </p>
               <pre>
 {
@@ -1596,109 +1616,258 @@ a:Dataset a dcat:Dataset ;
         <section id="bp-expr-geo">
           <h4>Describing location</h4>
           <p>Location information is often a common thread running through such data and can be an important 'hook' for finding information and for integrating different datasets. There are different ways of describing the location of spatial things. You can use and/or refer to the name of a well known named place, provide the location's coordinates as a geometry or describe it in relation to another location. These last two options are described in this section.</p>
-        <div class="practice">
-          <p><span id="describe-geometry" class="practicelab">Provide geometries on the Web in a usable way</span></p>
-          <p class="practicedesc">Geometry data should be expressed in a way that allows its
-            publication and use on the Web.</p>
-          <section class="axioms">
-            <h4 class="subhead">Why</h4>
-            <p>This best practice helps with choosing the right format for describing geometry
-              based on aspects like performance and tool support. It also helps when deciding on
-              whether or not using literals for geometric representations is a good idea.</p>
-          </section>
-          <section class="outcome">
-            <h4 class="subhead">Intended Outcome</h4>
-            <p>The format chosen to express geometry data should:</p>
-            <ul>
-              <li>Support the dimensionality of the geometry;</li>
-              <li>Be supported by the software tools used within data user community;</li>
-              <li>Keep geometry descriptions to a size that is convenient for Web
-                applications;</li>
-              <li>Support the CRS you need.</li>
-            </ul>
-          </section>
-          <section class="how">
-            <h4 class="subhead">Possible Approach to Implementation</h4>
-            <p>Steps to follow: </p>
-            <ul>
-              <li>Decide on the geometric data representations based on performance; often the
-                geometry data is a large proportion of the total size of a dataset.</li>
-              <li>Determine the dimensionality of geometry data (0d 'point' to 3d 'volume').</li>
-              <li>Determine in which coordinate reference system(s) (CRS) the data should be published (ref to section about CRS). Not all formats and vocabularies support the use of other CRS besides the most common one on the Web, WGS84.</li>
-              <li>Determine which format(s) are supported by software tools that you anticipate
-                your user community to employ; where multiple formats are in required, consider
-                offering as many representations as you can - balancing the benefit of ease of use
-                against the cost of the additional storage or additional processing if converting
-                on-the-fly. See [[DWBP]] <a href="https://www.w3.org/TR/dwbp/#Conneg">Best Practice 19: Use content negotiation for serving data available in multiple formats</a> for more
-                information.</li>
-              <li>Choose the right format and decide when to use geometry literals. For geometry
-                literals, several solutions are available, like Well-Known Text (<a>WKT</a>)
-                representations, <a href="https://en.wikipedia.org/wiki/Geohash">GeoHash</a> and
-                other geocoding representations. The alternative is to use structured geometry
-                objects as is possible, for example, in [[GeoSPARQL]].</li>
-              <li>There are also several suitable binary data formats (e.g. <a
-                  href="https://developers.google.com/protocol-buffers/">Google's protocol
-                  buffers</a> for vector tiling); however, some binary formats do not
-                (effectively) work on the Web as there are no software tools for working with
-                those formats from within a typical Web application; to work with data in such
-                formats, you must first download the data and then work with it locally. </li>
-              <li>There are widespread practices for representing geometric data as linked data,
-                such as using W3C [[W3C-BASIC-GEO]] (geo) <code>geo:lat</code> and <code>geo:long</code>
-                that are used extensively for describing <code>geo:Point</code> objects.</li>
-              <li>Concrete geometry types are available, such as those defined in the OpenGIS
-                [[SIMPLE-FEATURES]] Specification, namely 0-dimensional Point and MultiPoint;
-                1-dimensional curve LineString and MultiLineString; 2-dimensional surface Polygon
-                and MultiPolygon; and the heterogeneous GeometryCollection. </li>
-            </ul>
-            <aside class="example">
-              <p>Example(s) to be added; including:</p>
-              <ul>
-                <li>bounding box, centroid (ref: <a
-                    href="https://www.w3.org/TR/sdw-ucr/#BoundingBoxCentroid"
-                    >R-BoundingBoxCentroid</a>)</li>
-                <li>show <a>Coordinate Reference System</a> (CRS) definition (ref: <a
-                    href="https://www.w3.org/TR/sdw-ucr/#DeterminableCRS">R-DeterminableCRS</a>)</li>
-                <li>vector geometry (ref: <a
-                    href="https://www.w3.org/TR/sdw-ucr/#EncodingForVectorGeometry"
-                    >R-EncodingForVectorGeometry</a>)</li>
-                <li>non-geospatial example e.g. microscopy (ref: <a
-                    href="https://www.w3.org/TR/sdw-ucr/#IndependenceOnReferenceSystems"
-                    >R-IndependenceOnReferenceSystems</a>)</li>
-                <li>encoding information in different ways; e.g. height … above mean sea level, or
-                  floor 5 of <a href="http://dbpedia.org/resource/The_Shard">The Shard</a></li>
-                <li>provision of multiple geometries for a single feature; e.g. a single reference
-                  point (for "pin on map"), a bounding box (for search), a simple geometry (for
-                  coarse spatial analysis), a detailed geometry (for resolving cadastral boundary
-                  disputes) etc.</li>
-              </ul>
-            </aside>
-          </section>
-          <section class="test">
-            <h4 class="subhead">How to Test</h4>
-            <p>...</p>
-          </section>
-          <section class="ucr">
-            <h4 class="subhead">Evidence</h4>
-            <p><span>Relevant requirements</span>: 
-		<a href="https://www.w3.org/TR/sdw-ucr/#MultipleCRS">R-MultipleCRSs</a>, 
-		<a href="https://www.w3.org/TR/sdw-ucr/#BoundingBoxCentroid">R-BoundingBoxCentroid</a>, 
-		<a href="https://www.w3.org/TR/sdw-ucr/#Compressible">R-Compressible</a>, 
-		<a href="https://www.w3.org/TR/sdw-ucr/#CRSDefinition">R-CRSDefinition</a>, 
-		<a href="https://www.w3.org/TR/sdw-ucr/#EncodingForVectorGeometry">R-EncodingForVectorGeometry</a>, 
-		<a href="https://www.w3.org/TR/sdw-ucr/#IndependenceOnReferenceSystems">R-IndependenceOnReferenceSystems</a>, 
-		<a href="https://www.w3.org/TR/sdw-ucr/#MachineToMachine">R-MachineToMachine</a>, 
-		<a href="https://www.w3.org/TR/sdw-ucr/#SpatialMetadata">R-SpatialMetadata</a>, 
-		<a href="https://www.w3.org/TR/sdw-ucr/#3DSupport">R-3DSupport</a>, 
-		<a href="https://www.w3.org/TR/sdw-ucr/#TimeDependentCRS">R-TimeDependentCRS</a>, 
-		<a href="https://www.w3.org/TR/sdw-ucr/#TilingSupport">R-TilingSupport</a>.</p>
-          </section>
-          <section class="benefits">
-            <h4 class="subhead">Benefits</h4>
-            <ul class="benefitsList">
-              <li>...</li>
-            </ul>
-          </section>
-          </div>
+
+<div class="practice">
+<p><span id="describe-geometry" class="practicelab">Provide geometries on the Web in a usable way</span></p>
+<p class="practicedesc">Geometry data should be expressed in a way that allows its publication and use on the Web.</p>
+<section class="axioms">
+<h4 class="subhead">Why</h4>
+<p>The geospatial, Linked Data, and Web communities use different geometry formats and tools, which reflect different requirements with respect to data complexity and manipulation.</p>
+<p>When deciding how a geometry should be described, it is therefore necessary to take into account the intended uses and the related user communities. Which may imply providing alternative geometry descriptions.</p>
+<p>This best practice helps with choosing the right format for describing geometries, based on aspects like intended use(s), performance, and tool support. It also helps when deciding on when using literals rather than structured objects for geometric representations is a good idea.</p>
+<div class="note">
+<p>Since <a>coordinate reference system</a> and axis order are two of the factors determining how a geometry is described, this best practice is strictly correlated to <a href="#bp-crs-choice"></a> and <a href="#bp-crs"></a>, to which we refer the reader for more information.</p>
+</div>
+</section>
+<section class="outcome">
+<h4 class="subhead">Intended Outcome</h4>
+<p>The format chosen to express geometry data should:</p>
+<ul>
+<li>Support the dimensionality of the geometry (from points - 0D - to volumes - 3D) - not all geometry formats support all dimensions;</li>
+<li>Be supported by the software tools used within data user community - the geospatial and Web communities use different tools, working with different geometry formats;</li>
+<li>Keep geometry descriptions to a size that is convenient for the intended applications - Web applications are typically not using detailed geometries;</li>
+<li>Support the <a>coordinate reference system</a> you need.</li>
+</ul>
+<p>Ideally, to enable their widest re-use, geometries should be described having in mind the geospatial, Linked Data and Web communities. This may not be always feasible, but the objective should at least be to describe geometries (also) for Web consumption.</p>
+</section>
+<section class="how">
+<h4 class="subhead">Possible Approach to Implementation</h4>
+<p>Steps to follow:</p>
+<ul>
+<li>Identify the intended uses and applications. In particular, it is important to verify if geometries needs to be used in one or more of the following scenarios:
+<ul>
+<li>specific geospatial applications;</li>
+<li>linked data applications;</li>
+<li>Web consumption.</li>
+</ul>
+</li>
+<li>For each of the intended uses / applications, provide possibly alternative descriptions of geometries, taking into account:
+<ul>
+<li>The appropriate geometry dimensionality (0D - points, 1D - lines, 2D - surfaces, 3D - volumes). See <a href="#spatial-things-features-and-geometry" class="sectionRef"></a> for more information.</li>
+<li>The appropriate <a>coordinate reference system</a>(s). See <a href="#CRS-background" class="sectionRef"></a> for more information.</li>
+<li>The appropriate geometry encoding(s) / representation(s) - also taking into account the software tools that you anticipate your user community to employ. See <a href="#applicability-formatVbp" class="sectionRef"></a> for more information.</li>
+<li>The appropriate level of complexity.</li>
+</ul>
+</li>
+<li>Where multiple representations are required, consider offering as many as you can - balancing the benefit of ease of use against the cost of the additional storage or additional processing if converting on-the-fly. See [[DWBP]] <a href="https://www.w3.org/TR/dwbp/#Conneg">Best Practice 19: Use content negotiation for serving data available in multiple formats</a> for more information.</li>
+</ul>
+<p>It is important to note that the steps outlined above are interrelated. For instance, the dimensionality of a geometry determines the set of <a>coordinate reference systems</a> that can be used, as well as the geometry encodings / representations.</p>
+<p>Another issue to be taken into account in choosing the geometry format, it is whether the axis order is unambiguous - i.e., whether the order of the coordinates is, e.g., longitude/latitude or latitude/longitude. This specific topic is covered by <a href="#bp-crs"></a>.</p>
+<div class="note">
+<p>Multiple formats exists for representing geometries (and some of them are listed in <a href="#applicability-formatVbp" class="sectionRef"></a>). One of issues to be taken into account when choosing the format(s) to be supported, it is whether to use literals or structured objects.</p>
+<ul>
+<li>For geometry literals, several solutions are available, like Well-Known Text (<a>WKT</a>) representations, <a href="https://en.wikipedia.org/wiki/Geohash">GeoHash</a> and
+other geocoding representations. The alternative is to use structured geometry objects as is possible, for example, in [[GeoSPARQL]].</li>
+<li>There are also several suitable binary data formats (e.g. <a href="https://developers.google.com/protocol-buffers/">Google's protocol buffers</a> for vector tiling); however, some binary formats do not (effectively) work on the Web as there are no software tools for working with those formats from within a typical Web application; to work with data in such formats, you must first download the data and then work with it locally.</li>
+<li>There are widespread practices for representing geometric data as linked data, such as using [[W3C-BASIC-GEO]] (<code>geo</code>) <code>geo:lat</code> and <code>geo:long</code> that are used extensively for describing <code>geo:Point</code> objects.</li>
+<li>Concrete geometry types are available, such as those defined in the OpenGIS [[Simple-Features]] Specification, namely 0-dimensional Point and MultiPoint; 1-dimensional curve LineString and MultiLineString; 2-dimensional surface Polygon and MultiPolygon; and the heterogeneous GeometryCollection. </li>
+</ul>
+</div>
+<p>Currently, there are two reference geometry formats widely used in the geospatial and Web communities, respectively, [[GML]] and GeoJSON [[RFC7946]].</p>
+<p>[[GML]] provides the ability to express any type of geometry, in any <a>coordinate reference system</a>, and up to 3 dimensions (from points to volumes).</p>
+<p>On the other hand, GeoJSON supports only one <a>coordinate reference system</a> (CRS84 - i.e., WGS84 longitude/latitude), and geometries up to 2 dimensions (points, lines, surfaces).</p>
+<p>In order to facilitate the use of geometry data on the Web, it is therefore desirable that [[GML]]-encoded geometries are made available also in GeoJSON, by applying not only the required <a>coordinate reference system</a> transformation, but, if needed, by simplifying the original geometry (e.g., by transforming a 3D geometry in a 2D one).</p>
+<div class="note">
+<p>Another approach to publishing geometries on the Web is to embed them directly in Web pages. This is, for instance, the approach used by [[SCHEMA-ORG]], which defines a number of terms to specify them (see <a href="#indexable-by-search-engines"></a> for more information).</p>
+<p>Typically, this is used just for 0D-2D geometries (points, lines, surfaces). Detailed and complex geometries cannot be published with this methodology, so also in this case only a very simplified representation of the original geometry can be published - e.g., the centroid and/or 2D bounding box.</p>
+</div>
+<p>Finally, RDF-based representations of geometries are used in the Linked Data community. This is achieved by using specific vocabularies, as [[W3C-BASIC-GEO]] (only for points) or [[GeoSPARQL]] (for points, lines, surfaces) - see <a href="#semantic-thing"></a> for more information.</p>
+<p>These geometry representations are either stored with the related data, or are maintained separately, and possibly denoted with HTTP URIs (see <a href="#ex-http-uris-for-geometries"></a>).</p>
+<p>RDF representations of geometries can support most geometry types and dimensions (at least, up to 2 dimensions), with any level of complexity, in any <a>coordinate reference system</a>. On the other hand, existing Semantic Web tools, as triple stores, are currently not efficient enough to perform spatial queries which are complex and/or on complex geometries. In the latter case, it is therefore preferable to maintain geometries separately, in software platforms designed for these specific tasks.</p>
+<p>It is nonetheless desirable to make available these geometries for Web consumption as said before for [[GML]]-encoded geometries - i.e., by publishing also simplified version of them, either in GeoJSON or embedded in Web pages.</p>
+<p>The following Turtle snippet shows the [[GeoDCAT-AP]] representation of the dataset in <a href="#ex-schemaorg-dataset-and-place"></a>. Here the bounding box is provided in multiple literal encodings (<a>WKT</a>, [[GML]], GeoJSON), by using property <code>locn:geometry</code> [[LOCN]].</p>
+<aside class="example" id="ex-geodcat-ap-bag-addresses" title="GeoDCAT-AP representation of dataset spatial coverage (bounding box) in multiple encodings">
+<pre>
+&lt;http://www.ldproxy.net/bag/inspireadressen/&gt; a dcat:Dataset ;
+  dct:title "Adressen"@nl ;
+  dct:title "Addresses"@en ;
+  dct:description "INSPIRE Adressen afkomstig uit de basisregistratie Adressen,
+                   beschikbaar voor heel Nederland"@nl ;
+  dct:description "INSPIRE addresses derived from the Addresses base registry,
+                   available for the Netherlands"@en ;
+  dct:isPartOf &lt;http://www.ldproxy.net/bag/&gt; ;
+  dcat:theme &lt;http://inspire.ec.europa.eu/theme/ad&gt; ;
+  dct:spatial [
+    a dct:Location ;
+    locn:geometry
+# Bounding box in WKT
+      "POLYGON((3.053 47.975,7.24 47.975,7.24 53.504,3.053 53.504,3.053 47.975))"^^gsp:wktLiteral ,
+# Bounding box in GML
+      "&lt;gml:Envelope srsName=\"http://www.opengis.net/def/crs/OGC/1.3/CRS84\"&gt;
+         &lt;gml:lowerCorner&gt;3.053 47.975&lt;/gml:lowerCorner&gt;
+         &lt;gml:upperCorner&gt;7.24  53.504&lt;/gml:upperCorner&gt;
+       &lt;/gml:Envelope&gt;"^^gsp:gmlLiteral ,
+# Bounding box in GeoJSON
+      "{ \"type\":\"Polygon\",\"coordinates\":[[
+           [3.053,47.975],[7.24,47.975],[7.24,53.504],[3.053,53.504],[3.053,47.975]
+         ]] }"^^https://www.iana.org/assignments/media-types/application/vnd.geo+json
+  ] .
+</pre>
+</aside>
+<p>In the above example, the <a>coordinate reference system</a> used for the bounding box is CRS84 (equivalent to WGS84, but with axis order longitude/latitude), which is explicitly specified in the [[GML]] encoding via attribute <code>@srsName</code>, and by using the relevant HTTP URI from the <a href="http://www.opengis.net/def/crs/EPSG/0">OGC CRS registry</a>. The <a>coordinate reference system</a> is not specified for the <a>WKT</a> encoding, since CRS84 is the default <a>coordinate reference system</a> for <a>WKT</a> in [[GeoSPARQL]], and therefore it can be omitted. The <a>coordinate reference system</a> is also not specified in the GeoJSON encoding, since CRS84 is the only supported <a>coordinate reference system</a> in GeoJSON [[RFC7946]].</p>
+<p>Always with reference to <a href="#ex-schemaorg-dataset-and-place" class="exampleRef"></a>, the following snippet shows the [[GML]] and the RDF representations of the entry in the BAG Dutch register concerning the building where Anne Frank's house is located. For the corresponding GeoJSON representation, see the relevant <a href="#ex-crs-geojson">example</a> in <a href="#bp-crs"></a>.</p>
+<aside class="example" id="ex-anne-frank-building" title="Description of a building, with detailed geometry, bounding box, and centroid">
+<p>The [[GML]] representation of Anne Frank's house building (taken from the <a href="http://geodata.nationaalgeoregister.nl/bag/wfs?VERSION=2.0.0&SERVICE=WFS&REQUEST=GetFeature&typeName=pand&cql_filter=bag:identificatie=363100012169587">BAG WFS endpoint</a>):</p>
+<pre>
+&lt;bag:pand gml:id=&quot;pand.3323294&quot;&gt;
+  &lt;bag:identificatie&gt;363100012169587&lt;/bag:identificatie&gt;
+  &lt;bag:bouwjaar&gt;1635&lt;/bag:bouwjaar&gt;
+  &lt;bag:status&gt;Pand in gebruik (niet ingemeten)&lt;/bag:status&gt;
+  &lt;bag:gebruiksdoel&gt;woonfunctie&lt;/bag:gebruiksdoel&gt;
+  &lt;bag:oppervlakte_min&gt;1&lt;/bag:oppervlakte_min&gt;
+  &lt;bag:oppervlakte_max&gt;21&lt;/bag:oppervlakte_max&gt;
+  &lt;bag:aantal_verblijfsobjecten&gt;20&lt;/bag:aantal_verblijfsobjecten&gt;
+  &lt;bag:geometrie&gt;
+    &lt;gml:MultiSurface srsDimension=&quot;2&quot; axisLabels="east north"
+                         srsName=&quot;urn:ogc:def:crs:EPSG::28992&quot;&gt;
+      &lt;gml:surfaceMember&gt;
+        &lt;gml:Polygon srsDimension=&quot;2&quot;&gt;
+          &lt;gml:exterior&gt;
+            &lt;gml:LinearRing&gt;
+              &lt;gml:posList&gt;
+                120749.725 487589.422  120752.55  487594.375  120751.227 487595.129
+                120732.539 487605.788  120723.505 487589.745  120721.387 487585.939
+                120740.668 487575.07   120743.316 487573.589  120747.735 487581.337
+                120751.564 487579.154  120755.411 487576.96   120750.935 487569.172
+                120755.941 487566.288  120764.369 487581.066  120749.725 487589.422
+                &lt;/gml:posList&gt;
+            &lt;/gml:LinearRing&gt;
+          &lt;/gml:exterior&gt;
+        &lt;/gml:Polygon&gt;
+      &lt;/gml:surfaceMember&gt;
+    &lt;/gml:MultiSurface&gt;
+  &lt;/bag:geometrie&gt;
+&lt;/bag:pand&gt;
+</pre>
+<p>It is worth noting that the [[GML]] snippet above also includes the explicit specification of the axis order (via attribute <code>@axisLabels</code>) and the number of dimension of the geometry (via attribute <code>@srsDimension</code>).</p>
+<p>The corresponding RDF representation is provided in the following Turtle snippet (taken from the <a href="https://bag.basisregistraties.overheid.nl/resource?subject=http%3A%2F%2Fbag.basisregistraties.overheid.nl%2Fbag%2Fdoc%2F2016083000000000%2Fpand%2F0363100012169587">BAG Linked Data service</a>). NB: The RDF representation below has been complemented with additional properties (marked with <code># Added</code>) for demonstration purposes.</p>
+<pre>
+&lt;http://bag.basisregistraties.overheid.nl/bag/id/pand/0363100012169587&gt; 
+  a gsp:Feature, bag:Pand ;
+  rdfs:label "Pand 0363100012169587"@nl;
+  rdfs:isDefinedBy &lt;http://bag.basisregistraties.overheid.nl/bag/doc/2016083000000000/pand/0363100012169587&gt; ;
+  bag:identificatiecode "0363100012169587"^^xsd:string;
+# Added
+  dct:identifier "363100012169587"^^xsd:string ;
+  bag:status bag:PandInGebruik_nietIngemeten ;
+  bag:oorspronkelijkBouwjaar "1635"^^xsd:gYear;
+# Added
+  dct:created "1635"^^xsd:gYear ;
+# Added
+  locn:address &lt;http://www.ldproxy.net/bag/inspireadressen/inspireadressen.3329155&gt; ;
+# Added
+  geo:lat  "52.3750856076095"^^xsd:float ;
+# Added
+  geo:long "4.88412047472359"^^xsd:float ;
+# Added
+  schema:box "52.3749004358275,4.88382018823377 52.3752539733183,4.88445185541417"^^xsd:string .
+  gsp:hasGeometry &lt;http://bag.basisregistraties.overheid.nl/bag/id/geometry/5C1F8F11324717378B437B2CD12871FF&gt; ;
+  bag:geometriePand &lt;http://bag.basisregistraties.overheid.nl/bag/id/geometry/5C1F8F11324717378B437B2CD12871FF&gt;
+.
+
+&lt;http://bag.basisregistraties.overheid.nl/bag/id/geometry/5C1F8F11324717378B437B2CD12871FF&gt; 
+  a gsp:Geometry, sf:Surface ;
+  gsp:asWKT 
+    "POLYGON ((
+      4.884235252217925  52.375108067329755 , 4.884276231101587 52.37515275750655  , 
+      4.884256726627544  52.375159451429134 , 4.883981215233056 52.37525408134467  , 
+      4.8838501915846795 52.37510933464118  , 4.883819478089075 52.37507499685774  , 
+      4.884103718013221  52.374978516968966 , 4.884142753458582 52.37496537195161  , 
+      4.884206854242218  52.375035281028296 , 4.884263303626781 52.37501590054125  , 
+      4.8843200184035584 52.374996422289605 , 4.88425508456153  52.37492615022757  , 
+      4.884328888811774  52.37490054300959  , 4.884451143500816 52.375033882503686 , 
+      4.884235252217925  52.375108067329755
+    ))"^^gsp:wktLiteral ;
+  pdok:asWKT-RD 
+    "POLYGON ((
+      120749.725 487589.422 , 120752.55 487594.375  ,   
+      120751.227 487595.129 , 120732.539 487605.788 ,
+      120723.505 487589.745 , 120721.387 487585.939 , 
+      120740.668 487575.07  , 120743.316 487573.589 , 
+      120747.735 487581.337 , 120751.564 487579.154 , 
+      120755.411 487576.96  , 120750.935 487569.172 , 
+      120755.941 487566.288 , 120764.369 487581.066 , 
+      120749.725 487589.422
+    ))"^^xsd:string ;
+# Added
+  gsp:asWKT 
+    "&lt;http://www.opengis.net/def/crs/EPSG/0/28992&gt; POLYGON ((
+      120749.725 487589.422 , 120752.55 487594.375  ,   
+      120751.227 487595.129 , 120732.539 487605.788 ,
+      120723.505 487589.745 , 120721.387 487585.939 , 
+      120740.668 487575.07  , 120743.316 487573.589 , 
+      120747.735 487581.337 , 120751.564 487579.154 , 
+      120755.411 487576.96  , 120750.935 487569.172 , 
+      120755.941 487566.288 , 120764.369 487581.066 , 
+      120749.725 487589.422
+    ))"^^gsp:wktLiteral
+.
+</pre>
+</aside>
+<p>The RDF representation above includes:</p>
+<ul>
+  <li>The detailed geometry of the building (<code>gsp:asWKT</code> / <code>pdok:asWKT-RD</code>), in <a>WKT</a> and using multiple reference systems.</li>
+  <li>The bounding box (<code>schema:box</code>) and centroid (<code>geo:lat</code> and <code>geo:long</code>).</li>
+</ul>
+<p>The different <a>WKT</a> encodings in the example show alternative ways of specifying the <a>coordinate reference system</a> used.</p>
+<p>The two instances of property <code>gsp:asWKT</code> follow the syntax recommended in [[GeoSPARQL]], where the specification of the <a>coordinate reference system</a> is required only if different from CRS84. By contrast, property <code>pdok:asWKT-RD</code> implies the use of a specific <a>coordinate reference system</a>, namely, <a href="http://epsg.io/28992">EPSG:28992</a> ("Amersfoort / RD New"). The axis order used is determined here by the <a>coordinate reference system</a>, and in both cases it is longitude / latitude (more precisely, east/north for EPSG:28992). By contrast, the coordinates for the bounding box and centroid use WGS84, with axis order latitude / longitude.</p>
+<p><a href="#ex-anne-frank-building"></a> shows also how geometries for spatial things can be publshed as separate Web resources. This approach can be particularly suitable for giving access to huge geometries, consisting of hundreds of vertices (as the detailed geometry of the boundaries of a geographical region), without attaching them to the relevant spatial things. Moreover, this allows the same geometry to be linked from (i.e., re-used by) different spatial things. Finally, it is possible to use mechanisms (including HTTP content negotiation) to provide access to different representations / encodings of the geometry ([[GML]], <a>WKT</a>, GeoJSON, etc.), thus addressing different use cases. (On this topic, see also <a href="#entity-level-links"></a>).</p>
+<aside class="example" id="ex-http-uris-for-geometries" title="HTTP URIs for geometries">
+<p>As shown in <a href="#ex-amsterdam-station-uri" class="exampleRef"></a>, the following URI:</p>
+<p><code>https://brt.basisregistraties.overheid.nl/top10nl/id/gebouw/102625209</code></p>
+<p>denotes Amsterdam Central train station. However, its geometry is provided as a separate, standalone resource, denoted by the following URI:</p>
+<p><code>https://brt.basisregistraties.overheid.nl/top10nl/id/geometry/2525562935f2c33152e98f65f9d8d6ff</code></p>
+<p>A similar approach is used by Ordnance Survey. For instance, the geometry of North Devon (see <a href="#ex-linking-different-spatial-things" class="exampleRef"></a>) is denoted by the following URI:</p>
+<p><code>http://data.ordnancesurvey.co.uk/id/geometry/22933-4</code></p>
+<p>An additional example is the API of the <a href="http://gadm.geovocab.org/">GADM-RDF project</a>, providing access to spatial linked data concerning administrative areas. For instance, the following URI <a href="http://gadm.geovocab.org/id/0/60"><code>http://gadm.geovocab.org/id/0/60</code></a> returns a description of administrative area "Germany", which links to the geometry of Germany's boundaries, provided via a separate URI: <a href="http://gadm.geovocab.org/id/0/60/geometry"><code>http://gadm.geovocab.org/id/0/60/geometry</code></a>.</p>
+<p>The geometry URIs operated by the GADM-RDF API resolve to different geometry representations / encodings (SVG included), that can be accessed via HTTP content negotiation or by appending the format extension to the URI. For instance, URI <a href="http://gadm.geovocab.org/id/0/60/geometry.geojson"><code>http://gadm.geovocab.org/id/0/60/geometry.geojson</code></a> returns the GeoJSON representation of the geometry. Direct links to the supported geometry representations / encodings are specified in the RDF and HTML representations of the geometry.</p>
+</aside>
+<div class="note">
+<p>This section needs to be completed with guidelines on how to provide geometries at different levels of complexity, highlighting issues to be taken into account when simplifying geometries.</p>
+</div>
+</section>
+<section class="test">
+<h4 class="subhead">How to Test</h4>
+<p>Check if:</p>
+<ol>
+<li>Geometries are made available in possibly different formats and levels of complexity, taking into account their intended uses and their consumption on the Web.</li>
+<li>The choosen geometry descriptions comply with <a href="#bp-crs-choice"></a> and <a href="#bp-crs"></a>.</li>
+<li>The (possibly) alternative geometry descriptions can be accessible via standard mechanisms, as HTTP content negotiation.</li>
+</ol>
+</section>
+<section class="ucr">
+<h4 class="subhead">Evidence</h4>
+<p><span>Relevant requirements</span>: 
+<a href="https://www.w3.org/TR/sdw-ucr/#MultipleCRS">R-MultipleCRSs</a>,
+<a href="https://www.w3.org/TR/sdw-ucr/#BoundingBoxCentroid">R-BoundingBoxCentroid</a>, 
+<a href="https://www.w3.org/TR/sdw-ucr/#Compressible">R-Compressible</a>, 
+<a href="https://www.w3.org/TR/sdw-ucr/#CRSDefinition">R-CRSDefinition</a>, 
+<a href="https://www.w3.org/TR/sdw-ucr/#EncodingForVectorGeometry">R-EncodingForVectorGeometry</a>, 
+<a href="https://www.w3.org/TR/sdw-ucr/#IndependenceOnReferenceSystems">R-IndependenceOnReferenceSystems</a>, 
+<a href="https://www.w3.org/TR/sdw-ucr/#MachineToMachine">R-MachineToMachine</a>, 
+<a href="https://www.w3.org/TR/sdw-ucr/#SpatialMetadata">R-SpatialMetadata</a>, 
+<a href="https://www.w3.org/TR/sdw-ucr/#3DSupport">R-3DSupport</a>, 
+<a href="https://www.w3.org/TR/sdw-ucr/#TimeDependentCRS">R-TimeDependentCRS</a>, 
+<a href="https://www.w3.org/TR/sdw-ucr/#TilingSupport">R-TilingSupport</a>.</p>
+</section>
+<section class="benefits">
+<h4 class="subhead">Benefits</h4>
+<ul class="benefitsList">
+<li>...</li>
+</ul>
+</section>
+</div>
+          
           <div class="practice">
             <p><span id="relative-position" class="practicelab">How to describe relative
                 positions</span></p>
@@ -2030,8 +2199,7 @@ a:Dataset a dcat:Dataset ;
                 search on the name, label or other property may be useful.</li> 
             </ul>
 
-            <a name="elda-example">
-            <aside class="example">
+            <aside class="example" id="ex-elda">
               <p>The <a href="http://environment.data.gov.uk/bwq/">Environment Agency Bathing Water
                 Quality API</a> is implemented using the Epimorphic's <a
                   href="http://epimorphics.github.io/elda/current/index.html">ELDA implementation</a> of the <a
@@ -2039,7 +2207,7 @@ a:Dataset a dcat:Dataset ;
                 >Linked Data API</a> and enables configured queries against (general) SPARQL
                 endpoints to be exposed as RESTful web services.</p>
             </aside>
-            </a>  
+
             <aside class="example">
               <p>Use of <a href="http://www.opensearch.org/Home">OpenSearch</a> to find 
                 <a>SpatialThings</a>. For spatial or temporal searches use the <a
@@ -2101,7 +2269,7 @@ a:Dataset a dcat:Dataset ;
                   URL in general does not provide a good URI for a resource as it is unlikely to be
                   persistent. A Web service URL is often technology and implementation dependent and
                   in practice both are likely to change with time.</p>
-                <p>The <a href="#elda-example">Environment Agency Bathing Water
+                <p>The <a href="#ex-elda">Environment Agency Bathing Water
                   Quality API</a> example above uses URI templates, too. In this case, 
                   the Linked Data API configuration uses URI templates to provide RESTful 
                   access to SPARQL queries thereby taking away from the user the challenge 
@@ -2285,7 +2453,7 @@ a:Dataset a dcat:Dataset ;
                     <p>Links should be typed (explicitly or implicitly), so that clients can decide which link to follow when they are traversing a web of interlinked resources to reach application goals.</p>
                     <pre class="example" id="ex-webdata2-typed-links" title="HTTP response Link header with IANA Link Relation types">
 HTTP/1.1 200 OK
-Link: <http://www.gemeentegeschiedenis.nl/gemeentenaam/Amsterdam/2014>; rel="predecessor-version"
+Link: &lt;http://www.gemeentegeschiedenis.nl/gemeentenaam/Amsterdam/2014&gt;; rel="predecessor-version"
 Content-type: application/geo+json
 Connection: close
 
@@ -2711,7 +2879,7 @@ Date:Mon, 13 Mar 2017 16:12:04 GMT
           </section>
         </div>
         <div class="practice">
-          <p><span id="ids-for-chunks" class="practicelab">(to be deleted)</span></p>
+          <p><span id="find-related-data" class="practicelab">(to be deleted)</span></p>
           <p class="practicedesc"></p>
           <section class="axioms">
             <h4 class="subhead">Why</h4>
@@ -3854,7 +4022,7 @@ GID,On Street,Long,Lat,Species,Trim Cycle,Diameter at Breast Ht,Inventory Date,C
         across diverse data sources [[SPARQL11-OVERVIEW]].</p>
       <p><dfn>Spatial data</dfn>: Data describing anything with spatial extent; i.e. size, shape or
         position. In addition to describing things that are positioned relative to the Earth (also
-        see geospatial data), spatial data may also describe things using other coordinate systems
+        see <a>geospatial data</a>), spatial data may also describe things using other coordinate systems
         that are not related to position on the Earth, such as the size, shape and positions of
         cellular and sub-cellular features described using the 2D or 3D Cartesian coordinate system
         of a specific tissue sample.</p>
@@ -3863,7 +4031,7 @@ GID,On Street,Long,Lat,Species,Trim Cycle,Diameter at Breast Ht,Inventory Date,C
         spatial databases allow representation of simple geometric objects such as points, lines and
         polygons and provide functions to determine spatial relationships (overlaps, touches
         etc.).</p>
-      <p><dfn data-lt="SDI|SDIs|Spatial Data Infrastructure|Spatial Data Infrastructures">SDI</dfn>:
+      <p><dfn data-lt="SDI|SDIs|Spatial Data Infrastructure|Spatial Data Infrastructures">Spatial Data Infrastructure (SDI)</dfn>:
         An ecosystem of geographic data, metadata, tools, applications, policies and users that are
         necessary to acquire, process, distribute, use, maintain, and preserve spatial data. Due to
         its nature (size, cost, number of interactors) an SDI is often government-related.</p>


### PR DESCRIPTION
- Major revision to BP8
- Added JavaScript snippet to crossref examples and BPs, without the need of including number and textual label in the relevant anchors (the label is added automatically, as done for sections)
- Fixed HTML validation errors and warnings
- Editorial changes to glossary
- Fixed duplicate IDs in BP13 and BP15