### PR TITLE
Revisions to BP8 + editorial changes

### DIFF
--- a/bp/index.html
+++ b/bp/index.html
@@ -693,7 +693,7 @@ $(document).ready( function() {
         <p>Preparations for publishing spatial data on the Web need to start somewhere. Typically, your spatial data will be in the following places:</p>
         <ol>
           <li>plain text documents; e.g. historical texts, government reports, blog posts etc.</li>
-          <li>data files containing structured content or markup; e.g. geospatial vector data in Shapefile or GML format, statistical data in tabular CSV format or a spreadsheet, as GPX data with “waypoints” and “tracks”, satellite imagery in GeoTIFF, climate simulations in CF-NetCDF etc.</li>
+          <li>data files containing structured content or markup; e.g. geospatial vector data in Shapefile or [[GML]] format, statistical data in tabular CSV format or a spreadsheet, as GPX data with “waypoints” and “tracks”, satellite imagery in GeoTIFF, climate simulations in CF-NetCDF etc.</li>
           <li>a data repository; e.g. PostGIS (a spatially enabled relational database), Elasticsearch (a document-oriented noSQL repository based on Apache Lucene), Apache Jena’s TDB (an RDF triple store)</li>
           <li>exposed via an existing API; including OGC-compliant web services such as WFS and WCS</li>
         </ol>
@@ -1131,7 +1131,7 @@ a:Dataset a dcat:Dataset ;
 				    <p>Search engines may also index resource representations in other formats than HTML.</p>
 
             <aside class="example">
-              <p>At the time of writing, Google is indexing KML documents and supporting advanced searches that are restricted to KML documents. GML files are also indexed, but only like any other XML documents. JSON, including GeoJSON, is currently not indexed.</p>
+              <p>At the time of writing, Google is indexing KML documents and supporting advanced searches that are restricted to KML documents. [[GML]] files are also indexed, but only like any other XML documents. JSON, including GeoJSON, is currently not indexed.</p>
             </aside>
 
             <div class="note">
@@ -1359,7 +1359,7 @@ a:Dataset a dcat:Dataset ;
             
             <p>Approach (3) is suitable where a spatial thing has a small number of attributes that are frequently updated. For example, the GPS-position of a runner or when streaming data from a sensor, such as the water level from a stream guage.</p>
 
-            <p>With this approach, the description of the spatial thing must include a property that contains a sequentially-ordered set of data-points, each of which defines a time-stamp and the values for the time-varying attribute(s). By definition, this property can be considered as a time-series <a>coverage</a>. Standard data encodings are available for time-series data, including: [[TIMESERIESML]] for GML, plus [[COVERAGE-JSON]] and [[SENSORTHINGS]] for JSON.</p>
+            <p>With this approach, the description of the spatial thing must include a property that contains a sequentially-ordered set of data-points, each of which defines a time-stamp and the values for the time-varying attribute(s). By definition, this property can be considered as a time-series <a>coverage</a>. Standard data encodings are available for time-series data, including: [[TIMESERIESML]] for [[GML]], plus [[COVERAGE-JSON]] and [[SENSORTHINGS]] for JSON.</p>
 
             <p class="note">The OGC [[MOVING-FEATURES-XML]] and [[MOVING-FEATURES-CSV]] specifications follow the pattern described above. A <code>trajectory</code> element is used to describe the position of a spatial thing, and varying attributes (such as orientation or rotation) can be added alongside the tuples in the trajectory. However, there is limited evidence of adoption outside of Japan.</p>
 
@@ -1660,7 +1660,11 @@ a:Dataset a dcat:Dataset ;
 <li>The appropriate level of complexity.</li>
 </ul>
 </li>
-<li>Where multiple representations are required, consider offering as many as you can - balancing the benefit of ease of use against the cost of the additional storage or additional processing if converting on-the-fly. See [[DWBP]] <a href="https://www.w3.org/TR/dwbp/#Conneg">Best Practice 19: Use content negotiation for serving data available in multiple formats</a> for more information.</li>
+<li>Where multiple representations are required, consider offering as many as you can - balancing the benefit of ease of use against the cost of the additional storage or additional processing if converting on-the-fly. See [[DWBP]] <a href="https://www.w3.org/TR/dwbp/#Conneg">Best Practice 19: Use content negotiation for serving data available in multiple formats</a> for more information.
+<div class="note">
+<p>HTTP content negotiation only works for media-type, character set, encoding and language. As a consequence, it is not possible to select one representation that conforms to a given "profile" (e.g. data model, complexity level, CRS) from several that all share the same media-type; e.g. asking for the geojson features with "simple" geometries (compacted polygons or just points) not the "complex" geometries; or asking for the representation that uses CRS84 not Amersfoort-RD.</p>
+</div>
+</li>
 </ul>
 <p>It is important to note that the steps outlined above are interrelated. For instance, the dimensionality of a geometry determines the set of <a>coordinate reference systems</a> that can be used, as well as the geometry encodings / representations.</p>
 <p>Another issue to be taken into account in choosing the geometry format, it is whether the axis order is unambiguous - i.e., whether the order of the coordinates is, e.g., longitude/latitude or latitude/longitude. This specific topic is covered by <a href="#bp-crs"></a>.</p>
@@ -1670,8 +1674,8 @@ a:Dataset a dcat:Dataset ;
 <li>For geometry literals, several solutions are available, like Well-Known Text (<a>WKT</a>) representations, <a href="https://en.wikipedia.org/wiki/Geohash">GeoHash</a> and
 other geocoding representations. The alternative is to use structured geometry objects as is possible, for example, in [[GeoSPARQL]].</li>
 <li>There are also several suitable binary data formats (e.g. <a href="https://developers.google.com/protocol-buffers/">Google's protocol buffers</a> for vector tiling); however, some binary formats do not (effectively) work on the Web as there are no software tools for working with those formats from within a typical Web application; to work with data in such formats, you must first download the data and then work with it locally.</li>
-<li>There are widespread practices for representing geometric data as linked data, such as using [[W3C-BASIC-GEO]] (<code>geo</code>) <code>geo:lat</code> and <code>geo:long</code> that are used extensively for describing <code>geo:Point</code> objects.</li>
-<li>Concrete geometry types are available, such as those defined in the OpenGIS [[Simple-Features]] Specification, namely 0-dimensional Point and MultiPoint; 1-dimensional curve LineString and MultiLineString; 2-dimensional surface Polygon and MultiPolygon; and the heterogeneous GeometryCollection. </li>
+<li>There are widespread practices for representing geometric data as linked data, such as using [[W3C-BASIC-GEO]] (<code>geo</code>) <code>w3cgeo:lat</code> and <code>w3cgeo:long</code> that are used extensively for describing <code>w3cgeo:Point</code> objects.</li>
+<li>Concrete geometry types are available, such as those defined in the OpenGIS [[SIMPLE-FEATURES]] Specification, namely 0-dimensional Point and MultiPoint; 1-dimensional curve LineString and MultiLineString; 2-dimensional surface Polygon and MultiPolygon; and the heterogeneous GeometryCollection. </li>
 </ul>
 </div>
 <p>Currently, there are two reference geometry formats widely used in the geospatial and Web communities, respectively, [[GML]] and GeoJSON [[RFC7946]].</p>
@@ -1689,6 +1693,10 @@ other geocoding representations. The alternative is to use structured geometry o
 <p>The following Turtle snippet shows the [[GeoDCAT-AP]] representation of the dataset in <a href="#ex-schemaorg-dataset-and-place"></a>. Here the bounding box is provided in multiple literal encodings (<a>WKT</a>, [[GML]], GeoJSON), by using property <code>locn:geometry</code> [[LOCN]].</p>
 <aside class="example" id="ex-geodcat-ap-bag-addresses" title="GeoDCAT-AP representation of dataset spatial coverage (bounding box) in multiple encodings">
 <pre>
+@prefix dcat: &lt;http://www.w3.org/ns/dcat#&gt; .
+@prefix dct:  &lt;http://purl.org/dc/terms/&gt; .
+@prefix locn: &lt;http://www.w3.org/ns/locn#&gt; .
+
 &lt;http://www.ldproxy.net/bag/inspireadressen/&gt; a dcat:Dataset ;
   dct:title "Adressen"@nl ;
   dct:title "Addresses"@en ;
@@ -1702,22 +1710,22 @@ other geocoding representations. The alternative is to use structured geometry o
     a dct:Location ;
     locn:geometry
 # Bounding box in WKT
-      "POLYGON((3.053 47.975,7.24 47.975,7.24 53.504,3.053 53.504,3.053 47.975))"^^gsp:wktLiteral ,
+      "POLYGON((3.053 47.975,7.24 47.975,7.24 53.504,3.053 53.504,3.053 47.975))"^^geosparql:wktLiteral ,
 # Bounding box in GML
       "&lt;gml:Envelope srsName=\"http://www.opengis.net/def/crs/OGC/1.3/CRS84\"&gt;
          &lt;gml:lowerCorner&gt;3.053 47.975&lt;/gml:lowerCorner&gt;
          &lt;gml:upperCorner&gt;7.24  53.504&lt;/gml:upperCorner&gt;
-       &lt;/gml:Envelope&gt;"^^gsp:gmlLiteral ,
+       &lt;/gml:Envelope&gt;"^^geosparql:gmlLiteral ,
 # Bounding box in GeoJSON
       "{ \"type\":\"Polygon\",\"coordinates\":[[
            [3.053,47.975],[7.24,47.975],[7.24,53.504],[3.053,53.504],[3.053,47.975]
-         ]] }"^^https://www.iana.org/assignments/media-types/application/vnd.geo+json
+         ]] }"^^https://www.iana.org/assignments/media-types/application/geo+json
   ] .
 </pre>
 </aside>
 <p>In the above example, the <a>coordinate reference system</a> used for the bounding box is CRS84 (equivalent to WGS84, but with axis order longitude/latitude), which is explicitly specified in the [[GML]] encoding via attribute <code>@srsName</code>, and by using the relevant HTTP URI from the <a href="http://www.opengis.net/def/crs/EPSG/0">OGC CRS registry</a>. The <a>coordinate reference system</a> is not specified for the <a>WKT</a> encoding, since CRS84 is the default <a>coordinate reference system</a> for <a>WKT</a> in [[GeoSPARQL]], and therefore it can be omitted. The <a>coordinate reference system</a> is also not specified in the GeoJSON encoding, since CRS84 is the only supported <a>coordinate reference system</a> in GeoJSON [[RFC7946]].</p>
 <p>Always with reference to <a href="#ex-schemaorg-dataset-and-place" class="exampleRef"></a>, the following snippet shows the [[GML]] and the RDF representations of the entry in the BAG Dutch register concerning the building where Anne Frank's house is located. For the corresponding GeoJSON representation, see the relevant <a href="#ex-crs-geojson">example</a> in <a href="#bp-crs"></a>.</p>
-<aside class="example" id="ex-anne-frank-building" title="Description of a building, with detailed geometry, bounding box, and centroid">
+<aside class="example" id="ex-anne-frank-building-gml" title="GML description of a building, with detailed geometry">
 <p>The [[GML]] representation of Anne Frank's house building (taken from the <a href="http://geodata.nationaalgeoregister.nl/bag/wfs?VERSION=2.0.0&SERVICE=WFS&REQUEST=GetFeature&typeName=pand&cql_filter=bag:identificatie=363100012169587">BAG WFS endpoint</a>):</p>
 <pre>
 &lt;bag:pand gml:id=&quot;pand.3323294&quot;&gt;
@@ -1750,35 +1758,47 @@ other geocoding representations. The alternative is to use structured geometry o
   &lt;/bag:geometrie&gt;
 &lt;/bag:pand&gt;
 </pre>
+</aside>
 <p>It is worth noting that the [[GML]] snippet above also includes the explicit specification of the axis order (via attribute <code>@axisLabels</code>) and the number of dimension of the geometry (via attribute <code>@srsDimension</code>).</p>
 <p>The corresponding RDF representation is provided in the following Turtle snippet (taken from the <a href="https://bag.basisregistraties.overheid.nl/resource?subject=http%3A%2F%2Fbag.basisregistraties.overheid.nl%2Fbag%2Fdoc%2F2016083000000000%2Fpand%2F0363100012169587">BAG Linked Data service</a>). NB: The RDF representation below has been complemented with additional properties (marked with <code># Added</code>) for demonstration purposes.</p>
+<aside class="example" id="ex-anne-frank-building-rdf" title="RDF description of a building, with detailed geometry, bounding box, and centroid">
 <pre>
+@prefix bag:       &lt;http://bag.basisregistraties.overheid.nl/def/bag#&gt; .
+@prefix dct:       &lt;http://purl.org/dc/terms/&gt; .
+@prefix geosparql: &lt;http://www.opengis.net/ont/geosparql#&gt; .
+@prefix gml:       &lt;http://www.opengis.net/ont/gml#&gt; .
+@prefix locn:      &lt;http://www.w3.org/ns/locn#&gt; .
+@prefix pdok:      &lt;http://data.pdok.nl/def/pdok#&gt; .
+@prefix rdfs:      &lt;http://www.w3.org/2000/01/rdf-schema#&gt; .
+@prefix schema:    &lt;http://schema.org/&gt; .
+@prefix w3cgeo:    &lt;http://www.w3.org/2003/01/geo/wgs84_pos#&gt; .
+
 &lt;http://bag.basisregistraties.overheid.nl/bag/id/pand/0363100012169587&gt; 
-  a gsp:Feature, bag:Pand ;
+  a geosparql:Feature, bag:Pand ;
   rdfs:label "Pand 0363100012169587"@nl;
   rdfs:isDefinedBy &lt;http://bag.basisregistraties.overheid.nl/bag/doc/2016083000000000/pand/0363100012169587&gt; ;
   bag:identificatiecode "0363100012169587"^^xsd:string;
 # Added
   dct:identifier "363100012169587"^^xsd:string ;
-  bag:status bag:PandInGebruik_nietIngemeten ;
+  bag:status &lt;http://bag.basisregistraties.overheid.nl/id/begrip/PandInGebruik_nietIngemeten&gt; ;
   bag:oorspronkelijkBouwjaar "1635"^^xsd:gYear;
 # Added
   dct:created "1635"^^xsd:gYear ;
 # Added
   locn:address &lt;http://www.ldproxy.net/bag/inspireadressen/inspireadressen.3329155&gt; ;
 # Added
-  geo:lat  "52.3750856076095"^^xsd:float ;
+  w3cgeo:lat  "52.3750856076095"^^xsd:float ;
 # Added
-  geo:long "4.88412047472359"^^xsd:float ;
+  w3cgeo:long "4.88412047472359"^^xsd:float ;
 # Added
   schema:box "52.3749004358275,4.88382018823377 52.3752539733183,4.88445185541417"^^xsd:string .
-  gsp:hasGeometry &lt;http://bag.basisregistraties.overheid.nl/bag/id/geometry/5C1F8F11324717378B437B2CD12871FF&gt; ;
+  geosparql:hasGeometry &lt;http://bag.basisregistraties.overheid.nl/bag/id/geometry/5C1F8F11324717378B437B2CD12871FF&gt; ;
   bag:geometriePand &lt;http://bag.basisregistraties.overheid.nl/bag/id/geometry/5C1F8F11324717378B437B2CD12871FF&gt;
 .
 
 &lt;http://bag.basisregistraties.overheid.nl/bag/id/geometry/5C1F8F11324717378B437B2CD12871FF&gt; 
-  a gsp:Geometry, sf:Surface ;
-  gsp:asWKT 
+  a geosparql:Geometry, gml:Surface ;
+  geosparql:asWKT 
     "POLYGON ((
       4.884235252217925  52.375108067329755 , 4.884276231101587 52.37515275750655  , 
       4.884256726627544  52.375159451429134 , 4.883981215233056 52.37525408134467  , 
@@ -1788,7 +1808,7 @@ other geocoding representations. The alternative is to use structured geometry o
       4.8843200184035584 52.374996422289605 , 4.88425508456153  52.37492615022757  , 
       4.884328888811774  52.37490054300959  , 4.884451143500816 52.375033882503686 , 
       4.884235252217925  52.375108067329755
-    ))"^^gsp:wktLiteral ;
+    ))"^^geosparql:wktLiteral ;
   pdok:asWKT-RD 
     "POLYGON ((
       120749.725 487589.422 , 120752.55 487594.375  ,   
@@ -1801,7 +1821,7 @@ other geocoding representations. The alternative is to use structured geometry o
       120749.725 487589.422
     ))"^^xsd:string ;
 # Added
-  gsp:asWKT 
+  geosparql:asWKT 
     "&lt;http://www.opengis.net/def/crs/EPSG/0/28992&gt; POLYGON ((
       120749.725 487589.422 , 120752.55 487594.375  ,   
       120751.227 487595.129 , 120732.539 487605.788 ,
@@ -1811,30 +1831,36 @@ other geocoding representations. The alternative is to use structured geometry o
       120755.411 487576.96  , 120750.935 487569.172 , 
       120755.941 487566.288 , 120764.369 487581.066 , 
       120749.725 487589.422
-    ))"^^gsp:wktLiteral
+    ))"^^geosparql:wktLiteral
 .
 </pre>
 </aside>
 <p>The RDF representation above includes:</p>
 <ul>
-  <li>The detailed geometry of the building (<code>gsp:asWKT</code> / <code>pdok:asWKT-RD</code>), in <a>WKT</a> and using multiple reference systems.</li>
-  <li>The bounding box (<code>schema:box</code>) and centroid (<code>geo:lat</code> and <code>geo:long</code>).</li>
+  <li>The detailed geometry of the building (<code>geosparql:asWKT</code> / <code>pdok:asWKT-RD</code>), in <a>WKT</a> and using multiple reference systems.</li>
+  <li>The bounding box (<code>schema:box</code>) and centroid (<code>w3cgeo:lat</code> and <code>w3cgeo:long</code>).</li>
 </ul>
 <p>The different <a>WKT</a> encodings in the example show alternative ways of specifying the <a>coordinate reference system</a> used.</p>
-<p>The two instances of property <code>gsp:asWKT</code> follow the syntax recommended in [[GeoSPARQL]], where the specification of the <a>coordinate reference system</a> is required only if different from CRS84. By contrast, property <code>pdok:asWKT-RD</code> implies the use of a specific <a>coordinate reference system</a>, namely, <a href="http://epsg.io/28992">EPSG:28992</a> ("Amersfoort / RD New"). The axis order used is determined here by the <a>coordinate reference system</a>, and in both cases it is longitude / latitude (more precisely, east/north for EPSG:28992). By contrast, the coordinates for the bounding box and centroid use WGS84, with axis order latitude / longitude.</p>
-<p><a href="#ex-anne-frank-building"></a> shows also how geometries for spatial things can be publshed as separate Web resources. This approach can be particularly suitable for giving access to huge geometries, consisting of hundreds of vertices (as the detailed geometry of the boundaries of a geographical region), without attaching them to the relevant spatial things. Moreover, this allows the same geometry to be linked from (i.e., re-used by) different spatial things. Finally, it is possible to use mechanisms (including HTTP content negotiation) to provide access to different representations / encodings of the geometry ([[GML]], <a>WKT</a>, GeoJSON, etc.), thus addressing different use cases. (On this topic, see also <a href="#entity-level-links"></a>).</p>
+<p>The two instances of property <code>geosparql:asWKT</code> follow the syntax recommended in [[GeoSPARQL]], where the specification of the <a>coordinate reference system</a> is required only if different from CRS84. By contrast, property <code>pdok:asWKT-RD</code> implies the use of a specific <a>coordinate reference system</a>, namely, <a href="http://epsg.io/28992">EPSG:28992</a> ("Amersfoort / RD New"). The axis order used is determined here by the <a>coordinate reference system</a>, and in both cases it is longitude / latitude (more precisely, east/north for EPSG:28992). By contrast, the coordinates for the bounding box and centroid use WGS84, with axis order latitude / longitude.</p>
+<p><a href="#ex-anne-frank-building-rdf"></a> shows also how geometries for <a>spatial things</a> can be publshed as separate Web resources. This approach can be particularly suitable for giving access to huge geometries, consisting of hundreds of vertices (as the detailed geometry of the boundaries of a geographical region), without attaching them to the relevant spatial things. Moreover, this allows the same geometry to be linked from (i.e., re-used by) different spatial things. Finally, it is possible to use mechanisms (including HTTP content negotiation) to provide access to different representations / encodings of the geometry ([[GML]], <a>WKT</a>, GeoJSON, etc.), thus addressing different use cases. (On this topic, see also <a href="#entity-level-links"></a>).</p>
 <aside class="example" id="ex-http-uris-for-geometries" title="HTTP URIs for geometries">
 <p>As shown in <a href="#ex-amsterdam-station-uri" class="exampleRef"></a>, the following URI:</p>
 <p><code>https://brt.basisregistraties.overheid.nl/top10nl/id/gebouw/102625209</code></p>
 <p>denotes Amsterdam Central train station. However, its geometry is provided as a separate, standalone resource, denoted by the following URI:</p>
 <p><code>https://brt.basisregistraties.overheid.nl/top10nl/id/geometry/2525562935f2c33152e98f65f9d8d6ff</code></p>
-<p>A similar approach is used by Ordnance Survey. For instance, the geometry of North Devon (see <a href="#ex-linking-different-spatial-things" class="exampleRef"></a>) is denoted by the following URI:</p>
+<p>A similar approach is used by Ordnance Survey. For instance, North Devon is denoted by the following URI:</p>
+<p><code>http://data.ordnancesurvey.co.uk/id/7000000000022933</code></p>
+<p>whereas its geometry is denoted by:</p>
 <p><code>http://data.ordnancesurvey.co.uk/id/geometry/22933-4</code></p>
 <p>An additional example is the API of the <a href="http://gadm.geovocab.org/">GADM-RDF project</a>, providing access to spatial linked data concerning administrative areas. For instance, the following URI <a href="http://gadm.geovocab.org/id/0/60"><code>http://gadm.geovocab.org/id/0/60</code></a> returns a description of administrative area "Germany", which links to the geometry of Germany's boundaries, provided via a separate URI: <a href="http://gadm.geovocab.org/id/0/60/geometry"><code>http://gadm.geovocab.org/id/0/60/geometry</code></a>.</p>
 <p>The geometry URIs operated by the GADM-RDF API resolve to different geometry representations / encodings (SVG included), that can be accessed via HTTP content negotiation or by appending the format extension to the URI. For instance, URI <a href="http://gadm.geovocab.org/id/0/60/geometry.geojson"><code>http://gadm.geovocab.org/id/0/60/geometry.geojson</code></a> returns the GeoJSON representation of the geometry. Direct links to the supported geometry representations / encodings are specified in the RDF and HTML representations of the geometry.</p>
 </aside>
 <div class="note">
-<p>This section needs to be completed with guidelines on how to provide geometries at different levels of complexity, highlighting issues to be taken into account when simplifying geometries.</p>
+<p>This section needs to be completed with:</p>
+<ul>
+<li>Guidelines on how to provide geometries at different levels of <em>precision</em> and <em>complexity</em>, highlighting issues to be taken into account when simplifying geometries.</li>
+<li>More details about how WKT is used.</li>
+</ul>
 </div>
 </section>
 <section class="test">
@@ -2249,7 +2275,7 @@ other geocoding representations. The alternative is to use structured geometry o
                   data and metadata to schema.org according to a provided mapping scheme; 
                   assigns URIs to all resources based on a pattern; supports filtering 
                   based on a property; makes each resource available in HTML, XML, JSON-LD, 
-                  GML, GeoJSON; and generates links to data in other datasets managed in triple 
+                  [[GML]], GeoJSON; and generates links to data in other datasets managed in triple 
                   stores using SPARQL queries. The API is documented and published using 
                   Swagger.</p>
               </aside>    
@@ -2296,8 +2322,8 @@ other geocoding representations. The alternative is to use structured geometry o
                 Publication tools. This process also allows to enrich the data represented
                 in RDF with additional information and links. To maintain a direct link 
                 between the spatial things provided through the SDI and as Linked Data, 
-                use properties that link between the GML and RDF representations, for example,
-                by including an additional feature property 'rdf_seealso' in the GML encoding 
+                use properties that link between the [[GML]] and RDF representations, for example,
+                by including an additional feature property 'rdf_seealso' in the [[GML]] encoding 
                 pointing to the RDF representation of the spatial thing.</p>
                 <figure>
                   <img src="images/bp28-example.PNG"
@@ -2434,7 +2460,7 @@ other geocoding representations. The alternative is to use structured geometry o
             <ol>
               <li>
                 <p>Use formats that support Web linking (as defined in [[WEBARCH]] <a href="https://www.w3.org/TR/webarch/#hypertext">section 4.4 Hypertext</a>)</p>
-                <p>Earlier in this document (<a href="#linked-data" class="sectionRef"></a>) we explained that Linked Data requires only that the formats used to publish data support Web linking. In other words, linking spatial data does not automatically mean the use of RDF; links can also be created, for example, using GML, HTML or JSON-LD. The two key points from [[WEBARCH]] are:</p>
+                <p>Earlier in this document (<a href="#linked-data" class="sectionRef"></a>) we explained that Linked Data requires only that the formats used to publish data support Web linking. In other words, linking spatial data does not automatically mean the use of RDF; links can also be created, for example, using [[GML]], HTML or JSON-LD. The two key points from [[WEBARCH]] are:</p>
                 <ul>
                   <li><strong><em>Good practice: Link identification</em></strong> &mdash; A [data format] specification SHOULD provide ways to identify links to other resources [...].</li>
                   <li><strong><em>Good practice: Web linking</em></strong> &mdash; A [data format] specification SHOULD allow Web-wide linking, not just internal document linking.</li>
@@ -2704,7 +2730,7 @@ geonames:2650225 owl:sameAs ukgov-stat:S12000036 .
                 <p>For further information about sensors, sampling, observations and measurements, please refer to [[OandM]] and also to [[VOCAB-SSN]].</p>
 
                 <div class="note">
-                  <p>[[GML]] adopted the [[XLINK11]] standard to represent links between resources. At the time of adoption, XLink was the only W3C-endorsed standard mechanism for describing links between resources within XML documents. The <a href="http://www.opengeospatial.org/">Open Geospatial Consortium</a> anticipated broad adoption of XLink over time - and, with that adoption, provision of support within software tooling. While XML Schema, XPath, XSLT and XQuery etc. have seen good software support over the years, this never happened with XLink. The authors of GML note that given the lack of widespread support, use of Xlink within GML provided no significant advantage over and above use a bespoke mechanism tailored to the needs of GML.</p>
+                  <p>[[GML]] adopted the [[XLINK11]] standard to represent links between resources. At the time of adoption, XLink was the only W3C-endorsed standard mechanism for describing links between resources within XML documents. The <a href="http://www.opengeospatial.org/">Open Geospatial Consortium</a> anticipated broad adoption of XLink over time - and, with that adoption, provision of support within software tooling. While XML Schema, XPath, XSLT and XQuery etc. have seen good software support over the years, this never happened with XLink. The authors of [[GML]] note that given the lack of widespread support, use of Xlink within [[GML]] provided no significant advantage over and above use a bespoke mechanism tailored to the needs of [[GML]].</p>
                 </div>
 
                 <p>Our final example of a domain-specific relationship concerns creative works. For example, one may want to indicate the location a social media message was sent from. In the example below, we assume that Maurits, a tourist in Amsterdam, wants to comment on his visit to Anne Frank's House. His social media App uses the [[GEOLOCATION-API]] to determine his location (<code>Lat=52.37590</code> and <code>Long=4.88452</code>) and suggests several places that Maurits might choose from in order to geo-tag his message. Maurits wants people to know roughly where he is, so he chooses "Amsterdam-Centrum" and presses 'send'. The App encodes the message in [[SCHEMA-ORG]] and pushes the message to the server for distribution. The geo-information is provided using the <a href="http://schema.org/locationCreated"><code>schema:locationCreated</code></a> property.</p>
@@ -3174,7 +3200,7 @@ Content-type: application/geo+json
   }
 }
               </pre>
-              <p>The "Well Known Text" (WKT) encoding, itself defined in [[SIMPLE-FEATURES]], is extended by [[GeoSPARQL]] to include designation of the coordinate reference system used. The example above encodes the polygon as a [[GeoSPARQL]] <code>wktLiteral</code> data type, designating the coordinate reference system as <code>&lt;http://www.opengis.net/def/crs/EPSG/0/4326&gt;</code> (<a href="http://epsg.io/4326">EPSG:4326</a>) - WGS 84 Lat/Long.</p>
+              <p>The "Well Known Text" (<a>WKT</a>) encoding, itself defined in [[SIMPLE-FEATURES]], is extended by [[GeoSPARQL]] to include designation of the coordinate reference system used. The example above encodes the polygon as a [[GeoSPARQL]] <code>wktLiteral</code> data type, designating the coordinate reference system as <code>&lt;http://www.opengis.net/def/crs/EPSG/0/4326&gt;</code> (<a href="http://epsg.io/4326">EPSG:4326</a>) - WGS 84 Lat/Long.</p>
 
               <div class="note">
                 <p>When using the <code>wktLiteral</code> datatype specified in [[GeoSPARQL]], the <a>coordinate reference system</a> URI may be omitted. In such a case, WGS 84 Long/Lat (<code>urn:ogc:def:crs:OGC::CRS84</code>) is used. Please refer to [[GeoSPARQL]] <strong>Requirement 11</strong> for more details.</p>
@@ -3577,7 +3603,7 @@ GID,On Street,Long,Lat,Species,Trim Cycle,Diameter at Breast Ht,Inventory Date,C
       <p>The first table is a matrix of the common formats, showing in general terms how well these
         formats help achieve goals such as discoverability, granularity etc. </p>
       <table id="x-ref_formatVbp">
-        <caption>An attempt at matrix of the common formats (GeoJSON, GML, RDF, JSON-LD) and what
+        <caption>An attempt at matrix of the common formats (GeoJSON, [[GML]], RDF, JSON-LD) and what
           you can or can't achieve with it. (<span style="background-color:yellow">source:
             @eparsons</span>)</caption>
         <tr>
@@ -3636,7 +3662,7 @@ GID,On Street,Long,Lat,Species,Trim Cycle,Diameter at Breast Ht,Inventory Date,C
           <td>Yes</td>
         </tr>
         <tr>
-          <td><a href="http://www.opengeospatial.org/standards/gml">GML</a></td>
+          <td>[[GML]]</td>
           <td>Open</td>
           <td>Text</td>
           <td>Geometry and attributes inline or xlinked</td>


### PR DESCRIPTION
- Corrected mispelled bib ref
- Corrected GeoJSON media type URI
- Added a note about open issues in the use of HTTP conneg on negotiation by profile
- Revised whole BP doc to use w3cgeo: and geosparql: as namespace prefixes for, respectively, W3C Basic Geo and GeoSPARQL
- Added prefix declarations to all examples in BP8
- Split Example 19 in BP8 in two distinct examples
- Fixed original Example 20: it included a reference to a no longer existing example
- Updated final note in BP8 to include in the list of things to do (a) guidelines on different levels of precision and (b) details on the use of WKT