### PR TITLE
Fixing SSN ISSUE-117

### DIFF
--- a/ssn/ssn_separated/dul-alignment.owl
+++ b/ssn/ssn_separated/dul-alignment.owl
@@ -192,6 +192,11 @@
                                      rdfs:subPropertyOf <http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#hasRegion> .
 
 
+###  http://www.w3.org/ns/ssn/wasOriginatedBy
+<http://www.w3.org/ns/ssn/wasOriginatedBy> rdf:type owl:ObjectProperty ;
+                                     rdfs:subPropertyOf <http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#includesEvent> .
+
+
 #################################################################
 #    Classes
 #################################################################

--- a/ssn/ssn_separated/dul-alignment.ttl
+++ b/ssn/ssn_separated/dul-alignment.ttl
@@ -2,6 +2,7 @@
 @prefix dul: <http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix ssn: <http://www.w3.org/ns/ssn/> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -79,118 +80,118 @@ dul:satisfies rdf:type owl:ObjectProperty .
 
 
 ###  http://www.w3.org/ns/ssn/attachedSystem
-<http://www.w3.org/ns/ssn/attachedSystem> rdf:type owl:ObjectProperty ;
-                                          rdfs:subPropertyOf dul:isLocationOf .
+ssn:attachedSystem rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf dul:isLocationOf .
 
 
 ###  http://www.w3.org/ns/ssn/deployedOnPlatform
-<http://www.w3.org/ns/ssn/deployedOnPlatform> rdf:type owl:ObjectProperty ;
-                                              rdfs:subPropertyOf dul:hasParticipant .
+ssn:deployedOnPlatform rdf:type owl:ObjectProperty ;
+                       rdfs:subPropertyOf dul:hasParticipant .
 
 
 ###  http://www.w3.org/ns/ssn/deployedSystem
-<http://www.w3.org/ns/ssn/deployedSystem> rdf:type owl:ObjectProperty ;
-                                          rdfs:subPropertyOf dul:hasParticipant .
+ssn:deployedSystem rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf dul:hasParticipant .
 
 
 ###  http://www.w3.org/ns/ssn/deploymentProcessPart
-<http://www.w3.org/ns/ssn/deploymentProcessPart> rdf:type owl:ObjectProperty ;
-                                                 rdfs:subPropertyOf dul:hasPart .
+ssn:deploymentProcessPart rdf:type owl:ObjectProperty ;
+                          rdfs:subPropertyOf dul:hasPart .
 
 
 ###  http://www.w3.org/ns/ssn/endTime
-<http://www.w3.org/ns/ssn/endTime> rdf:type owl:ObjectProperty ;
-                                   rdfs:subPropertyOf dul:hasRegion .
+ssn:endTime rdf:type owl:ObjectProperty ;
+            rdfs:subPropertyOf dul:hasRegion .
 
 
 ###  http://www.w3.org/ns/ssn/featureOfInterest
-<http://www.w3.org/ns/ssn/featureOfInterest> rdf:type owl:ObjectProperty ;
-                                             rdfs:subPropertyOf dul:isSettingFor .
+ssn:featureOfInterest rdf:type owl:ObjectProperty ;
+                      rdfs:subPropertyOf dul:isSettingFor .
 
 
 ###  http://www.w3.org/ns/ssn/hasDeployment
-<http://www.w3.org/ns/ssn/hasDeployment> rdf:type owl:ObjectProperty ;
-                                         rdfs:subPropertyOf dul:isParticipantIn .
+ssn:hasDeployment rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf dul:isParticipantIn .
 
 
 ###  http://www.w3.org/ns/ssn/hasProperty
-<http://www.w3.org/ns/ssn/hasProperty> rdf:type owl:ObjectProperty ;
-                                       rdfs:subPropertyOf dul:hasQuality .
+ssn:hasProperty rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf dul:hasQuality .
 
 
 ###  http://www.w3.org/ns/ssn/hasSubSystem
-<http://www.w3.org/ns/ssn/hasSubSystem> rdf:type owl:ObjectProperty ;
-                                        rdfs:subPropertyOf dul:hasPart .
+ssn:hasSubSystem rdf:type owl:ObjectProperty ;
+                 rdfs:subPropertyOf dul:hasPart .
 
 
 ###  http://www.w3.org/ns/ssn/hasValue
-<http://www.w3.org/ns/ssn/hasValue> rdf:type owl:ObjectProperty ;
-                                    rdfs:subPropertyOf dul:hasRegion .
+ssn:hasValue rdf:type owl:ObjectProperty ;
+             rdfs:subPropertyOf dul:hasRegion .
 
 
 ###  http://www.w3.org/ns/ssn/implementedBy
-<http://www.w3.org/ns/ssn/implementedBy> rdf:type owl:ObjectProperty ;
-                                         rdfs:subPropertyOf dul:describes .
+ssn:implementedBy rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf dul:describes .
 
 
 ###  http://www.w3.org/ns/ssn/implements
-<http://www.w3.org/ns/ssn/implements> rdf:type owl:ObjectProperty ;
-                                      rdfs:subPropertyOf dul:isDescribedBy .
+ssn:implements rdf:type owl:ObjectProperty ;
+               rdfs:subPropertyOf dul:isDescribedBy .
 
 
 ###  http://www.w3.org/ns/ssn/inDeployment
-<http://www.w3.org/ns/ssn/inDeployment> rdf:type owl:ObjectProperty ;
-                                        rdfs:subPropertyOf dul:isParticipantIn .
+ssn:inDeployment rdf:type owl:ObjectProperty ;
+                 rdfs:subPropertyOf dul:isParticipantIn .
 
 
 ###  http://www.w3.org/ns/ssn/isPropertyOf
-<http://www.w3.org/ns/ssn/isPropertyOf> rdf:type owl:ObjectProperty ;
-                                        rdfs:subPropertyOf dul:isQualityOf .
+ssn:isPropertyOf rdf:type owl:ObjectProperty ;
+                 rdfs:subPropertyOf dul:isQualityOf .
 
 
 ###  http://www.w3.org/ns/ssn/madeObservation
-<http://www.w3.org/ns/ssn/madeObservation> rdf:type owl:ObjectProperty ;
-                                           rdfs:subPropertyOf dul:isObjectIncludedIn .
+ssn:madeObservation rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf dul:isObjectIncludedIn .
 
 
 ###  http://www.w3.org/ns/ssn/observationResult
-<http://www.w3.org/ns/ssn/observationResult> rdf:type owl:ObjectProperty ;
-                                             rdfs:subPropertyOf dul:isSettingFor .
+ssn:observationResult rdf:type owl:ObjectProperty ;
+                      rdfs:subPropertyOf dul:isSettingFor .
 
 
 ###  http://www.w3.org/ns/ssn/observationResultTime
-<http://www.w3.org/ns/ssn/observationResultTime> rdf:type owl:ObjectProperty ;
-                                                 rdfs:subPropertyOf dul:hasRegion .
+ssn:observationResultTime rdf:type owl:ObjectProperty ;
+                          rdfs:subPropertyOf dul:hasRegion .
 
 
 ###  http://www.w3.org/ns/ssn/observationSamplingTime
-<http://www.w3.org/ns/ssn/observationSamplingTime> rdf:type owl:ObjectProperty ;
-                                                   rdfs:subPropertyOf dul:hasRegion .
+ssn:observationSamplingTime rdf:type owl:ObjectProperty ;
+                            rdfs:subPropertyOf dul:hasRegion .
 
 
 ###  http://www.w3.org/ns/ssn/observedBy
-<http://www.w3.org/ns/ssn/observedBy> rdf:type owl:ObjectProperty ;
-                                      rdfs:subPropertyOf dul:includesObject .
+ssn:observedBy rdf:type owl:ObjectProperty ;
+               rdfs:subPropertyOf dul:includesObject .
 
 
 ###  http://www.w3.org/ns/ssn/observedProperty
-<http://www.w3.org/ns/ssn/observedProperty> rdf:type owl:ObjectProperty ;
-                                            rdfs:subPropertyOf dul:isSettingFor .
+ssn:observedProperty rdf:type owl:ObjectProperty ;
+                     rdfs:subPropertyOf dul:isSettingFor .
 
 
 ###  http://www.w3.org/ns/ssn/onPlatform
-<http://www.w3.org/ns/ssn/onPlatform> rdf:type owl:ObjectProperty ;
-                                      rdfs:subPropertyOf dul:hasLocation .
+ssn:onPlatform rdf:type owl:ObjectProperty ;
+               rdfs:subPropertyOf dul:hasLocation .
 
 
 ###  http://www.w3.org/ns/ssn/sensingMethodUsed
-<http://www.w3.org/ns/ssn/sensingMethodUsed> rdf:type owl:ObjectProperty ;
-                                             rdfs:subPropertyOf dul:satisfies .
+ssn:sensingMethodUsed rdf:type owl:ObjectProperty ;
+                      rdfs:subPropertyOf dul:satisfies .
 
 
 ###  http://www.w3.org/ns/ssn/startTime
-<http://www.w3.org/ns/ssn/startTime> rdf:type owl:ObjectProperty ;
-                                     rdfs:subPropertyOf dul:hasRegion .
+ssn:startTime rdf:type owl:ObjectProperty ;
+              rdfs:subPropertyOf dul:hasRegion .
 
 
 #################################################################
@@ -238,82 +239,82 @@ dul:Situation rdf:type owl:Class .
 
 
 ###  http://www.w3.org/ns/ssn/DeploymentRelatedProcess
-<http://www.w3.org/ns/ssn/DeploymentRelatedProcess> rdf:type owl:Class ;
-                                                    rdfs:subClassOf dul:Process .
+ssn:DeploymentRelatedProcess rdf:type owl:Class ;
+                             rdfs:subClassOf dul:Process .
 
 
 ###  http://www.w3.org/ns/ssn/Device
-<http://www.w3.org/ns/ssn/Device> rdf:type owl:Class ;
-                                  rdfs:subClassOf dul:DesignedArtifact .
+ssn:Device rdf:type owl:Class ;
+           rdfs:subClassOf dul:DesignedArtifact .
 
 
 ###  http://www.w3.org/ns/ssn/FeatureOfInterest
-<http://www.w3.org/ns/ssn/FeatureOfInterest> rdf:type owl:Class ;
-                                             rdfs:subClassOf [ rdf:type owl:Class ;
-                                                               owl:unionOf ( dul:Event
-                                                                             dul:Object
-                                                                           )
-                                                             ] .
+ssn:FeatureOfInterest rdf:type owl:Class ;
+                      rdfs:subClassOf [ rdf:type owl:Class ;
+                                        owl:unionOf ( dul:Event
+                                                      dul:Object
+                                                    )
+                                      ] .
 
 
 ###  http://www.w3.org/ns/ssn/Observation
-<http://www.w3.org/ns/ssn/Observation> rdf:type owl:Class ;
-                                       rdfs:subClassOf dul:Situation ,
-                                                       [ rdf:type owl:Restriction ;
-                                                         owl:onProperty dul:includesEvent ;
-                                                         owl:someValuesFrom <http://www.w3.org/ns/ssn/Stimulus>
-                                                       ] .
+ssn:Observation rdf:type owl:Class ;
+                rdfs:subClassOf dul:Situation ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty dul:includesEvent ;
+                                  owl:someValuesFrom ssn:Stimulus
+                                ] .
 
 
 ###  http://www.w3.org/ns/ssn/ObservationValue
-<http://www.w3.org/ns/ssn/ObservationValue> rdf:type owl:Class ;
-                                            rdfs:subClassOf dul:Region ,
-                                                            [ rdf:type owl:Restriction ;
-                                                              owl:onProperty dul:isRegionFor ;
-                                                              owl:someValuesFrom <http://www.w3.org/ns/ssn/SensorOutput>
-                                                            ] .
+ssn:ObservationValue rdf:type owl:Class ;
+                     rdfs:subClassOf dul:Region ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty dul:isRegionFor ;
+                                       owl:someValuesFrom ssn:SensorOutput
+                                     ] .
 
 
 ###  http://www.w3.org/ns/ssn/Platform
-<http://www.w3.org/ns/ssn/Platform> rdf:type owl:Class ;
-                                    rdfs:subClassOf dul:PhysicalObject .
+ssn:Platform rdf:type owl:Class ;
+             rdfs:subClassOf dul:PhysicalObject .
 
 
 ###  http://www.w3.org/ns/ssn/Process
-<http://www.w3.org/ns/ssn/Process> rdf:type owl:Class ;
-                                   rdfs:subClassOf dul:Method .
+ssn:Process rdf:type owl:Class ;
+            rdfs:subClassOf dul:Method .
 
 
 ###  http://www.w3.org/ns/ssn/Property
-<http://www.w3.org/ns/ssn/Property> rdf:type owl:Class ;
-                                    rdfs:subClassOf dul:Quality .
+ssn:Property rdf:type owl:Class ;
+             rdfs:subClassOf dul:Quality .
 
 
 ###  http://www.w3.org/ns/ssn/Sensor
-<http://www.w3.org/ns/ssn/Sensor> rdf:type owl:Class ;
-                                  rdfs:subClassOf dul:Object .
+ssn:Sensor rdf:type owl:Class ;
+           rdfs:subClassOf dul:Object .
 
 
 ###  http://www.w3.org/ns/ssn/SensorDataSheet
-<http://www.w3.org/ns/ssn/SensorDataSheet> rdf:type owl:Class ;
-                                           rdfs:subClassOf dul:InformationObject .
+ssn:SensorDataSheet rdf:type owl:Class ;
+                    rdfs:subClassOf dul:InformationObject .
 
 
 ###  http://www.w3.org/ns/ssn/SensorInput
-<http://www.w3.org/ns/ssn/SensorInput> rdf:type owl:Class ;
-                                       rdfs:subClassOf dul:Event .
+ssn:SensorInput rdf:type owl:Class ;
+                rdfs:subClassOf dul:Event .
 
 
 ###  http://www.w3.org/ns/ssn/SensorOutput
-<http://www.w3.org/ns/ssn/SensorOutput> rdf:type owl:Class ;
-                                        rdfs:subClassOf dul:Object .
+ssn:SensorOutput rdf:type owl:Class ;
+                 rdfs:subClassOf dul:Object .
 
 
 ###  http://www.w3.org/ns/ssn/Stimulus
-<http://www.w3.org/ns/ssn/Stimulus> rdf:type owl:Class ;
-                                    rdfs:subClassOf dul:Event .
+ssn:Stimulus rdf:type owl:Class ;
+             rdfs:subClassOf dul:Event .
 
 
 ###  http://www.w3.org/ns/ssn/System
-<http://www.w3.org/ns/ssn/System> rdf:type owl:Class ;
-                                  rdfs:subClassOf dul:PhysicalObject .
+ssn:System rdf:type owl:Class ;
+           rdfs:subClassOf dul:PhysicalObject .

--- a/ssn/ssn_separated/dul-alignment.ttl
+++ b/ssn/ssn_separated/dul-alignment.ttl
@@ -1,0 +1,319 @@
+@prefix : <https://www.w3.org/ns/ssn/dul#> .
+@prefix dul: <http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@base <https://www.w3.org/ns/ssn/dul> .
+
+<https://www.w3.org/ns/ssn/dul> rdf:type owl:Ontology ;
+                                 owl:imports <http://www.ontologydesignpatterns.org/ont/dul/DUL.owl> .
+
+#################################################################
+#    Object Properties
+#################################################################
+
+###  http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#describes
+dul:describes rdf:type owl:ObjectProperty .
+
+
+###  http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#hasLocation
+dul:hasLocation rdf:type owl:ObjectProperty .
+
+
+###  http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#hasPart
+dul:hasPart rdf:type owl:ObjectProperty .
+
+
+###  http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#hasParticipant
+dul:hasParticipant rdf:type owl:ObjectProperty .
+
+
+###  http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#hasQuality
+dul:hasQuality rdf:type owl:ObjectProperty .
+
+
+###  http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#hasRegion
+dul:hasRegion rdf:type owl:ObjectProperty .
+
+
+###  http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#includesEvent
+dul:includesEvent rdf:type owl:ObjectProperty .
+
+
+###  http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#includesObject
+dul:includesObject rdf:type owl:ObjectProperty .
+
+
+###  http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#isDescribedBy
+dul:isDescribedBy rdf:type owl:ObjectProperty .
+
+
+###  http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#isLocationOf
+dul:isLocationOf rdf:type owl:ObjectProperty .
+
+
+###  http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#isObjectIncludedIn
+dul:isObjectIncludedIn rdf:type owl:ObjectProperty .
+
+
+###  http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#isParticipantIn
+dul:isParticipantIn rdf:type owl:ObjectProperty .
+
+
+###  http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#isQualityOf
+dul:isQualityOf rdf:type owl:ObjectProperty .
+
+
+###  http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#isRegionFor
+dul:isRegionFor rdf:type owl:ObjectProperty .
+
+
+###  http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#isSettingFor
+dul:isSettingFor rdf:type owl:ObjectProperty .
+
+
+###  http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#satisfies
+dul:satisfies rdf:type owl:ObjectProperty .
+
+
+###  http://www.w3.org/ns/ssn/attachedSystem
+<http://www.w3.org/ns/ssn/attachedSystem> rdf:type owl:ObjectProperty ;
+                                          rdfs:subPropertyOf dul:isLocationOf .
+
+
+###  http://www.w3.org/ns/ssn/deployedOnPlatform
+<http://www.w3.org/ns/ssn/deployedOnPlatform> rdf:type owl:ObjectProperty ;
+                                              rdfs:subPropertyOf dul:hasParticipant .
+
+
+###  http://www.w3.org/ns/ssn/deployedSystem
+<http://www.w3.org/ns/ssn/deployedSystem> rdf:type owl:ObjectProperty ;
+                                          rdfs:subPropertyOf dul:hasParticipant .
+
+
+###  http://www.w3.org/ns/ssn/deploymentProcessPart
+<http://www.w3.org/ns/ssn/deploymentProcessPart> rdf:type owl:ObjectProperty ;
+                                                 rdfs:subPropertyOf dul:hasPart .
+
+
+###  http://www.w3.org/ns/ssn/endTime
+<http://www.w3.org/ns/ssn/endTime> rdf:type owl:ObjectProperty ;
+                                   rdfs:subPropertyOf dul:hasRegion .
+
+
+###  http://www.w3.org/ns/ssn/featureOfInterest
+<http://www.w3.org/ns/ssn/featureOfInterest> rdf:type owl:ObjectProperty ;
+                                             rdfs:subPropertyOf dul:isSettingFor .
+
+
+###  http://www.w3.org/ns/ssn/hasDeployment
+<http://www.w3.org/ns/ssn/hasDeployment> rdf:type owl:ObjectProperty ;
+                                         rdfs:subPropertyOf dul:isParticipantIn .
+
+
+###  http://www.w3.org/ns/ssn/hasProperty
+<http://www.w3.org/ns/ssn/hasProperty> rdf:type owl:ObjectProperty ;
+                                       rdfs:subPropertyOf dul:hasQuality .
+
+
+###  http://www.w3.org/ns/ssn/hasSubSystem
+<http://www.w3.org/ns/ssn/hasSubSystem> rdf:type owl:ObjectProperty ;
+                                        rdfs:subPropertyOf dul:hasPart .
+
+
+###  http://www.w3.org/ns/ssn/hasValue
+<http://www.w3.org/ns/ssn/hasValue> rdf:type owl:ObjectProperty ;
+                                    rdfs:subPropertyOf dul:hasRegion .
+
+
+###  http://www.w3.org/ns/ssn/implementedBy
+<http://www.w3.org/ns/ssn/implementedBy> rdf:type owl:ObjectProperty ;
+                                         rdfs:subPropertyOf dul:describes .
+
+
+###  http://www.w3.org/ns/ssn/implements
+<http://www.w3.org/ns/ssn/implements> rdf:type owl:ObjectProperty ;
+                                      rdfs:subPropertyOf dul:isDescribedBy .
+
+
+###  http://www.w3.org/ns/ssn/inDeployment
+<http://www.w3.org/ns/ssn/inDeployment> rdf:type owl:ObjectProperty ;
+                                        rdfs:subPropertyOf dul:isParticipantIn .
+
+
+###  http://www.w3.org/ns/ssn/isPropertyOf
+<http://www.w3.org/ns/ssn/isPropertyOf> rdf:type owl:ObjectProperty ;
+                                        rdfs:subPropertyOf dul:isQualityOf .
+
+
+###  http://www.w3.org/ns/ssn/madeObservation
+<http://www.w3.org/ns/ssn/madeObservation> rdf:type owl:ObjectProperty ;
+                                           rdfs:subPropertyOf dul:isObjectIncludedIn .
+
+
+###  http://www.w3.org/ns/ssn/observationResult
+<http://www.w3.org/ns/ssn/observationResult> rdf:type owl:ObjectProperty ;
+                                             rdfs:subPropertyOf dul:isSettingFor .
+
+
+###  http://www.w3.org/ns/ssn/observationResultTime
+<http://www.w3.org/ns/ssn/observationResultTime> rdf:type owl:ObjectProperty ;
+                                                 rdfs:subPropertyOf dul:hasRegion .
+
+
+###  http://www.w3.org/ns/ssn/observationSamplingTime
+<http://www.w3.org/ns/ssn/observationSamplingTime> rdf:type owl:ObjectProperty ;
+                                                   rdfs:subPropertyOf dul:hasRegion .
+
+
+###  http://www.w3.org/ns/ssn/observedBy
+<http://www.w3.org/ns/ssn/observedBy> rdf:type owl:ObjectProperty ;
+                                      rdfs:subPropertyOf dul:includesObject .
+
+
+###  http://www.w3.org/ns/ssn/observedProperty
+<http://www.w3.org/ns/ssn/observedProperty> rdf:type owl:ObjectProperty ;
+                                            rdfs:subPropertyOf dul:isSettingFor .
+
+
+###  http://www.w3.org/ns/ssn/onPlatform
+<http://www.w3.org/ns/ssn/onPlatform> rdf:type owl:ObjectProperty ;
+                                      rdfs:subPropertyOf dul:hasLocation .
+
+
+###  http://www.w3.org/ns/ssn/sensingMethodUsed
+<http://www.w3.org/ns/ssn/sensingMethodUsed> rdf:type owl:ObjectProperty ;
+                                             rdfs:subPropertyOf dul:satisfies .
+
+
+###  http://www.w3.org/ns/ssn/startTime
+<http://www.w3.org/ns/ssn/startTime> rdf:type owl:ObjectProperty ;
+                                     rdfs:subPropertyOf dul:hasRegion .
+
+
+#################################################################
+#    Classes
+#################################################################
+
+###  http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#DesignedArtifact
+dul:DesignedArtifact rdf:type owl:Class .
+
+
+###  http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Event
+dul:Event rdf:type owl:Class .
+
+
+###  http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#InformationObject
+dul:InformationObject rdf:type owl:Class .
+
+
+###  http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Method
+dul:Method rdf:type owl:Class .
+
+
+###  http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Object
+dul:Object rdf:type owl:Class .
+
+
+###  http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#PhysicalObject
+dul:PhysicalObject rdf:type owl:Class .
+
+
+###  http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Process
+dul:Process rdf:type owl:Class .
+
+
+###  http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Quality
+dul:Quality rdf:type owl:Class .
+
+
+###  http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Region
+dul:Region rdf:type owl:Class .
+
+
+###  http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Situation
+dul:Situation rdf:type owl:Class .
+
+
+###  http://www.w3.org/ns/ssn/DeploymentRelatedProcess
+<http://www.w3.org/ns/ssn/DeploymentRelatedProcess> rdf:type owl:Class ;
+                                                    rdfs:subClassOf dul:Process .
+
+
+###  http://www.w3.org/ns/ssn/Device
+<http://www.w3.org/ns/ssn/Device> rdf:type owl:Class ;
+                                  rdfs:subClassOf dul:DesignedArtifact .
+
+
+###  http://www.w3.org/ns/ssn/FeatureOfInterest
+<http://www.w3.org/ns/ssn/FeatureOfInterest> rdf:type owl:Class ;
+                                             rdfs:subClassOf [ rdf:type owl:Class ;
+                                                               owl:unionOf ( dul:Event
+                                                                             dul:Object
+                                                                           )
+                                                             ] .
+
+
+###  http://www.w3.org/ns/ssn/Observation
+<http://www.w3.org/ns/ssn/Observation> rdf:type owl:Class ;
+                                       rdfs:subClassOf dul:Situation ,
+                                                       [ rdf:type owl:Restriction ;
+                                                         owl:onProperty dul:includesEvent ;
+                                                         owl:someValuesFrom <http://www.w3.org/ns/ssn/Stimulus>
+                                                       ] .
+
+
+###  http://www.w3.org/ns/ssn/ObservationValue
+<http://www.w3.org/ns/ssn/ObservationValue> rdf:type owl:Class ;
+                                            rdfs:subClassOf dul:Region ,
+                                                            [ rdf:type owl:Restriction ;
+                                                              owl:onProperty dul:isRegionFor ;
+                                                              owl:someValuesFrom <http://www.w3.org/ns/ssn/SensorOutput>
+                                                            ] .
+
+
+###  http://www.w3.org/ns/ssn/Platform
+<http://www.w3.org/ns/ssn/Platform> rdf:type owl:Class ;
+                                    rdfs:subClassOf dul:PhysicalObject .
+
+
+###  http://www.w3.org/ns/ssn/Process
+<http://www.w3.org/ns/ssn/Process> rdf:type owl:Class ;
+                                   rdfs:subClassOf dul:Method .
+
+
+###  http://www.w3.org/ns/ssn/Property
+<http://www.w3.org/ns/ssn/Property> rdf:type owl:Class ;
+                                    rdfs:subClassOf dul:Quality .
+
+
+###  http://www.w3.org/ns/ssn/Sensor
+<http://www.w3.org/ns/ssn/Sensor> rdf:type owl:Class ;
+                                  rdfs:subClassOf dul:Object .
+
+
+###  http://www.w3.org/ns/ssn/SensorDataSheet
+<http://www.w3.org/ns/ssn/SensorDataSheet> rdf:type owl:Class ;
+                                           rdfs:subClassOf dul:InformationObject .
+
+
+###  http://www.w3.org/ns/ssn/SensorInput
+<http://www.w3.org/ns/ssn/SensorInput> rdf:type owl:Class ;
+                                       rdfs:subClassOf dul:Event .
+
+
+###  http://www.w3.org/ns/ssn/SensorOutput
+<http://www.w3.org/ns/ssn/SensorOutput> rdf:type owl:Class ;
+                                        rdfs:subClassOf dul:Object .
+
+
+###  http://www.w3.org/ns/ssn/Stimulus
+<http://www.w3.org/ns/ssn/Stimulus> rdf:type owl:Class ;
+                                    rdfs:subClassOf dul:Event .
+
+
+###  http://www.w3.org/ns/ssn/System
+<http://www.w3.org/ns/ssn/System> rdf:type owl:Class ;
+                                  rdfs:subClassOf dul:PhysicalObject .

--- a/ssn/ssn_separated/dul-alignment.ttl
+++ b/ssn/ssn_separated/dul-alignment.ttl
@@ -194,6 +194,11 @@ ssn:startTime rdf:type owl:ObjectProperty ;
               rdfs:subPropertyOf dul:hasRegion .
 
 
+### http://www.w3.org/ns/ssn/wasOriginatedBy
+ssn:wasOriginatedBy rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf dul:includesEvent .
+
+
 #################################################################
 #    Classes
 #################################################################

--- a/ssn/ssn_separated/ssn.ttl
+++ b/ssn/ssn_separated/ssn.ttl
@@ -451,6 +451,13 @@ ssn:startTime rdf:type owl:ObjectProperty ;
               rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Base#Time" .
 
 
+### http://www.w3.org/ns/ssn/wasOriginatedBy
+ssn:wasOriginatedBy rdf:type owl:ObjectProperty ;
+                    rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
+                    rdfs:comment "Relation between an Observation and the Stimulus that originated it." ;
+                    rdfs:label "was originated by" ;
+                    rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" .
+
 #################################################################
 #    Classes
 #################################################################
@@ -661,6 +668,10 @@ ssn:Observation rdf:type owl:Class ;
                                 [ rdf:type owl:Restriction ;
                                   owl:onProperty ssn:sensingMethodUsed ;
                                   owl:allValuesFrom ssn:Sensing
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty ssn:wasOriginatedBy ;
+                                  owl:someValuesFrom ssn:Stimulus
                                 ] ,
                                 [ rdf:type owl:Restriction ;
                                   owl:onProperty ssn:observationResultTime ;


### PR DESCRIPTION
Fixing issue 117 by adding the ssn:wasOriginatedBy property, the corresponding restriction in Observation, and the DUL alignment.
Also added a file with the DUL alignment in Turtle format with .ttl extension and prefixes.
