### PR TITLE
[BP] Fix "sameAs" example title

### DIFF
--- a/bp/index.html
+++ b/bp/index.html
@@ -2875,7 +2875,7 @@ geonames:2650225 owl:sameAs ukgov-stat:S12000036 .
                 <p>Publish your links to a third-party service.</p>
                 <p>Because the links we define use global identifiers for both the source and target resources, they do not need any context to be useful (e.g. one doesn't need any prior knowledge to determine that the URI <a href="http://dbpedia.org/resource/Anne_Frank_House"><code>http://dbpedia.org/resource/Anne_Frank_House</code></a> identifies Anne Frank's House). This means that our links can be published independently from the datasets where they were originally defined.</p>
                 <p>The service <a href="http://sameas.org">&lt;sameAs&gt;</a> provides an example of this in practice &mdash; albeit only for links using the <code>owl:sameAs</code> relation type. The HTTP GET request <a href="http://sameas.org/store/freebase/n3?uri=%3Chttp%3A%2F%2Frdf.freebase.com%2Fns%2Fm.02s5hd%3E"><code>http://sameas.org/store/freebase/n3?uri=&lt;http://rdf.freebase.com/ns/m.02s5hd&gt;</code></a> produces the following result in [[N-TRIPLES]] format:</p>
-                <pre class="example" id="ex-linking-sameas-service" title="Discovering links from the &lt;sameAs> service ([N-TRIPLES] format)">
+                <pre class="example" id="ex-linking-sameas-service" title="Discovering links from the &amp;lt;sameAs> service ([N-TRIPLES] format)">
 HTTP/1.1 200 OK
 Connection:close
 Content-Length:864


### PR DESCRIPTION
It turns out that the escaping issue in ReSpec is a feature, not a bug, see:
https://github.com/w3c/respec/issues/1173

This commit updates the "sameAs" example to use double-escaping to produce the `<` character.