### PR TITLE
12.2 BP5 Positional accuracy

### DIFF
--- a/bp/index.html
+++ b/bp/index.html
@@ -1162,10 +1162,20 @@ a:Dataset a dcat:Dataset ;
           used. This can be seen as conformance of data with a "standard" - in this case, a (spatial
           or temporal) reference system. This is how you can describe spatial data quality using
           different vocabularies. We will provide an example in this section. </p>
-        <div class="practice">
+	      <p>For some uses, it may be sufficient to simply state conformance to a published specification</p>
+            <pre class="example" id="ex-geodcat-ap-dataset-conformance-with-specification" title="GeoDCAT-AP specification of a dataset conformance with the INSPIRE Regulation on spatial data and services interoperability">a:Dataset a dcat:Dataset ;
+  dct:conformsTo &lt;<a href="http://data.europa.eu/eli/reg/2010/1089/oj">http://data.europa.eu/eli/reg/2010/1089/oj</a>&gt; .
+
+&lt;<a href="http://data.europa.eu/eli/reg/2010/1089/oj">http://data.europa.eu/eli/reg/2010/1089/oj</a>&gt; a dct:Standard , foaf:Document ;
+  dct:title "COMMISSION REGULATION (EU) No 1089/2010 of 23 November 2010
+             implementing Directive 2007/2/EC of the European Parliament
+             and of the Council as regards interoperability of spatial
+             data sets and services"@en ;
+  dct:issued "2010-12-08"^^xsd:date .</pre>
+	  <div class="practice">
           <p><span id="desc-accuracy" class="practicelab">Describe the positional accuracy of
               spatial data</span></p>
-          <p class="practicedesc">Accuracy and precision of spatial data should be specified in
+          <p class="practicedesc">Accuracy of spatial data should be specified in
             machine-interpretable and human-readable form.</p>
           <section class="axioms">
             <h4 class="subhead">Why</h4>
@@ -1183,9 +1193,10 @@ a:Dataset a dcat:Dataset ;
           </section>
           <section class="outcome">
             <h4 class="subhead">Intended Outcome</h4>
-            <p>When known, the resolution and precision of spatial data should be specified in a way
-              to allow consumers of the data to be aware of the resolution and level of details that
-              are considered in the specifications.</p>
+            <p>For many uses, the positional accuracy of the data is an important aspect of assessing
+	      its fitness for purpose (quality).
+	      As with other data quality statements, this can be a quantitative measure, a statement 
+	      of conformance to a standard or policy, or an assertion or report of fitness for a particular purpose.</p>
           </section>
           <section class="how">
             <h4 class="subhead">Possible Approach to Implementation</h4>
@@ -1193,27 +1204,45 @@ a:Dataset a dcat:Dataset ;
             <p>In addition, describe the accuracy of spatial data in a machine-readable format.
               [[VOCAB-DQV]] is such a format. It is a vocabulary for describing data quality, including
               the details of quality metrics and measurements. </p>
+	    <p>For observed (measured) datasets, it is possible to make specific quantitative statements
+	      about positional accuracy, based on knowledge of the equipment used to make the observations,
+	      and any processing carried out.</p> 
+	    <p>For <a>coverages</a>, the sampling distance is an effective way of indicating the amount of
+	      detail in the dataset - this is one of the meanings of the term "resolution".
+	      Alternatively, samples of the data could be independently checked against the real world, 
+	      and the results of that check reported.
+	      Either way, this is usually a statement of <a>absolute postional accuracy</a>, but for some uses, 
+	      relative positional accuracy is more important.</p>
+	    <p>Positional accuracy measurements, whether observed or asserted based on process,
+	      can be given using QualityMeasurement.</p>
+	    <p>For modelled datasets, for example in planning and construction, there is no 'real world' against
+	      which to assess the positional accuracy - but relative positional accuracy can still be stated.</p>
+	    <p>For many uses, a statement of the amount of detail provided is sufficient to assess fitness for purpose; 
+	      examples include "level of detail" (building models), "navigational purpose" (marine navigation),
+	      "equivalent scale" or "zoom level" (cartography).
+	      Sometimes, this is expressed as if it were a statement of positional accuracy.</p>
+	    <p>These can be expressed in the same way as for non-spatial data, using for example the QualityAnnotation,
+	      Standard, and QualityPolicy statements of [[VOCAB-DQV]].</p>
             <aside class="example">
-              <p>example(s) to be added; including:</p>
+              <p>examples:</p>
               <ul>
                 <li>second quarter of the 9th century is <em>approx.</em> 825-850 but could be
                   823-852</li>
                 <li>the ends of a 'sampling traverse' could be known in a national/global CRS to
                   within ±5m, whilst the position of the samples themselves may be accurate to ±0.01
                   along the traverse</li>
-                <li>describe spatial data quality with [[VOCAB-DQV]] and [[GeoDCAT-AP]].</li>
+                <li>a hydrographic survey may conform to the 'special order' survey specification in IHO S-44</li>
+		<li>a coverage dataset may have a ground sampling distance of 1 000m</li>
               </ul>
             </aside>
-            <pre class="example" id="ex-geodcat-ap-dataset-conformance-with-specification" title="GeoDCAT-AP specification of a dataset conformance with the INSPIRE Regulation on spatial data and services interoperability">a:Dataset a dcat:Dataset ;
-  dct:conformsTo &lt;<a href="http://data.europa.eu/eli/reg/2010/1089/oj">http://data.europa.eu/eli/reg/2010/1089/oj</a>&gt; .
+	    <p>The following example shows how DQV can express conformance to a specified positional accuracy</p>
+            <pre class="example" id="ex-geodcat-ap-dataset-conformance-with-specification2" title="GeoDCAT-AP specification of a dataset conformance with IHO's S44">a:Dataset a dcat:Dataset ;
+  dct:conformsTo &lt;<a href="https://www.iho.int/iho_pubs/standard/S-44_5E.pdf">https://www.iho.int/iho_pubs/standard/S-44_5E.pdf#Special</a>&gt; .
 
-&lt;<a href="http://data.europa.eu/eli/reg/2010/1089/oj">http://data.europa.eu/eli/reg/2010/1089/oj</a>&gt; a dct:Standard , foaf:Document ;
-  dct:title "COMMISSION REGULATION (EU) No 1089/2010 of 23 November 2010
-             implementing Directive 2007/2/EC of the European Parliament
-             and of the Council as regards interoperability of spatial
-             data sets and services"@en ;
-  dct:issued "2010-12-08"^^xsd:date .</pre>
-            <p>The following example shows how DQV can express the precision of a spatial dataset: </p>
+&lt;<a href="https://www.iho.int/iho_pubs/standard/S-44_5E.pdf">https://www.iho.int/iho_pubs/standard/S-44_5E.pdf</a>&gt; a dct:Standard , foaf:Document ;
+  dct:title "IHO Standards for Hydrographic Surveys"@en ;
+  dct:issued "2008-02-01"^^xsd:date.</pre>
+            <p>The following example shows how DQV can express the amount of detail in a coverage dataset: </p>
             <pre class="example" id="ex-dqv-dataset-quality" title="DQV specification of data quality">
 :myDataset a dcat:Dataset ;
    dqv:hasQualityMeasurement :myDatasetPrecision, :myDatasetAccuracy .
@@ -1238,7 +1267,9 @@ a:Dataset a dcat:Dataset ;
           </section>
           <section class="test">
             <h4 class="subhead">How to Test</h4>
-            <p>...</p>
+            <p>Check if the metadata contains at least one human and machine readable statement regarding positional accuracy </p>
+	    <p>Check that the kind of statement is relevant to the kind of data, e.g. not an absolute positional accuracy measure for Atlantis</p>
+	    <p>Checking that the accuracy statement is actually correct is beyond the scope of this best practice.</p>
           </section>
           <section class="ucr">
             <h4 class="subhead">Evidence</h4>

--- a/bp/index.html
+++ b/bp/index.html
@@ -1162,7 +1162,7 @@ a:Dataset a dcat:Dataset ;
           used. This can be seen as conformance of data with a "standard" - in this case, a (spatial
           or temporal) reference system. This is how you can describe spatial data quality using
           different vocabularies. We will provide an example in this section. </p>
-	      <p>For some uses, it may be sufficient to simply state conformance to a published specification</p>
+	      <p>For some uses, it may be sufficient to simply state conformance to a published specification:</p>
             <pre class="example" id="ex-geodcat-ap-dataset-conformance-with-specification" title="GeoDCAT-AP specification of a dataset conformance with the INSPIRE Regulation on spatial data and services interoperability">a:Dataset a dcat:Dataset ;
   dct:conformsTo &lt;<a href="http://data.europa.eu/eli/reg/2010/1089/oj">http://data.europa.eu/eli/reg/2010/1089/oj</a>&gt; .
 
@@ -1211,7 +1211,7 @@ a:Dataset a dcat:Dataset ;
 	      detail in the dataset - this is one of the meanings of the term "resolution".
 	      Alternatively, samples of the data could be independently checked against the real world, 
 	      and the results of that check reported.
-	      Either way, this is usually a statement of <a>absolute postional accuracy</a>, but for some uses, 
+	      Either way, this is usually a statement of <a>absolute positional accuracy</a>, but for some uses, 
 	      relative positional accuracy is more important.</p>
 	    <p>Positional accuracy measurements, whether observed or asserted based on process,
 	      can be given using QualityMeasurement.</p>
@@ -3729,6 +3729,8 @@ GID,On Street,Long,Lat,Species,Trim Cycle,Diameter at Breast Ht,Inventory Date,C
           SPARQL)? Maybe WFS etc. should be added to the references, too, and the text should include
           a link both to the glossary and the references?</p>
       </div>
+	    <p><dfn data-lt="Absolute positional accuracy">absolute positional accuracy</dfn>: 
+		    closeness of reported coordinate values to values accepted as or being true (ISO 19159-2)</p>
       <p><dfn data-lt="Coverage|Coverages|Coverage Function">Coverage</dfn>: A coverage is a function that describe characteristics of real-world phenomena that vary over space and/or time. Typical examples are temperature, elevation and precipitation. A coverage is typically represented as a data structure containing a set of such values, each associated with one of the elements in a spatial, temporal or spatiotemporal domain. Typical spatial domains are point sets (e.g. sensor locations), curve sets (e.g. contour lines), grids (e.g. orthoimages, elevation models), etc. A property whose value varies as a function of time may be represented as a temporal coverage or time-series [[ISO-19109]] §8.8.</p>
       <p><dfn data-lt="CRS|Coordinate Reference System|Coordinate Reference Systems">Coordinate Reference System (CRS)</dfn>: A
         coordinate-based local, regional or global system used to locate geographical entities. Also known as <em>Spatial Reference System</em>.

--- a/index.html
+++ b/index.html
@@ -1,239 +1,3962 @@
-<!doctype html>
-<html>
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
-<style>
-*{margin:0;padding:0;}
-body {
-	font: 12px arial, helvetica,arial,freesans,clean,sans-serif;
-	color:black;
-	line-height:1.4em;
-	background-color: #F8F8F8;
-	padding: 0em 2em;
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta content="text/html; charset=utf-8" http-equiv="content-type" />
+    <title>Spatial Data on the Web Best Practices</title>
+    <script class="remove" src="https://www.w3.org/Tools/respec/respec-w3c-common"></script>
+    <script class="remove" src="bpconfig.js"></script>
+    <script>
+    window.onload=init;
+
+    function bpObject(t, id, reqs) {
+      this.title = t;
+      this.id = id;
+      reqsList = new Array();
+      for (var i = 0; i < reqs.length; i++) {
+        reqsList.push(reqs[i].hash.substring(1));
+      }
+      this.requirements = reqsList;
+    }
+
+    function createRequirementsTable(BPlist) {
+      var reqs = new Array();
+      var requirmentsTable = document.getElementById('x-ref_ucrVbp');
+      var tbody = requirmentsTable.getElementsByTagName('tbody')[0];
+      BPlist.forEach(function(bp){
+        bp.requirements.forEach(function(req){
+          if (reqs[req] !== undefined) {
+            reqs[req].push(bp);
+          }
+          else {
+            reqs.push(req);
+            reqs[req] = new Array();
+            reqs[req].push(bp);
+          }
+
+        });
+      });
+      reqs.forEach(function(req){
+        var row = tbody.insertRow(tbody.rows.length); // new row for the table
+        var cellReq = row.insertCell(0);              // cell for requirement
+        var cellBps = row.insertCell(1);              // cell for BPs
+        var reqLink = document.createElement('a');
+        reqLink.setAttribute('href', 'https://www.w3.org/TR/sdw-ucr/#'+req);
+        reqLink.appendChild(document.createTextNode(req));
+        cellReq.appendChild(reqLink);
+
+        reqs[req].forEach(function(bp){
+          var p = document.createElement('p');
+          var bpLink = document.createElement('a');
+          bpLink.setAttribute('href', '#'+bp.id);
+          bpLink.appendChild(document.createTextNode(bp.title));
+          p.appendChild(bpLink);
+          cellBps.appendChild(p);
+        });
+      });
+    }
+
+
+    function init() {
+      var BPlist = new Array (); // This will be our array of BPs from the document
+      var BPdivs = new Array ();
+      BPdivs = document.getElementsByClassName('practice'); // This is the info we have effectively scraped from the page
+      for (var i = 0; i < BPdivs.length; i++) {
+        var t; var id; var b; var reqs;
+        var BPtop = BPdivs[i].getElementsByClassName('practicelab');
+        t = BPtop[0].textContent; // There should only be values in BPtop[0]
+        id = BPtop[0].id;
+        reqs = BPdivs[i].getElementsByClassName('ucr')[0].getElementsByTagName('a');
+        BPlist.push(new bpObject(t, id, reqs));
+      }
+      createRequirementsTable(BPlist); // Call function to create Requirements Table
+    }
+
+// @andrea-perego
+function popCrossRefs() {
+  $('a[href^="#"]').each( function () {
+    var href = $(this).attr('href');
+    var id = href.trim().replace('#','');
+    var text = $(this).text();
+    if (text.trim().length == 0 && id.length > 0 && ( $(href).hasClass('example') || $(href).hasClass('practicelab') )) {
+      var label = $('.example:has(#' + id + ') > .example-title, *[id="' + id + '"].example > .example-title, *[id="' + id + '"].illegal-example > .example-title, *[id="' + id + '"].practicelab').text();
+      if (label.trim().length > 0) {
+        $(this).text(label);
+      }
+    }
+  } );
 }
 
-table {
-	font-size:inherit;
-	font:100%;
-	margin:1em;
-}
+$(document).ready( function() {
+  popCrossRefs();
+});
+// @andrea-perego
 
-p {
-	margin-bottom: 1em;
-}
+    </script>
+    <style type="text/css">
+      /* Force W3C logo to site side by side with OGC logo */
+      .head img[src*="logos/W3C"] {
+        display: inherit !important;
+      }
+      .head a:hover > img[src*='ogc'] {
+        opacity: 0.8;
+      }
 
-td {  
-  padding-left: 0.3em;
-}
+      #bp-summary ul{
+          list-style-type: none;
+          padding-left: 0;
+          line-height: 1.6em;
+          background-color: #FCFAEE;
+      }
 
-th {  
-  font-weight: bold;  
-  text-align: center;  
-  background-color: NavyBlue !important; 
-  font-size: 110%;
-  background: hsl(180, 30%, 50%); 
-  color: #fff;
-}
+      @media screen and (min-width : 600px){
+          #bp-summary ul{
+              column-count: 2;
+              -moz-column-count: 2;
+              -webkit-column-count: 2;
+              column-gap: 1em;
+          }
+      }
 
-th a:link {
-  color: #fff;
-}
+      .practice,
+      #tempPractice{
+          padding-left: 1em;
+          background-color: #FCFAEE;
+          border: thin solid black;
+      }
 
-th a:visited {
-  color: #aaa;
-}
+      #tempPractice .tempPracticelab{
+          background-color: #dfffff;
+          position: relative;
+          top: -1.5em;
+          font-weight: bold;
+      }
 
-tr:nth-child(even) { background-color: hsl(180, 30%, 93%) }
+      .practice p.practicedesc,
+      #tempPractice p.tempPracticedesc{
+          font-style: italic;
+          border-bottom: thin solid black;
+          position: relative;
+          top: -1.5em;
+          margin: 0 2em -1em 1em;
+          ;
+      }
 
-table th{border-bottom:1px solid #bbb;padding:.2em 1em;}
-table td{border-bottom:1px solid #ddd;padding:.2em 1em;}
+      .subhead{
+          font-weight: bold;
+      }
 
+      .practice dl dt #tempPractice dl dt{
+          font-weight: normal;
+      }
 
-select,option{padding:0 .25em;}
-optgroup{margin-top:.5em;}
+      figure{
+          text-align: center;
+      }
 
-pre,code{font:12px Monaco,"Courier New","DejaVu Sans Mono","Bitstream Vera Sans Mono",monospace;}
-pre {
-	margin:1em 0;
-	background-color:#eee;
-	border:1px solid #ddd;
-	padding:5px;
-	line-height:1.5em;
-	color:#444;
-	overflow:auto;
-	-webkit-box-shadow:rgba(0,0,0,0.07) 0 1px 2px inset;
-	-webkit-border-radius:3px;
-	-moz-border-radius:3px;border-radius:3px;
-}
-pre code {
-	padding:0;
-	font-size:10px;
-	background-color:#eee;
-	border:none;
-}
-code {
-	background-color:#f8f8ff;
-	color:#444;
-	padding:0 .2em;
-	border:1px solid #dedede;
-}
+      figure#contextDiagram{
+          width: 60%;
+          margin: 0 auto;
+      }
 
-img{border:0;max-width:100%;}
-abbr{border-bottom:none;}
+      figure figcaption{
+          text-align: center;
+          font-style: italic;
+      }
 
-a{color:#4183c4;}
+      table#x-ref_ucrVbp,
+      table#x-ref_formatVbp,
+      table#detailed-format-matrix{
+          border-collapse: collapse;
+          caption-side: bottom;
+      }
 
-a:link, a:active {
-  background: transparent;
-  text-decoration:none;
-}
+      table#x-ref_ucrVbp th,
+      table#x-ref_ucrVbp td,
+      table#x-ref_formatVbp th,
+      table#x-ref_formatVbp td,
+      table#detailed-format-matrix th,
+      table#detailed-format-matrix td{
+          border: 1px solid black;
+          padding: 0.3em;
+      }
 
-a:visited {
-  color: #529;
-  background: transparent;
-}
+      table#x-ref_ucrVbp caption,
+      table#x-ref_formatVbp caption,
+      table#detailed-format-matrix caption{
+          margin: 0.5em;
+          font-style: italic;
+      }
 
-a:hover{background-color: yellow; color: #00e;}
+      .stmt
+      {
+          padding: 3pt}
 
-a code,a:link code,a:visited code{color:#4183c4;}
+      .stmt1
+      {
+          column-count: 2;
+          -moz-column-count: 2;
+          -webkit-column-count: 2;
+          column-gap: 1em;
+          background-color: #FCFAEE;
+      }
 
-a:link img, a:visited img {
-   border-style: none
-}
+      .expand{
+          display: block;
+          cursor: pointer;
+      }
+      .expand:hover{
+          color: #3D3D3D;
+      }
+      .expand:before{
+          font-weight: bold;
+          content: "\25C6  Example (click to expand or collapse)";
+      }
+      .expand + input{
+          display: none;
+      }
+      .expand + input + *{
+          display: none;
+      }
+      .expand + input:checked + *{
+          display: block;
+      }</style>
+  </head>
+  <body>
+    <section id="abstract">
+      <p>This document advises on best practices related to the publication and usage of spatial
+        data on the Web; the use of Web technologies <em>as they may be applied to location</em>.
+        The best practices are intended for practitioners, including Web developers and geospatial
+        experts, and are compiled based on evidence of real-world application. These best practices
+        suggest a significant change of emphasis from traditional Spatial Data Infrastructures by
+        adopting a Linked Data approach. As location is often the common factor across multiple
+        datasets, spatial data is an especially useful addition to the Linked Data cloud; the <a
+          href="https://www.w3.org/DesignIssues/LinkedData.html">5 Stars of Linked Data</a> paradigm
+        is promoted where relevant.</p>
+    </section>
+    <section id="sotd">
+      <p>This Working Draft incorporates a significant set of changes (see <a href="#changes" class="sectionRef"></a> for details). The editors feel that in many places, this document is now in its final form. However, we anticipate one further set of changes (our last working iteration) plus another set of final editorial changes to be completed before the Working Group ends in June 2017. Our aim is to provide actionable advice and guidance to practitioners (e.g. those directly publishing spatial data on the Web themselves, or those developing software tools to assist that publication) through use of clear advice and examples.</p>
 
-h1, h2, h3, h4, h5, h6
+      <p>Looking to the next release (planned for end of April 2017), the editors anticipate:</p>
+      <ol>
+        <li>Reordering of the best practices to improve the readability of the document (note that the numerical identifiers <em>will</em> change as these are automatically assigned in sequential order).</li>
+        <li>Further development of <a href="#how-to-use" class="sectionRef"></a> which is intended to provide a would-be spatial data publisher navigate through best practices from here and [[DWBP]] by presenting with questions they should consider and helping them to identify which best practices they should prioritize. This section is currently less than half-complete.</li> 
+        <li>Updates to <a href="#describe-geometry">Best Practice 8: Provide geometries on the Web in a usable way</a> and <a href="#semantic-thing" class="sectionRef">Best Practice 10: Encoding spatial data</a>.</li>
+        <li>Refactoring <a href="#describe-geometry">Best Practice 8: Provide geometries on the Web in a usable way</a> and <a href="#entity-level-links" class="sectionRef">Best Practice 14: Publish links between spatial things and related resources</a> into smaller, more coherent best practices.</li>
+        <li>Systematic review of <strong>How to test</strong>, <strong>Evidence</strong> and <strong>Benefits</strong> sections for each best practice to make sure these are complete and correct</li>
+        <li>Adding a list of the namespaces used within this document for convenient reference.</li>
+        <li>Writing the content for <a href="#conclusions" class="sectionRef"></a>; with an emphasis on interoperability issues with spatial data publishing for which there are currently no best practices.</li>
+        <li>Including a combined list of file formats and vocabularies that one may use to publish spatial data (based on edited versions of the lists of file formats and vocabularies in <a href="#applicability-formatVbp" class="sectionRef">Appendix A</a> and <a href="#bp-expressing-spatial" class="sectionRef"></a> respectively).</li>
+        <li>Updating <a href="#requirements" class="sectionRef">Appendix C</a> to include cross-reference between requirements for spatial data publishing and the Best Practices from [[DWBP]].</li>
+      </ol>
+
+      <p>The editors would like to thank everyone for their feedback - and to encourage reviewers to continue this critique.</p>
+
+      <p><strong>For <abbr title="Open Geospatial Consortium">OGC</abbr>:</strong> This is a Public
+        Draft of a document prepared by the Spatial Data on the Web Working Group (<a
+          href="http://www.opengeospatial.org/projects/groups/sdwwg">SDWWG</a>) - a joint W3C-OGC
+        project (see <a href="https://www.w3.org/2015/spatial/charter">charter</a>). The document is
+        prepared following W3C conventions. The document is released to solicit public
+        comment.</p>
+    </section>
+    <section id="intro" class="informative">
+      <h2>Introduction</h2>
+      <p>Increasing numbers of Web applications provide a means of accessing data. From simple
+        visualizations to sophisticated interactive tools, there is a growing reliance on data. The
+        open data movement has led to many national, regional and local governments publishing
+        their data through portals. Scientific and cultural heritage data is increasingly published
+        on the Web for reuse by others. Crowd-sourced and social media data are abundant on the Web.
+        Sensors, connected devices and services from domains such as energy, transport,
+        manufacturing and healthcare are becoming commonly integrated using the Web as a common data
+        sharing platform.</p>
+      <p>The Data on the Web Best Practices [[DWBP]] provide a set of recommendations that are
+        applicable to the publication of <em>all</em> types of data on the Web. Those best practices
+        cover aspects including data formats, data access, data identifiers, metadata, licensing and
+        provenance.</p>
+      <p>Location information, or <a>spatial data</a>, is often a common thread running through
+        such data; describing how things are positioned relative to the Earth in terms of
+        coordinates and/or topology.</p>
+      <p>Within this document our focus is the somewhat broader concern of <a>spatial data</a>; data
+        that describes <em>anything</em> with spatial extent (i.e. size, shape or position) whether
+        or not it is positioned relative to the Earth.</p>
+      <p>Similarly to the challenges identified in [[DWBP]] relating to publishing data on the Web,
+        and therefore not making use of the full potential of the Web as a data sharing platform,
+        there is a lack of consistency in how people publish <a>spatial data</a>.</p>
+      <p>It is not that there is a lack of spatial data on the Web; the maps, satellite and street
+        level images offered by search engines are familiar and there are many more examples of
+        spatial data being used in Web applications.</p>
+      <aside class="example" id="ex-sfpark" title="SFpark"><a href="http://sfpark.org/">SFpark</a>
+        is a Web site where users can look at a map of San Francisco to see where parking is
+        available and at what price. Parking prices are incrementally raised or lowered in SFpark
+        pilot areas based on demand. In this application, static data on existing parking spaces is
+        combined with changing data about where people park the most, which is measured by parking
+        sensors.</aside>
+      <p>However, the data that has been published is difficult to find and often problematic to
+        access for non-specialist users. The key problems we are trying to solve in this document
+        are discoverability, accessibility and interoperability. Our overarching goal is to enable
+        spatial data to be integrated within the wider Web of data; providing standard patterns and
+        solution that help solve these problems.</p>
+    </section>
+    <section id="audience" class="informative">
+      <h2>Audience</h2>
+      <p>Our goal in writing this best practice document is to support the practitioners who are
+        responsible for publishing their spatial data on the Web or developing tools to make it easy
+        for others to work with spatial data.</p>
+      <p>We expect readers to be familiar both with the fundamental concepts of the architecture of
+        the Web [[WEBARCH]] and the generalized best practices related to the publication and usage
+        of data on the Web [[DWBP]].</p>
+      <p>We aim to provide two primary pathways into these best practices:</p>
+      <ol>
+        <li>for those already familiar with publishing data on the Web who want to better exploit
+          the spatial aspects of their data; and</li>
+        <li>for those who publish spatial data through Spatial Data Infrastructures and want to
+          better integrate that data within the wider Web ecosystem.</li>
+      </ol>
+      <p>In each case, we aim to help them provide incremental value to their data through
+        application of these best practices.</p>
+      <p>This document provides a wide range of examples that illustrate how these best practices
+        may be applied using specific technologies. We do not expect readers to be familiar with all
+        the technologies used herein; rather that readers can identify with the activities being
+        undertaken in the various examples and, in doing so, find relevant technologies that they
+        are already aware of or discover technologies that are new them.</p>
+      <p>In this document, we focus on the needs of data publishers and the developers that provide
+        tools for them. That said, we recognize that value can only be gained from
+          <em>publishing</em> the spatial data when people <em>use</em> it! Although we do not
+        directly address the needs of those users, we ask that data publishers and developers
+        reading this document do not forget about them; moreover, that they always consider the
+        needs of users when publishing spatial data or developing the supporting tools. All our
+        best practices are intended to provide guidance about the publishing spatial data to improve
+        ease of use. As we said above: the key problems we are trying to solve in this document are
+        discoverability, accessibility and interoperability. We hope that the examples included in
+        the urban flooding scenario will help illustrate how users may benefit from the application
+        of these best practices.</p>
+    </section>
+    <section id="scope" class="informative">
+      <h2>Scope</h2>
+      <section>
+        <h3>Spatial data</h3>
+        <p>All the best practices described in [[DWBP]] are relevant to publication of spatial data
+        on the Web. Some, such as [[DWBP]] <a href="https://www.w3.org/TR/dwbp/#DataLicense">Best Practice 4: Provide data license information</a> 
+        need no further elaboration in the context of <a>spatial data</a>.
+        However, other best practices from [[DWBP]] are further refined in this document to provide
+        more specific guidance for <a>spatial data</a>.</p>
+      <p>The best practices described below are intended to meet requirements derived from the
+        scenarios in [[SDW-UCR]] that describe how spatial data in commonly published and used on
+        the Web.</p>
+      <p>In line with the <a href="https://www.w3.org/2015/spatial/charter#bp">charter</a>, this
+        document provides advice on:</p>
+      <ul>
+        <li>The choice of ontology and data format to be used when encoding spatial data;</li>
+        <li>The use of URIs for identifiers of resources described in spatial data;</li>
+        <li>The use of metadata to complement spatial data; and</li>
+        <li>The use of APIs to expose spatial data.</li>
+      </ul>
+      <p>As stated in the <a href="https://www.w3.org/2015/spatial/charter#bp">charter</a>, discussion of activities relating to rending spatial data as maps is explicitly out of scope.</p>
+      <p>We extend [[DWBP]] to cover aspects specifically relating to <a>spatial data</a>,
+        introducing new best practices only where necessary. In particular, we consider the
+        individual resources, or <a>Spatial Things</a>, that are described within a dataset.</p>
+      <p>We consider a ‘programmable web’, formed by a network of connected services, products, data
+        and devices, each doing what it is good at, to be the future of the Web. So, whether we are
+        talking about Big, Crawlable, Linked, Open, Closed, Small, Spatial or Structured Data; our
+        starting point is that it needs to be machine-friendly and developer-friendly: making it as
+        programmable as possible.</p>
+      </section>
+      <section>
+        <h3>Best practice criteria</h3>
+        <p>The best practices described in this document are compiled based on evidence of real-world
+        application. Where the <a href="http://www.opengeospatial.org/projects/groups/sdwwg">Working
+          Group</a> have identified issues that inhibit the use or interoperability of spatial data
+        on the Web, yet no evidence of real-world application is available, the editors present
+        these issues to the reader for consideration, along with any approaches recommended by the
+        Working Group. Such recommendations will be clearly distinguished as such to ensure
+        that they are not confused with evidence-based best practice.</p>
+      <p class="issue" data-number="81">Devise a way to make best versus emerging practices clearly
+        recognizable in this document.</p>
+      <p>The normative element of each best practice is the <em>intended outcome</em>. Possible
+        implementations are suggested and, where appropriate, these recommend the use of a
+        particular technology.</p>
+      <p>We intend this best practice to be durable; that is that the best practices remain relevant
+        for many years to come as the specific technologies change. However, to provide
+        actionable guidance, i.e. to provide readers with the technical information they need to get
+        their spatial data on the Web, we try to balance between durable advice (that is necessarily
+        general) and examples using currently available technologies that illustrate how these best
+        practices can be implemented. We expect that readers will continue to be able to derive
+        insight from the examples even when those specifically mentioned technologies are no longer
+        in common usage, understanding that technology ‘y’ has replaced technology ‘x’.</p></section>
+      <section>
+        <h3>Privacy considerations</h3>
+        <p>There are many situations where the location of a person is very useful; from using a taxi hailing service to geocoding a selfie. Technology makes this location information easy to collect and share. However, spatial data has particular characteristics which makes its use potentially more complex. For example, a single location of an anonymous tracked mobile phone may cause few privacy concerns, however the same phone tracked over a few days could provide enough information to make the identification of its user possible. Like all personally identifiable information, great care must be taken as the collection, management and security of such information is the subject of legal frameworks. We do not attempt to provide guidance as to legal aspects of storing potentially personally identifiable spatial information, expert legal advice should be obtained. In summary: legal and privacy considerations relating to spatial data are out of scope.</p>
+      </section>
+    </section>
+    <section id="bp-summary">
+      <h2>Best Practices Summary</h2>
+      <p>This document contains a variety of best practices related to the publication and usage of spatial data on the Web. First, it continues with several more in-depth introductions on spatial things and geometry, coverages, spatial relations, coordinate reference systems, linked data, and Spatial Data Infrastructures. Then it describes how these best practices can be used, depending on your starting point and context. After that, the best practices themselves are described. They are about metadata, quality, versioning, identifiers, vocabularies, (API) access, linking, and large datasets. </p>
+      <p>The following best practices can be found in this document:</p>
+    </section>
+    <section id="spatial-things-features-and-geometry">
+      <h2>Spatial Things, Features and Geometry</h2>
+      <p>In spatial data standards from the <a href="http://www.opengeospatial.org">Open
+          Geospatial Consortium</a> (OGC) and the 19100 series of ISO geographic information
+        standards from <a href="http://www.isotc211.org">ISO/TC 211</a> the primary entity is the
+          <a>feature</a>. [[ISO-19101]] defines a feature
+        as an: “abstraction of real world phenomena”.</p>
+      <p>This terse definition is a little confusing, so let’s unpack it.</p>
+      <p>Firstly, it talks about “real world phenomena”; that’s everything from highways to
+        helicopters, parking meters to postcode areas, water bodies to weather fronts and more.
+        These can be physical things that you can touch (e.g. a phone box) or an abstract concept
+        that has spatial extent (e.g. a postcode area). Features can even be fictional (e.g.
+        “Dickensian London”) and may even lack any concrete location information such as the
+        mythical Atlantis.</p>
+      <p>The key point is that these “features” are things that one talks about in the <a>universe
+          of discourse</a> - which is defined in [[ISO-19101]] as the “view of the real or hypothetical world that includes
+        everything of interest”.</p>
+      <p>Secondly, the definition of feature talks about “abstraction”. Take the example of <a
+          href="https://www.wikidata.org/wiki/Q546122">Eddystone Lighthouse</a>. A helicopter pilot
+        might see it a “vertical obstruction” and be interested in attributes such as its height and
+        precise location. Whereas a sailor may see it as a “maritime navigation aid” and need
+        information about its light characteristic and general location. Depending on one’s set of
+        concerns, only a subset of the attributes of a given “real world phenomenon” are relevant.
+        In the case of Eddystone Lighthouse, we defined two separate “abstractions”. As is common
+        practice in many information modelling activities, the common sets of attributes for a given
+        “abstraction” are used to define <em>classes</em>. In the parlance of [[ISO-19101]], such a class is known as “feature
+        type”. </p>
+      <div class="note">
+        <p>Although the exact semantics differ a little, there is a good correlation between the
+          concept of “feature type” as defined in spatial data standards and the concept
+          of “class” defined in [[RDF-SCHEMA]]. The former is an information modelling construct that
+          binds a fixed set of attributes to an identified resource, whereas the latter defines the
+          set of all resources that share the same group of attributes.</p>
+        <p>When combined with the <a>open-world assumption</a> embraced by RDF Schema and the Web
+          Ontology Language (OWL) [[OWL2-OVERVIEW]], the set-based approach to classes provides more
+          flexibility when combining information from multiple sources. For example, the “Eddystone
+          Lighthouse” resource can be seen as <em>both</em> a “vertical obstruction” <em>and</em> a
+          “maritime navigation aid” as it meets the criteria for membership of both sets.
+          Conversely, this flexibility makes it much more difficult to build software applications
+          as there is no guarantee that an information resource will specify a given attribute. Web
+          standards such the Shapes Constraint Language [[SHACL]] are being defined to remedy this
+          issue.</p>
+      </div>
+      <p>However, the term “feature” is also commonly used to mean a capability of a system, application or component. Also, in some domains and/or applications no distinction is made between "<a>feature</a>" and the corresponding real-world phenomena.</p>
+
+      <p>To avoid confusion, we adopt the term “<a>spatial thing</a>” throughout the remainder of this best practice document. “<a>Spatial thing</a>” is defined in [[W3C-BASIC-GEO]] as “Anything with spatial extent, i.e. size, shape, or position. e.g. people, places, bowling balls, as well as abstract areas like cubes”.</p>
+
+      <p>The concept of “<a>spatial thing</a>” is considered to include <em>both</em> "real-world phenomena" <em>and</em> their abstractions (e.g. “<a>feature</a>” as defined in [[ISO-19101]]). Furthermore, we treat it as inclusive of other commonly used definitions; e.g. <strong>Feature</strong> from [[NeoGeo]], described as “A geographical feature, capable of holding spatial relations”.</p>
+      <div class="note">
+        <p>A <a>spatial thing</a> may move. We must take care not to oversimplify our concept of <a>spatial thing</a> by assuming that it is equivalent to definitions such as <strong>Location</strong> (from [[DCTERMS]]) or <strong>Place</strong> (from [[SCHEMA-ORG]]), which are respectively described as “A spatial region or named place” and "Entities that have a somewhat fixed, physical extension".</p>
+      </div>
+      <div class="issue" data-number="382">
+        <p>How do we ensure alignment with the terminology being used in the <a
+            href="https://www.w3.org/2015/spatial/wiki/Further_development_of_GeoSPARQL">further
+            development of GeoSPARQL</a>? We expect a new spatial ontology to be published which
+          will contain clear and unambiguous definitions for the terms used therein.</p>
+      </div>
+      <p>Looking more closely, it is important to note that geometry is typically a property of a <a>spatial
+          thing</a>.</p>
+      <pre class="example" id="ex-eddystone-geometry" title="Eddystone Lighthouse geometry (encoded as GeoJSON)">
 {
-	margin-bottom: 0.5em;
-	margin-top: 1em;
-	padding-bottom: 0.15em;
-	border-bottom: 1px solid #ccc;
-	background: transparent;
-	color: #005a9c;
-	font-weight: normal;
+  “geometry”: {
+    “type”: “Point”,
+    “coordinates”: [50.184, -4.268]
+  }
 }
+      </pre>
+      <p>In fact, this is only one geometry that may be used to describe Eddystone
+        Lighthouse. Other geometries might include a 2D polygon that defines the footprint of the
+        lighthouse in a horizontal plane and a 3D solid describing the volumetric shape of the
+        lighthouse.</p>
+      <p>Furthermore, these geometries may be subject to change due to, say, a resurvey of the
+        lighthouse. In such a situation, the geometry object would be updated- but the <a>spatial
+          thing</a> that we are talking about is still Eddystone Lighthouse. Following the best
+        practices presented below, we use a HTTP URI to unambiguously identify Eddystone Lighthouse:
+            <code><a href="http://d-nb.info/gnd/1067162240"
+          >http://d-nb.info/gnd/1067162240</a></code> (URI sourced from <a
+          href="http://www.dnb.de/">Deutsche Nationalbibliothek</a>).</p>
+      <p>We say that the <a>spatial thing</a> is disjoint from the geometry object. The <a>spatial
+          thing</a>, Eddystone Lighthouse (<code><a href="http://d-nb.info/gnd/1067162240"
+            >http://d-nb.info/gnd/1067162240</a></code>), is the “real world phenomenon” about which
+        we want to state facts (such as it has a focal height is at 41 meters above sea level) and link to
+        other real world phenomena (for example, that it is located at Eddystone Rocks, Cornwall; another <a>spatial thing</a> identified as
+            <code><a href="http://sws.geonames.org/2650253">http://sws.geonames.org/2650253</a></code> by <a href="http://www.geonames.org">GeoNames</a>).</p>
+    </section>
 
-h1
-{
-	border-bottom: none;
-	background: transparent;
-	/* color: #000; */
-}
+    <section id="coverages">
+      <h2>Coverages: describing properties that vary with location (and time)</h2>
+      <p>Many aspects of <a>spatial things</a> can be described with single-valued, static properties. However, in some applications it is more useful to describe the variation of property values in space and time. Such descriptions are formalized as <a>coverages</a>. Users of spatial information may employ both viewpoints.</p>
 
-h4, h5, h6 {border: none;}
+      <p>So what is a <a>coverage</a>? As defined by [[ISO-19123]] it is simply a data structure that maps points in space and time to property values. For example, an aerial photograph can be thought of as a coverage that maps positions on the ground to colors. A river gauge maps points in time to flow values. A weather forecast maps points in space and time to values of temperature, wind speed, humidity and so forth. One way to think of a coverage is as a mathematical function, where data values are a function of coordinates in space and time.</p>
 
+      <div class="note">
+        <p>Sometimes you’ll hear the word “coverage” used synonymously with “gridded data” or “raster data” but this isn’t really accurate. You can see from the above paragraph that non-gridded data (like a river gauge measurement) can also be modelled as coverages. Nevertheless, you will often find a bias toward gridded data in discussions (and software) that concern coverages.</p>
+      </div>
 
-hr{border:1px solid #ddd;}
+      <p>A coverage is not itself a <a>spatial thing</a>. The definition above presents a coverage as a data construct - in which case, it does not exist in the real world. Accordingly, we might say in the hydrology example, where a river gauge measures flow values at regular sampling times, that the “river segment” (a spatial thing) has a property “flow rate” that is expressed as coverage data.</p>
 
-ul{margin:1em 0 1em 2em;}
-ol{margin:1em 0 1em 2em;}
-ul li,ol li{
-	margin-bottom:.1em;
-}
-ul ul,ul ol,ol ol,ol ul{margin-top:0;margin-bottom:0;}
-
-ul.toc {
-  list-style: disc;
-  list-style: none;
-}
-
-blockquote{margin:1em 0;border-left:5px solid #ddd;padding-left:.6em;color:#555;}
-dt{font-weight:bold;margin-left:1em;}
-dd{margin-left:2em;margin-bottom:1em;}
-sup {
-    font-size: 0.83em;
-    vertical-align: super;
-    line-height: 0;
-}
-* {
-	-webkit-print-color-adjust: exact;
-}
-
-@media print {
-	table, pre {
-		page-break-inside: avoid;
-	}
-	pre {
-		word-wrap: break-word;
-	}
-}
-</style>
-<title>Deliverables of W3C/OGC Spatial Data on the Web Working Group</title>
-</head>
-<body>
-
-<p><a href="http://www.w3.org/"><img src="http://www.w3.org/Icons/w3c_home" width="72" height="48" alt="W3C"/></a>
-<a href="http://www.opengeospatial.org/"><img src="http://www.w3.org/2015/01/ogc_logo.jpg" width="115" height="48" alt="OGC"/></a></p>
-
-<h1>SDW</h1>
-
-<p>Deliverables of the W3C and OGC <a href="http://www.w3.org/2015/spatial/">Spatial Data on the Web Working Group</a>.</p>
-
-<p>Current documents in this repository:</p>
-
-<ul>
-  <li>Use Cases &amp; Requirements<ul>
-    <li><span class="status"><abbr title="WG NOTE">NOTE</abbr></span> <a href="https://www.w3.org/TR/sdw-ucr/">Latest Published Version</a></li>
-    <li><span class="status"><abbr title="Editor's Draft">ED</abbr></span> <a href="UseCases/SDWUseCasesAndRequirements.html">Editors' Draft</a></li>
-    <li>Published snapshots<ul>
-      <li><span class="status"><abbr title="WG NOTE">NOTE</abbr> 23 July 2015</span> <a href="http://w3c.github.io/sdw/publishing-snapshots/FPWD-2015-06-11-UseCases/Overview.html"><abbr title="First Public Working Draft">FPWD</abbr></a></li>
-			<li><span class="status"><abbr title="WG NOTE">NOTE</abbr> 17 December 2015</span> <a href="http://w3c.github.io/sdw/publishing-snapshots/2015-12-17-UseCases/"><abbr title="Second Working Draft">Second Working Draft</abbr></a></li>
-		</ul></li>
-    </ul>
-  </li>
-  <li>Spatial Data on the Web Best Practices<ul>
-    <li><span class="status"><abbr title="Working Draft">WD</abbr></span> <a href="https://www.w3.org/TR/sdw-bp/">Latest Published Version</a></li>
-    <li><span class="status"><abbr title="Editor's Draft">ED</abbr></span> <a href="bp/">Editors' Draft</a></li>
-    <li>Published snapshots<ul>
-      <li><span class="status"><abbr title="WG NOTE">NOTE</abbr> 19 January 2016</span> <a href="http://w3c.github.io/sdw/publishing-snapshots/FPWD-2016-01-19-BestPractices/index.html"><abbr title="First Public Working Draft">FPWD</abbr></a></li>
-      <li><span class="status"><abbr title="WG NOTE">NOTE</abbr> 25 October 2016</span> <a href="http://w3c.github.io/sdw/publishing-snapshots/2016-10-24-bp/"><abbr title="Working Draft">WD</abbr></a></li>
-      <li><span class="status"><abbr title="WG NOTE">NOTE</abbr> 5 January 2017</span> <a href="http://w3c.github.io/sdw/publishing-snapshots/2017-01-05-bp/"><abbr title="Working Draft">WD</abbr></a></li>
-    </ul></li>
-  </ul></li>
-  <li>Semantic Sensor Network Ontology<ul>
-    <li><span class="status"><abbr title="WG NOTE">NOTE</abbr></span> <a href="https://www.w3.org/TR/vocab-ssn/">Latest Published Version</a></li>
-  	<li><span class="status"><abbr title="Editor's Draft">ED</abbr></span> <a href="ssn/">Editors' Draft</a></li>
-    <li>Published snapshots<ul>
-      <li><span class="status"><a href="publishing-snapshots/FPWD-2016-05-31-SSN/"><abbr title="First Public Working Draft">FPWD</abbr></a></span> 31 May 2016</li>
-      <li><span class="status"><a href="publishing-snapshots/2017-01-05-ssn/"><abbr title="Working Draft">WD</abbr></a></span> 5 January 2017</li>
-    </ul></li>
-   </ul></li>
-  <li>Time Ontology in OWL<ul>
-    <li><span class="status"><abbr title="Working Draft">WD</abbr></span> <a href="https://www.w3.org/TR/owl-time/">Latest Published Version</a></li>
-  	<li><span class="status"><abbr title="Editor's Draft">ED</abbr></span> <a href="time/">Editors' Draft</a></li>
-  </ul></li>
-  <li>Coverages<ul>
-    <li>Publishing and Using Earth Observation Data with RDF Data Cube and the Discrete Global Grid System<ul>
-      <li><span class="status"><abbr title="First Public Working Draft">FPWD</abbr></span> <a href="https://www.w3.org/TR/eo-qb/">Latest Published Version</a></li>
-      <li><span class="status"><abbr title="Editor's Draft">ED</abbr></span> <a href="eo-qb/">Editors' Draft</a></li>
-      <li>Published snapshots<ul>
-        <li><span class="status"><abbr title="WG NOTE">NOTE</abbr> 5 January 2017</span> <a href="http://w3c.github.io/sdw/publishing-snapshots/FPWD-2017-01-05-eo-qb/"><abbr title="First Public Working Draft">FPWD</abbr></a></li>
-      </ul></li>
-
+      <p><a>Spatial things</a> and <a>coverages</a> may be related in several ways:</p>
+      <ul>
+        <li>signals in coverages may be used to provide the evidence for the existence, location and type of spatial things; for example, within a geophysical borehole the variation in soil/rock type may be used to infer the presence of particular rock-units at underground locations</li>
+        <li>as the property value of a spatial thing whose value varies within the extent of that spatial thing; for example, the varying strength of mobile-network coverage throughout the UK</li>
+        <li>the values of a common property for a distributed set of spatial things provide a discrete sampling of a coverage; for example, the measurement of soil moisture based at a set of sampling stations can be compiled to show the spatial variation of soil moisture across the region where the sampling stations are located</li>
       </ul>
 
-      <li>CoverageJSON<ul>
-      <li><span class="status"><abbr title="Editor's Draft">ED</abbr></span> <a href="coverage-json/">Editors' Draft</a></li>
-    </ul></li>
+      <p>A coverage can be defined using three main pieces of information:</p>
+      <ul>
+        <li>The <em>domain</em> of the coverage is the set of points in space and time for which we have data values. For example, in a river gauge measurement, the domain is the set of times at which the flow was measured. In a satellite image, the domain is the set of pixels. In a weather forecast, the domain is a set of grid cells.</li>
+        <li>The <em>range</em> of the coverage is the set of measured, simulated or observed data values. A single coverage may record values for lots of different quantities; for example, a weather forecast predicts values for many things (temperature, humidity etc.) on the same domain. So the range of a coverage often consists of several lists of data values, one for each measured variable. Each element within each list corresponds with one of the elements of the domain (e.g. a pixel or grid cell).</li>
+        <li>The <em>range metadata</em> describes the range of the coverage, to help users to understand what the data values mean. This may include links to definitions of variables, units of measure and other bits of useful information.</li>
+      </ul>
+      <p>Usually, the most complex piece of information in the coverage is the definition of the domain. This can vary quite widely from coverage type to coverage type, as the list above shows. For this reason, coverages are often defined by the spatiotemporal geometry of their domain. You will hear people talking about “multidimensional grid coverages” or “time-series coverages” or “vertical profile coverages” for example.</p>
+    </section>
+    <section id="spatial-relations">
+      <h2>Spatial relations</h2>
+      <p>A spatial relation specifies how an object is located in space in relation to a reference
+        object. Commonly used types of spatial relations are: topological, directional and distance
+        relations.</p>
+      <ul>
+        <li><em>Topological relations</em> describe the relationships between geometric objects that
+          are invariant to rotation, translation and scaling. As such, topological relations can
+          support qualitative spatial reasoning without reference to the geometries themselves; for
+          example, to assert that object A touches object B. These relations, also known as “spatial
+          predicates”, include concepts such as: equals, disjoint, intersects, touches, within,
+          contains, overlaps and crosses.</li>
+        <li><em>Directional relations</em> specify the relative direction between object and
+          reference. Examples include: left, in front of and astern.</li>
+        <li><em>Distance relations</em> specify how far the object is from the reference object.
+          Examples include: at, nearby and far away.</li>
+      </ul>
+      <div class="issue" data-number="383">
+        <p>Do we also need to talk about spatial relationships? And how they are related to
+            <a>spatial things</a> and geometries?</p>
+      </div>
+    </section>
+    <section id="CRS-background">
+      <h2>Coordinate Reference Systems (CRS)</h2>
 
-      <li>QB4ST<ul>
-      <li><span class="status"><abbr title="First Public Working Draft">FPWD</abbr></span> <a href="https://www.w3.org/TR/qb4st/">Latest Published Version</a></li>
-      <li><span class="status"><abbr title="Editor's Draft">ED</abbr></span> <a href="qb4st/">Editors' Draft</a></li>
-      <li>Published snapshots<ul>
-        <li><span class="status"><abbr title="WG NOTE">NOTE</abbr> 5 January 2017</span> <a href="http://w3c.github.io/sdw/publishing-snapshots/FPWD-2017-01-05-qb4st/"><abbr title="First Public Working Draft">FPWD</abbr></a></li>
-      </ul></li>
+      <div class="issue" data-number="392">
+        <p>Introduction to CRS does not yet cover non-geographic cases.</p>
+        <p>Best Practice scope is "spatial data" - which includes non-geographic location (e.g. where things aren't positioned relative to the Earth). For example, we have a microscopy use case where the locations of cells are described.</p>
+      </div>
 
+      <p>One of the most fundamental aspects of publishing spatial data, data about location, is how to express and share the location in a consistent way. In almost all cases where you are publishing data for use by the wider web community the use of <a>latitude</a> and <a>longitude</a> coordinates (Lat and Long) is most appropriate. Latitude and longitude coordinates are global and offer a level of precision well suited to many applications: you can express a location to within a few meters which is perfect for locating your favorite coffee shop, geocoding a photograph or capturing an augmented reality Pokemon hiding in your local park.  </p>
+      
+      <p>As with everything to do with spatial data, things can get more complicated. One of the most common problems occurs because not all <a>Coordinate Reference Systems</a> (CRS) agree how to express latitude and longitude coordinates. Some CRS order the coordinates <em>Lat/Long</em> while others use <em>Long/Lat</em>; some use <em>decimal degrees</em> while others use <em>degrees, minutes and seconds</em> (<em>dms</em>). Axis order mistakes can mean the difference between, say, a position in the Netherlands or somewhere in Somalia, while encoding coordinates in <em>decimal degrees</em> when <em>dms</em> is expected can lead to positional errors on the kilometer scale.  </p>
+      
+      <p>Therefore, it is very important to provide explicit information to your users about how coordinates are encoded. For example, this snippet of results from the <a href="https://developers.google.com/maps/documentation/geocoding/intro">Google Geocoding API</a> makes explicit which is the latitude and which is the longitude coordinate. </p>
 
+      <pre class="example" title="A Google Geocoding API result snippet">
+ "formatted_address" : "1600 Amphitheatre Parkway, Mountain View, CA 94043, USA",
+         "geometry" : {
+            "location" : {
+               "lat" : 37.4224764,
+               "lng" : -122.0842499
+            },
+            "location_type" : "ROOFTOP",
+            "viewport" : {
+               "northeast" : {
+                  "lat" : 37.4238253802915,
+                  "lng" : -122.0829009197085
+               },
+               "southwest" : {
+                  "lat" : 37.4211274197085,
+                  "lng" : -122.0855988802915
+               }
+            }
+         },
+      </pre>
+      
+      <p>Other mechanisms include using a data format that specifies how the coordinates are included (such as GeoJSON [[RFC7946]] where section <a href="https://tools.ietf.org/html/rfc7946#section-4">4. Coordinate Reference System</a> specifies coordinate order of longitude and latitude using units of decimal degrees) or by having your data explicitly reference the CRS definition you're using. See <a href="#bp-crs" class="sectionRef">Best Practice 17: State how coordinate values are encoded</a> for more information.</p>
 
-    </ul></li>
+      <p>Users of spatial data are often interested in the third dimension too: vertical elevation (or altitude). For most situations, we can consider elevation to be the vertical distance above (or below) mean sea level. The elevation is most often expressed in meters (but this can vary between CRS definitions) and is provided as a third value in a coordinate position.</p>
 
+      <p>The following is a little more technical; and in most cases this should only be for information.</p> 
+      
+      <p>Latitude, longitude and elevation measurements express a position on the surface of the Earth. But to define this position we need to state where we are making the measurements from (e.g. the equator, the prime meridian and the approximated surface of the Earth, or <a>geoid</a>) and consider the shape of the earth (a flattened sphere with lumps and bumps, but for convenient mathematical operations, usually approximated to an <a>ellipsoid</a>). This information is used to define the geodetic datum which provides the basis of every Coordinate Reference System.</p>
 
-  </ul></li>
+      <p>The <a href="https://en.wikipedia.org/wiki/World_Geodetic_System">World Geodetic System 1984</a> (<strong>WGS 84</strong>) Coordinate Reference System is used in almost all cases where spatial data is published on the Web. Since this is also used by the GPS system, it's handy for all those mobile Apps! </p>
 
+      <p>Most people can stop reading now, but of course there are going to be a few cases where WGS 84 is not appropriate.</p>
+      
+      <p>In many parts of the world location data has been collected using local coordinate systems that are specific to particular countries or regions. These local coordinate systems may use  projected measurements defined on a flat, two-dimensional surface (which are easier to use for calculating distances than angular measurements and are essential when making topographic maps).</p>
 
+      <div class="note">
+        <p>Users of spatial data should be aware that projected coordinate systems distort distances and angular measurements and accordingly affect how <a href="http://thetruesize.com">the true size</a> of countries of countries and other large-scale entities is perceived. CNN explore some of the challenges relating to map projections in their article <a href="http://edition.cnn.com/2016/08/18/africa/real-size-of-africa/">What's the real size of Africa?</a>.</p>
+      </div>
+      
+      <p>So, it may be that you have information in a projected CRS, rather than global latitude and longitude - what should you do? You can publish data as is in one of these many projected CRS, but you need to tell users which particular CRS is being used. A good directory of Coordinate Reference Systems is maintained by the International Association of Oil and Gas Producers: the <a href="http://www.epsg.org/">EPSG Geodetic Parameter Dataset</a>. </p>
+
+      <div class="note">
+        <p>It is common for a CRS to be described by its ESPG code. For example, 2-dimensional WGS 84 (Lat/Long) is <a href="http://epsg.io/4326">EPSG:4326</a>, 3-dimensional WGS 84 (Lat/Long/Elevation) <a href="http://epsg.io/4979">EPSG:4979</a>, Web-Mercator (a global projected CRS used in most Web-mapping applications) is <a href="http://epsg.io/3857">EPSG:3857</a> and British National Grid (a national projected CRS, based on the OSGB 1936 datum) is <a href="http://epsg.io/27700">EPSG:27700</a>. </p>
+        <p>Definitions of coordinate reference systems are available from the <a href="http://www.opengis.net/def/crs/">Open Geospatial Consortium CRS Register</a>, <a href="http://spatialreference.org/">Spatial Reference</a> and <a href="http://epsg.io/">EPSG.io</a> (an open-source web service which simplifies discovery of coordinate reference systems utilized worldwide).</p>
+      </div>  
+      
+      <p>Alternatively, you can re-project your coordinates to WGS 84 using many available tools online. So, for example, the location at <code>516076, 170953</code> in British National Grid (<a href="http://epsg.io/27700">EPSG:27700</a>) coordinates is <code>-0.331841, 51.425708</code> in WGS 84 Long/Lat. This conversion is a useful step as it makes you data more accessible to global users. So, if you can do so, it is helpful to publish data in both local (projected) and global coordinates. </p>      
+      
+      <p>Re-projecting to a better-known CRS is also a necessary step if you are publishing data in the form of engineering or Computer Aided Design (CAD)  drawings of a new building or road layout for example. Usually these drawings are made using a very local coordinate reference system for the site itself, so the data will need to be reprojected to “fit” with existing data.</p>
+      
+      <p>So, we are now at the point where almost everyone publishing spatial data on the Web can stop reading. But for those with specific requirements concerning high precision locations, there are a few more topics that need to be mentioned.</p>
+
+      <p>If you need to be able to measure in terms of a few centimeters or less then things are more complicated.  With this level of precision required you need to consider a more sophisticated model of the shape of the Earth and consider plate tectonics.  </p>
+
+      <p>For these more complex use cases other reference systems with alternative geodetic datums are used. The geodetic datum can be thought of as the model of the Earth's surface over which the coordinate reference system is applied. Different datums use different models for the precise <em>shape</em> and <em>size</em> of the Earth to provide more accurate horizontal or vertical measurements at different positions on the globe (because depending on your location, different <a>ellipsoids</a> will provide a better approximation of the local Earth's surface - but this is at the expense of a poorer match elsewhere).</p> 
+
+      <p>While WGS 84 provides a <em>reasonable</em> fit at all points on the Earth's surface, many other datums are defined for improved fit within a regional or national area. For example, in Europe a system called ETRS89 (<a href="http://epsg.io/4258">EPSG:4258</a>) can be used instead of WGS 84, while in North America a similar system called NAD-83 (<a href="http://epsg.io/4269">EPSG:4269</a>) is used.  So, it might be that you have measurements made using these reference systems. Here the best practice is once more to be explicit in describing the CRS used, but also to be careful re-projecting to different systems as required accuracy may be lost.</p>
+      
+      <p>Finally, another issue is that points on the surface of the earth are actually moving relative to the coordinate system, due to geologic processes. You may think this is of interest only to geologists, but when I tell you that Australia has moved around 1.5m since the framework was last reset 20 years ago, and remind you that we are entering the age of self-driving cars, then you will probably think again. Re-calculating the datum from time to time, or maybe continuously such as in the case of the dynamic New Zealand Geodetic Datum (NZGD2000), really does matter for some applications. See <a href="#bp-crs-choice" class="sectionRef">Best Practice 3: Choose the coordinate reference system to suit your user's applications</a> for more information.</p>
+
+      <div class="note">
+        <p>Detailed discussion of coordinate reference system definitions themselves is beyond the scope of this best practice document. Should this topic be of interest, please refer to specialist documentation such as [[OGC-TOPIC-2]] / [[ISO-19111]].</p>
+      </div>
+
+    </section>
+    <section id="linked-data">
+      <h2>Linked Data</h2>
+      <p>The term ‘Linked Data’ refers to an approach to publishing data that puts linking at
+        the heart of the notion of data, and uses the linking technologies provided by the Web to
+        enable the weaving of a global distributed database. By naming real world entities - be they
+        web resources, physical objects such as the Eiffel Tower, or even more abstract things such
+        as relations or concepts - with URLs data can be published and linked in the same way web
+        pages can. [[LDP-PRIMER]]</p>
+      <p>The 5-star scheme at <a href="http://5stardata.info">5 Star Data</a> states:</p>
+      <p style="text-indent:80px">&#9733; make your stuff available on the Web (whatever format)
+        under an open license</p>
+      <p style="text-indent:65px">&#9733;&#9733; make it available as structured data (e.g., Excel
+        instead of image scan of a table)</p>
+      <p style="text-indent:50px">&#9733;&#9733;&#9733; make it available in a non-proprietary open
+        format (e.g., CSV as well as of Excel)</p>
+      <p style="text-indent:35px">&#9733;&#9733;&#9733;&#9733; use URIs to denote things, so that
+        people can point at your stuff</p>
+      <p style="text-indent:20px">&#9733;&#9733;&#9733;&#9733;&#9733; link your data to other data
+        to provide context</p>
+      <p>We think that the concept of <a>Linked Data</a> is fundamental to the publishing of spatial
+        data on the Web: it is the <a>links</a> that connect data together that are the foundational
+        to the Web of data.</p>
+      <p>These best practices promote a Linked Data approach.</p>
+      <p>Sources such as the Best Practices for Publishing Linked Data [[LD-BP]] assert a strong
+        association between Linked Data and the <a>Resource Description Framework</a> (RDF)
+        [[RDF11-PRIMER]]. Yet we believe that Linked Data requires only that the formats used to
+        publish data support Web linking (see [[WEBARCH]] <a
+          href="https://www.w3.org/TR/webarch/#hypertext">section 4.4 Hypertext</a>). <a href="http://5stardata.info">5 Star Data</a> (based on [[5STAR-LOD]])
+        asserts only that data formats be open and non-proprietary (&#9733;&#9733;&#9733;); and
+        infers the need for data formats to support use of URIs as identifiers
+        (&#9733;&#9733;&#9733;&#9733;) and Web linking (&#9733;&#9733;&#9733;&#9733;&#9733;).</p>
+      <p>Within this document, we include examples that use <a>RDF</a> and related technologies such
+        as <a>triple stores</a> and <a>SPARQL</a> because we see evidence of its use in real world
+        applications that support <a>Linked Data</a>. However, we must make clear to readers that
+        there is no requirement for all publishers of spatial data on the Web to embrace the wider
+        suite of technologies associated with the Semantic Web; we recognize that in many cases, a
+        Web developer has little or no interest in the toolchains associated with Semantic Web due
+        to the addition of complexity to any Web-centric solution.</p>
+      <p>Although we think that <a>Linked Data</a> need not necessarily require the use of
+          <a>RDF</a>, it is probably the most commonly representation. We note that [[JSON-LD]] provides a bridge
+        between those worlds by providing a data format that is compatible with RDF but relies on
+        standard <a>JSON</a> tooling.</p>
+      <p>Furthermore, as the examples in this document illustrate, we often see a ‘hybrid’ approach
+        being used in real-world applications; using <a>RDF</a> to work with graphs of information
+        that interlink resources, while relying on other technologies to query and process the
+        spatial aspects of that information for performance reasons.</p>
+    </section>
+    <section id="why-are-traditional-sdi-not-enough">
+      <h2>Why are traditional Spatial Data Infrastructures not enough?</h2>
+      <p>Finding, accessing and using data disseminated through <a>spatial data infrastructures</a>
+        (SDI) based on <abbr title="Open Geospatial Consortium">OGC</abbr> web services is difficult
+        for non-expert users. There are several reasons, including:</p>
+      <ul>
+        <li>In <a>spatial data infrastructures</a>, catalog services are intended to be used for
+          discovering spatial assets, not the general-purpose search engines of the Web. <abbr
+            title="Open Geospatial Consortium">OGC</abbr> web services do not address indexing of
+          their content by those search engines.</li>
+        <li>By design, the catalog services only provide access to metadata - and in general
+          metadata that is focused on the needs of expert users - not the data itself.</li>
+        <li>Users cannot just “follow links” to access data, it is typically necessary to construct
+          some kind of query to access data. Often these queries are complex to define, requiring in
+          depth knowledge both data structure and the domain-specific query language.</li>
+        <li>In addition, it is often difficult for non-expert users to understand and use the data.
+          Part of this are domain-specific complexities that are difficult for non-experts (e.g.,
+          handling of coordinates in different coordinate reference systems), but hard to avoid
+          entirely. But the datasets often address requirements of expert communities with diverse
+          needs, resulting in comprehensive, but complex specifications that cover many edge cases,
+          too. And the data is typically available in formats that are not easy to process for
+          non-expert users.</li>
+      </ul>
+      <p>However, <a>spatial data infrastructures</a> are a key component of the broader <a>spatial
+          data</a> ecosystem. Such infrastructures typically include workflows and tools related to
+        the management and curation of spatial datasets, and provide mechanism to support the rich
+        set of capabilities required by the expert community. Our goal is to help spatial data
+        publishers build on these foundations to enable the spatial data from SDIs to be fully
+        integrated with the Web of data.</p>
+      <p>When your starting point is a <a>spatial data infrastructure</a>, you should at least read the following best practices. These provide the most important extra steps that should be taken to bring spatial data from <a>spatial data infrastructures</a> to the Web: </p>
+      <ul>
+        <li><a href="#indexable-by-search-engines">Best Practice 4: Make your spatial data indexable by search engines</a></li>
+        <li><a href="#globally-unique-ids">Best Practice 7: Use globally unique persistent HTTP URIs for spatial things</a></li>
+        <li><a href="#convenience-apis">Best Practice 11: Expose spatial data through 'convenience APIs'</a></li>
+      </ul>
+      <p>The rest of the best practices provide more detail on specific aspects of publishing spatial data on the Web, such as metadata, geometries, CRS information, versioned data, and so on.</p>
+    </section>
+    <section id="how-to-use">
+      <h2>How to use these best practices</h2>
+      <div class="issue" data-number="381">
+        <p>Section <a href="#how-to-use"></a> is incomplete.</p>
+        <p>Estimate that this covers only a quarter of the "spatial data publication pathway" that we are trying to help would-be spatial data publishers navigate. More material to be added describing the full range of considerations when publishing spatial data on the Web in the next public draft.</p>
+      </div>
+      <section id="starting-points">
+        <h3>What are the starting points?</h3>
+        <p>Preparations for publishing spatial data on the Web need to start somewhere. Typically, your spatial data will be in the following places:</p>
+        <ol>
+          <li>plain text documents; e.g. historical texts, government reports, blog posts etc.</li>
+          <li>data files containing structured content or markup; e.g. geospatial vector data in Shapefile or [[GML]] format, statistical data in tabular CSV format or a spreadsheet, as GPX data with “waypoints” and “tracks”, satellite imagery in GeoTIFF, climate simulations in CF-NetCDF etc.</li>
+          <li>a data repository; e.g. PostGIS (a spatially enabled relational database), Elasticsearch (a document-oriented noSQL repository based on Apache Lucene), Apache Jena’s TDB (an RDF triple store)</li>
+          <li>exposed via an existing API; including OGC-compliant web services such as WFS and WCS</li>
+        </ol>
+        <p>If your spatial data is managed within a software system it is likely that you will be able to access that data through one or more of the methods identified above; as structured data from a bulk extract (e.g. a “data dump”), via direct access to the underpinning data repository or through a bespoke or standards-compliant API provided by the system.</p>
+        <p>As working with specific spatial data management systems is beyond the scope of this best practice document we will assume that one of the four methods identified above is your starting point.</p>
+        <p>Each of these starting points have their own challenges, but working with plain text documents can be particularly tricky as you will need to parse the natural language to identify the spatial things and their properties before you can proceed any further. Natural Language Processing (NLP) is also beyond the scope of this best practice document - so we will assume that you’ve already completed this step and have parsed any plain documents into structured data records of some kind.</p>
+      </section>
+      <section id="what-r-u-talking-about">
+        <h3>What are you talking about?</h3>
+        <p>The Web is an information space in which the items of interest, referred to as resources, are identified by URIs ([[WEBARCH]] <a href="https://www.w3.org/TR/webarch/#intro">§1. Introduction</a>). The spatial data you want to publish is one such <strong>resource</strong>. Depending on the nature of your spatial data, it may be a single <strong>dataset</strong> or a collection of datasets. [[VOCAB-DCAT]] provides a useful definition of dataset: “A collection of data, published or curated by a single agent, and available for access or download in one or more formats.”</p>
+
+        <p>Deciding whether your spatial data is a single dataset or not is somewhat arbitrary. To decide this, it is often useful to consider attributes such as the license under which the data will be made available, the refresh or publication schedules, the quality of the data and the governance regime applied in managing the data. Typically, all of these attributes should be consistent within a single dataset.</p>
+
+        <p>As a first step in publishing your spatial data on the Web, we need to stitch your data into the Web’s information space by assigning a URI to each dataset (see [[DWBP]] <a href="https://www.w3.org/TR/dwbp/#UniqueIdentifiers">Best Practice 9: Use persistent URIs as identifiers of datasets</a>). Furthermore, if you anticipate your data changing over time and you want users to be able to refer to a particular version of your dataset you should also consider assigning a URI to each version of the dataset (see [[DWBP]] <a href="https://www.w3.org/TR/dwbp/#VersionIdentifiers">Best Practice 11: Assign URIs to dataset versions and series</a>).</p>
+
+        <div class="note">
+          <p>[[DWBP]] <a href="https://www.w3.org/TR/dwbp/#dataVersioning">section 8.6 Data Versioning</a> provides further guidance on working with versioned resources: providing metadata to indicate the particular version of a given dataset resource (see [[DWBP]] <a href="https://www.w3.org/TR/dwbp/#VersioningInfo">Best Practice 7: Provide a version indicator</a>) and enabling users to browse the history of your dataset (see [[DWBP]] <a href="https://www.w3.org/TR/dwbp/#VersionHistory">Best Practice 8: Provide version history</a>).</p>
+        </div>
+
+        <p>We also need to look inside the datasets at the resources described within your data. If you want these resources to be visible within the Web’s information space, by which we mean that others can refer to or talk about those resources, then they must also be assigned URIs (see [[DWBP]] <a href="https://www.w3.org/TR/dwbp/#identifiersWithinDatasets">Best Practice 10: Use persistent URIs as identifiers within datasets</a>). These URIs are like 'Web-scale foreign keys' that enable information from different sources to be stitched together.</p>
+
+        <p>In spatial data, our primary concern is always the spatial things; these are the things with spatial extent (i.e. size, shape, or position) that we talk about in our data - anything from physical things like people, places and post boxes to abstractions such as administrative areas. Spatial things should always be assigned URIs (see <a href="#globally-unique-ids">Best Practice 7: Use globally unique persistent HTTP URIs for spatial things</a>) - potentially reusing existing URIs that are already in common usage. A common pattern used when assigning URIs to spatial things is append the locally-scoped identifiers used within the dataset to a URI path within an internet DNS domain where one has administrative rights to publish content.</p>
+
+        <p>Depending on how you organize your data, it may also be helpful to give your geometry objects URIs. For example, you may want to reuse a line string when describing the boundaries of adjacent administrative areas, or you may need to serve geometry data from an alternate URL because property data and geometry data are managed in different systems. Essentially, if you want to refer to a resource on the Web, you need to assign a URI to it.</p>
+      </section>
+      <section id="who-is-your-audience">
+        <h3>Who is your audience?</h3>
+        <p>Once you have determined the subjects of your spatial data, you should then consider your users - and the software tools, applications and capabilities they might have at their disposal.</p>
+
+        <p>Your objective should be to reduce the “friction” created for users to work with your data by providing it in a form that is closest to what their chosen software environment supports.</p>
+
+        <p>It is likely that you will be able to identify your intended “community of use” - and on that basis, discern how best to publish data for them. However, increasingly data is being repurposed to derive insight in ways that the original publisher had never foreseen. This “unanticipated re-use” can add significant value to your data (e.g. because you didn’t know that your data could be used that way!) but this introduces the challenge of working with a large set of unknown users, developers and devices.</p>
+
+        <p>So, while you should always prioritize your known users when publishing spatial data on the Web (often, because they are your stakeholders and their happiness can lead to continued funding!), it will often reap dividends to “design for the masses”: providing your spatial data in a way that is most readily usable with the (geo)spatial JavaScript libraries commonly employed across the Web.</p>
+
+        <p>Things that you should consider when choosing how to publish your spatial data on the Web are described next …</p>
+      </section>
+      <section id="parse-that">
+        <h3>Parse that!</h3>
+        <p>For users to work with your data, software agents (a.k.a. the “machines”) need to be able to parse it - to resolve the serialized data into its component parts. You should make your data available in machine-readable, standardized data formats (see [[DWBP]] <a href="https://www.w3.org/TR/dwbp/#MachineReadableStandardizedFormat">Best Practice 12: Use machine-readable standardized data formats</a>); e.g. JSON [[RFC7159]], XML [[XML11]], CSV [[RFC4180]] and other tabular data formats, YAML [[YAML]], protocol-buffers [[PROTO3]] etc. According to the 5 Star Data [[5STAR-LOD]] scheme, using open and non-proprietary structured data formats yields a 3-star rating (&#9733;&#9733;&#9733;), so you’re well on your way to good practice.</p>
+
+        <p>Consider that Web applications are most often written in JavaScript, probably the most “frictionless” data format for Web developers is JSON. That said, it is reasonably simple to parse other formats for use in JavaScript using widely available libraries. In some cases, there are even standards to define how this should be done (for example: [[CSV2JSON]])</p>
+
+        <p>You should also consider whether there are any attributes of these machine-readable standardized data formats that offset a little inconvenience for your data user. For example, protocol-buffers [[PROTO3]] and <abbr title="Concise Binary Object Representation">CBOR</abbr> [[RFC7049]] (“Concise Binary Object Representation”) provide a significantly more compact encoding than JSON. The inconvenience of having to use additional libraries to parse these binary formats is offset by the convenience of much faster load times.</p>
+
+        <p>Imagery formats JPEG [[JPEG2000]] and PNG [[PNG]] can also be coerced to carry data; providing 3 or 4 channels of 8-bit data values. This can be an attractive way to encode gridded coverage data values as it is highly compact. So long as you don’t apply compression algorithms to the “image”; while compression retains visual integrity, it can ruin your data integrity. Experience indicates that network providers often do apply compression to image formats - even if you don’t want that. The key point is to ensure that you choose formats that are unaffected by the transport network.</p>
+
+        <p>When selecting the data format, make sure that your community of use have access to libraries or other software components required to work with that format. Let’s take [[GeoTIFF]] as an “anti-example”: it’s the <i>de facto</i> format for encoding geo-referenced imagery data - such as that available from satellites - but the lack of widely available libraries for working with it in a JavaScript application make it unsuitable for publishing spatial data on the Web. Although a developer could write a byte-level parser, it puts an additional burden on any re-use.</p>
+      </section>
+    </section>
+    <section id="bestPractices">
+      <h2>The Best Practices</h2>
+      <section id="bp-metadata">
+        <h3>Spatial Metadata</h3>
+        <p>[[DWBP]] provides best practices discussing the provision of metadata to support
+          discovery and reuse of data (see [[DWBP]] <a href="https://www.w3.org/TR/dwbp/#metadata"
+            >section 8.2 Metadata</a> for more details). Providing metadata at the <em>dataset</em> level
+          supports a mode of discovery well aligned with the practices used in <a>Spatial Data
+            Infrastructure</a> (SDI) where a user begins their search for spatial data by submitting
+          a query to a catalog. Once the appropriate dataset has been located, the information
+          provided by the catalog enables the user to find a service end-point from which to access
+          the data itself - which may be as simple as providing a mechanism to download the entire
+          dataset for local usage or may provide a rich API enabling the users to request only the
+          required parts for their needs. The dataset-level metadata is used by the catalog to match
+          the appropriate dataset(s) with the user's query.</p>
+        <p>This section includes best practices for including the spatial extent, CRS, and other spatial details of the
+          dataset in the metadata. These are the extra metadata items needed to make spatial
+          datasets both discoverable and usable. A third best practice in this section goes a
+          step further in granularity: exposing spatial data on the web in such a way that individual entities or "granules"
+          within a dataset can be discovered, evaluated, and utilized. </p>
+        <div class="practice">
+          <p><span id="spatial-info-dataset-metadata" class="practicelab">Include spatial metadata
+              in dataset metadata</span></p>
+          <p class="practicedesc">The description of datasets that have spatial features should
+            include explicit metadata about their spatial extent, coverage, and representation</p>
+          <p class="note">This best practice extends [[DWBP]] <a
+              href="https://www.w3.org/TR/dwbp/#DescriptiveMetadata">Best Practice 2: Provide descriptive metadata</a>.</p>
+          <section class="axioms">
+            <h4 class="subhead">Why</h4>
+            <p>Since location is such a powerful organizing principle, it is usually necessary to specifically describe the spatial details and nature of a
+              dataset to discover it as well as to determine its fitness for use. This information is used, for example, by
+                <a>SDI</a> catalog services that offer spatial querying to find data - but also by
+              users to understand the nature of the dataset. In some cases, for example when dealing with crowd-sourced data, provenance information 
+              or how the dataset came to be in its published form and with what quality, is important as well. The first level of spatial description is the spatial extent of the dataset,
+              the area of the world that the dataset describes. This often suffices for initial discovery, but further levels of description are needed to evaluate a dataset for use.
+              These include the dataset spatial coverage (continuity, resolution, properties) as well as the spatial representation or geometric model (for example, grid coverage,
+              discrete coverage, point cloud, linear network). Dataset quality measures such as positional accuracy are also important for determining applicability. In the case
+              of datasets whose spatial characteristics vary over their temporal coverage, spatial descriptions must include an explicit temporal aspect</p>
+          </section>
+          <section class="outcome">
+            <h4 class="subhead">Intended Outcome</h4>
+            <p>Dataset metadata should include the information necessary to enable spatial queries
+              within catalog services such as those provided by <a>SDIs</a>.</p>
+            <p>Dataset metadata should also include the information required for a user to evaluate
+              whether a spatial dataset is suitable for their intended application.</p>
+          </section>
+          <section class="how">
+            <h4 class="subhead">Possible Approach to Implementation</h4>
+            <p>When publishing a dataset, provide as much spatial metadata as necessary, but at least the spatial extent, coverage, and representation.
+              Other examples of spatial metadata include: </p>
+            <ul>
+              <li>number of dimensions (1D, 2D, 3D, 4D)</li>
+              <li>spatial representation type (e.g. grid, vector, text table)</li>
+              <li>geometric property (e.g. boundary, region, centerline, centroid, field</li>
+              <li>Coordinate Reference System(s) - refer to <a href="#CRS-background" class="sectionRef"></a> for an introduction to that topic</li>
+              <li>spatial resolution - <a href="#desc-accuracy" class="sectionRef">Best Practice 5: Describe the positional accuracy of spatial data</a></li>
+              <li>spatial significance of non-spatial properties (e.g. point value, interpolation, unit average, sum)</li>
+            </ul>
+            <p>In Spatial Data Infrastructures, the accepted standard for describing metadata is
+              [[ISO-19115]] or profiles thereof. </p>
+            <p>To provide information about the spatial attributes of the dataset on the Web one
+              can: </p>
+            <ul>
+              <li>As shown in [[DWBP]] <a
+              href="https://www.w3.org/TR/dwbp/#DescriptiveMetadata">Best Practice 2: Provide descriptive metadata</a>:
+                Include the spatial coverage of the features described by the dataset using
+                [[VOCAB-DCAT]] and a reference to a named place in a common vocabulary for
+                geospatial semantics (e.g. <a
+                  href="http://www.geonames.org/ontology/documentation.html">GeoNames</a>), </li>
+              <li>Again, use [[VOCAB-DCAT]], but instead of a reference to a named place, use a set
+                of coordinates to specify the boundaries of the area either as a bounding box (add
+                glossary ref) or a polygon.</li>
+              <li>Use the spatial extension of [[VOCAB-DCAT]], [[GeoDCAT-AP]], to specify spatial
+                attributes that are not available in [[VOCAB-DCAT]]. [[GeoDCAT-AP]] provides an RDF
+                syntax binding for the metadata elements defined in the core profile of [[ISO-19115]]
+                and in the INSPIRE metadata schema [[INSPIRE-MD]].</li>
+              <li>Use geospatial ontologies (see W3C Geospatial Incubator Group (GeoXG)'s <a
+                  href="https://www.w3.org/2005/Incubator/geo/XGR-geo-ont-20071023/">report</a>) to
+                describe the spatial data for the datasets.</li>
+            </ul>
+            <aside class="example">
+              <h4>Spatial representation type</h4>
+              <p>[[GeoDCAT-AP]] models this information by using <code>adms:representationTechnique</code> [[VOCAB-ADMS]], with URIs
+                corresponding to the items in the appropriate <a
+                  href="https://geo-ide.noaa.gov/wiki/index.php?title=ISO_19115_and_19115-2_CodeList_Dictionaries#MD_SpatialRepresentationTypeCode"
+                  >ISO 19115 code list</a>.</p>
+              <pre class="example" id="ex-geodcat-ap-dataset-spatial-representation-type-vector" title="GeoDCAT-AP specification of a dataset using a vector spatial representation type">
+a:Dataset a dcat:Dataset ;
+  adms:representationTechnique &lt;http://inspire.ec.europa.eu/metadata-codelist/SpatialRepresentationTypeCode/vector&gt; .
+</pre>
+              <pre class="example" id="ex-geodcat-ap-dataset-spatial-representation-type-grid" title="GeoDCAT-AP specification of a dataset using a grid spatial representation type">
+a:Dataset a dcat:Dataset ;
+  adms:representationTechnique &lt;http://inspire.ec.europa.eu/metadata-codelist/SpatialRepresentationTypeCode/grid&gt; .
+</pre>
+              <p class="note">The URIs in the example, denoting the spatial representation type, are part of a register yet to be added to the <a href="http://inspire.ec.europa.eu/registry/">INSPIRE Registry</a>. Therefore, they currently do not resolve.</p>
+            </aside>
+            <aside class="example">
+              <h4>Metadata for crowd-sourced data</h4>
+              <p>Quality, trust and density levels of crowd-sourced data varies and it is important that the data is provided with contextual information that helps people judge the probable completeness and accuracy of the observations. Human-readable and machine-readable metadata data should be provided with crowd-sourced data.</p>
+              <p>An example of crowd-sourced data that is being put to use is the <a href="https://twitter.com/hashtag/uksnow">Twitter hashtag #uksnow</a> for snowfall observations, which are shown on the <a href="http://uksnowmap.com">#uksnow Map</a>. In this case, the Twitter accounts from which observations originate are shown, giving users an idea of the source and its trustworthiness.</p>
+            </aside>
+          </section>
+          <section class="test">
+            <h4 class="subhead">How to Test</h4>
+            <p>Check if the spatial metadata for the dataset itself includes the overall features of
+              the dataset in a human-readable format.</p>
+            <p>Check if the descriptive spatial metadata is available in a valid machine-readable
+              format.</p>
+          </section>
+          <section class="ucr">
+            <h4 class="subhead">Evidence</h4>
+            <p><span>Relevant requirements</span>: <a
+                href="https://www.w3.org/TR/sdw-ucr/#Discoverability"
+                >R-Discoverability</a>, <a
+                href="https://www.w3.org/TR/sdw-ucr/#Compatibility"
+                >R-Compatibility</a>, <a
+                href="https://www.w3.org/TR/sdw-ucr/#BoundingBoxCentroid"
+                >R-BoundingBoxCentroid</a>, <a
+                href="https://www.w3.org/TR/sdw-ucr/#Crawlability"
+                >R-Crawlability</a>, <a
+                href="https://www.w3.org/TR/sdw-ucr/#SpatialMetadata"
+                >R-SpatialMetadata</a> and <a
+                href="https://www.w3.org/TR/sdw-ucr/#Provenance"
+                >R-Provenance</a>.</p>
+          </section>
+          <section class="benefits">
+            <h4 class="subhead">Benefits</h4>
+            <ul class="benefitsList">
+              <li>Reuse</li>
+              <li>Discoverability</li>
+            </ul>
+          </section>
+        </div>
+        <div class="practice">
+          <p><span id="provide-context" class="practicelab">(to be deleted)</span></p>
+          <p class="practicedesc"></p>
+          <section class="axioms">
+            <h4 class="subhead">Why</h4>
+          </section>
+          <section class="outcome">
+            <h4 class="subhead">Intended Outcome</h4>
+          </section>
+          <section class="how">
+            <h4 class="subhead">Possible Approach to Implementation</h4>
+          </section>
+          <section class="test">
+            <h4 class="subhead">How to Test</h4>
+          </section>
+          <section class="ucr">
+            <h4 class="subhead">Evidence</h4>
+          </section>
+          <section class="benefits">
+            <h4 class="subhead">Benefits</h4>
+          </section>
+        </div>
+        <div class="practice">
+          <p><span id="bp-crs-choice" class="practicelab">Choose the coordinate reference system to suit your user's applications</span></p>
+          <p class="practicedesc">Consider your user's intended application when choosing the coordinate reference system(s) used to publish spatial data. </p>
+          <section class="axioms">
+            <h4 class="subhead">Why</h4>
+            <p>A multitude of <a>coordinate reference systems</a> exist because there is no perfect solution to meet all requirements:</p>
+            <ol>
+              <li>
+                <p>The Earth is a complicated shape (neither spherical nor flat!):</p>
+                <p>For each (Earth-based) coordinate reference system, the topographical surface of the Earth is approximated to a <em>geodetic datum</em> that is described using an <a>ellipsoid</a>. The trouble with approximation is that nothing is perfect everywhere, which means that compromise is inevitable. Some datums, like WGS 84, provide a reasonable (but not highly accurate) fit everywhere on the Earth, while other datums (such as the European Terrestrial Reference System 1989 - as used by <a href="http://epsg.io/4258">ETRS89 / EPSG:4258</a>) provide a better fit in a given region at the expense of accuracy elsewhere.</p>
+                <p>Spatial data is often <em>projected</em> from the curved surface of the Earth onto a flat plane (e.g. a computer screen or a topographical map) to make it easier to compute distances between positions and calculate areas. There are many choices of projection (e.g. equirectangular, mercator, stereographic, orthographic etc.), each of which is designed for particular tasks. As with datums, projections are often chosen to better support regional, national or local needs.</p>
+                <p>It is also worth noting that as a living planet, the Earth continues to change its shape; for example, continental drift moves Australia north-eastwards several centimeters each year and New Zealand shifts in multiple directions. To retain accuracy, datums need to be adjusted from time to time - as is the case of the New Zealand Geodetic Datum (NZGD2000) that is frequently revised to take account of earth deformations.</p>
+              </li>
+              <li>
+                <p>Sometimes we don't want to measure relative to the surface of the Earth at all:</p>
+                <p>Spatial data such as descriptions of the built environment, geological surveys, satellite imagery, etc. are often captured and stored in an <em>engineering</em> coordinate reference system as measurements from a local datum. For example, <em>X</em>  <em>Y</em> survey coordinates relative to a building corner, pixel positions within the image swath of a satellite camera, or distance along a linear feature from a fixed origin point.</p>
+                </li>
+            </ol>
+            
+            <p>Although it is possible to convert coordinates from one CRS to another, many users will be put off by the need to do so. Furthermore, the need for such transformations introduces a point where errors can be introduced to the spatial data - especially where users have limited expertise with spatial data.</p>
+
+            <p>When publishing spatial data, it is best to help users avoid the need for them to transform spatial data between coordinate reference systems themselves by providing data in a form, or forms, which they can use directly. To determine which coordinate reference system(s) are needed, data publishers must consider the intended applications of their user community.</p>
+
+          </section>
+          <section class="outcome">
+            <h4 class="subhead">Intended Outcome</h4>
+            <p>Spatial data is provided in a coordinate reference system, or systems, that are sensitive to the needs of user's intended applications.</p>
+            <p>Most of a publisher's anticipated user community do not need to transform coordinate values prior to using the spatial data.</p>
+          </section>
+          <section class="how">
+            <h4 class="subhead">Possible Approach to Implementation</h4>
+            <div class="note">
+              <p>Whichever <a>coordinate reference system</a> is chosen for the publication of spatial data, it is imperative that that choice is made clear to users. Please refer to <a href="#bp-crs" class="sectionRef">Best Practice 17: State how coordinate values are encoded</a> for further details.</p>
+            </div>
+
+            <p>The first thing that publishers of spatial data need to do is consider their audience.</p>
+
+            <p>When publishing spatial data on the Web, the largest community of potential users will be unknown: anyone might find and use data published on the Web! To support this <em>unanticipated reuse</em>, we recommend <em>always</em> publishing your spatial data using a global coordinate reference system which allows spatial data from multiple sources to be readily combined for display or computation. WGS 84 Lat/Long (<a href="http://epsg.io/4326">EPSG:4326</a>) or WGS 84 Lat/Long/Elevation (<a href="http://epsg.io/4979">EPSG:4979</a>) are good choices as many of the tools and applications used by Web developers are set up to use data from GPS-enabled mobile devices that all use WGS 84. Although Web Mercator (<a href="http://epsg.io/3857">EPSG:3857</a>) has global coverage data publishers should be aware that its geodetic datum is spherical and not true to the shape of the earth, thereby introducing positional differences of up to 20 kilometers when compared with WGS 84.</p>
+
+            <p>Where considerations of the known user community (or communities) call for different coordinate reference systems, we recommend publishing spatial data in multiple representations: one for each of the prioritized coordinate reference systems. Clearly, the number of representations provided needs to be determined with respect to the associated effort. However, remember that a decision not to publish data in a priority CRS will result in each member of your user community needing to do that task - or them not using your data.</p>
+            <p>Common reasons for needing to publish in additional coordinate reference systems include:</p>
+            <ol>
+              <li>
+                <p>publication through government data portals that require use of a projected CRS defined by the national mapping agency - and similar legislative requirements;</p>
+                <p class="example">The <a href="https://bag.basisregistraties.overheid.nl/">Basisregistraties Adressen en Gebouwen</a> (BAG), or <em>Basic Registers for Addresses and Buildings</em>, provided by <a href="https://www.kadaster.nl/">Kadaster</a>, publishes data in both OGC CRS84 (using the WGS 84 geodetic datum) and the Amersfoort / RD (<a href="http://epsg.io/28992">EPSG:28992</a>) coordinate reference systems.</p>
+                <p class="example">The INSPIRE Directive 2007/2/EC of the European Commission requires that the European Terrestrial Reference System 1989 ETRS89 (<a href="http://epsg.io/4258">EPSG:4258</a>) is used for the referencing of spatial data sets.</p>
+              </li>
+              <li>applications such as defense and precision agriculture that require coordinates to be accurate to tens of centimeters or less, thereby requiring the use of a CRS with an alternative geodetic datum that provides a superior fit for the local or regional geographic area - noting that every CRS and datum should define the geographic area within which it is intended to be used;</li>
+              <li>the need to support applications that work in a local frame of reference using an engineering CRS - such as in an urban environment, inside a building complex or using chainage along a survey line;</li>
+              <li>avoiding computationally intensive reprojection of raster data within end-user applications; and </li>
+              <li>the need to retain the integrity of raster data by publishing in its original projection, thereby avoiding modification of pixel values due to the reprojection.</li>
+            </ol>
+
+            <div class="note">
+              <p>Discussion of coordinate system transformations is beyond the scope of this best practice document: converting coordinates between CRSs that use different datums and or projections can be very involved. This is especially true where elevation values are missing from the source data. For reference, EPSG guidelines say that in such cases reasonable assumptions are:</p>
+              <ul>
+                <li>Height = 0 meters (i.e. we are standing on the surface of the ellipsoid); or</li>
+                <li>The height is given by a digital elevation model (i.e. we are standing on the surface of the planet).</li>
+              </ul>
+              <p>That said, we note that there are several open source software implementations are available to help users do such conversions. These include: the <a href="http://www.gdal.org/">Geospatial Data Abstraction Library</a> (GDAL), the <a href="http://proj.osgeo.org/">Cartographic Projections Library</a> (PROJ.4), its associated <a href="http://proj4js.org/">JavaScript implementation</a> (PROJ4.JS) and the <a href="http://sis.apache.org/">Apache Spatial Information System Library</a> (SIS).</p>
+            </div>
+
+          </section>
+          <section class="test">
+            <h4 class="subhead">How to Test</h4>
+            <p>Spatial data is available in at least WGS 84 Lat/Long (<a href="http://epsg.io/4326">EPSG:4326</a>) or WGS 84 Lat/Long/Elevation (<a href="http://epsg.io/4979">EPSG:4979</a>).</p>
+          </section>
+          <section class="ucr">
+            <h4 class="subhead">Evidence</h4>
+            <p><span>Relevant requirements</span>: 
+              <a href="https://www.w3.org/TR/sdw-ucr/#AvoidCoordinateTransformations">R-AvoidCoordinateTransformations</a>, 
+              <a href="https://www.w3.org/TR/sdw-ucr/#CoordinatePrecision">R-CoordinatePrecision</a>.
+            </p>
+          </section>
+          <section class="benefits">
+            <h4 class="subhead">Benefits</h4>
+            <ul class="benefitsList">
+              <li>Comprehension</li>
+            </ul>
+          </section>
+        </div>
+
+        <div class="practice">
+          <p><span id="indexable-by-search-engines" class="practicelab">Make your spatial data indexable by search engines</span></p>
+          <p class="practicedesc">Search engines should be able to crawl spatial data on the Web and index spatial things for direct discovery by users.</p>
+          <section class="axioms">
+            <h4 class="subhead">Why</h4>
+
+            <p>In <a>SDIs</a> information about spatial datasets is published as authoritative metadata records and collated in Web-based catalogues. This approach causes several problems:</p>
+            <ol>
+              <li>the catalogues are often designed to primarily support expert users - people may not even be aware of their existence;</li>
+              <li>once you have discovered a dataset that meets your needs and identified where it is available from, a second step is required to access the data itself - often requiring the use of unfamiliar protocols or complex API requests; and</li>
+              <li>the data itself is not indexed - discovery relies on the metadata records that are often sparsely populated or out of date.</li>
+            </ol>
+
+            <p>Search engines are the common starting point for people looking for content on the Web that is widely understood. By publishing spatial data in a way that enables their crawlers to index spatial datasets including each <a>spatial thing</a>, the fidelity of search results should improve. Users will be able to directly search for specific entities rather than having to look for a dataset and then parse through it; e.g. to search for "Anne Frank’s House" (<a href="https://g.co/kg/m/02s5hd"><code>https://g.co/kg/m/02s5hd</code></a>) rather than looking for a dataset about "Cultural Heritage in Amsterdam" and hoping that it contains a reference to what you’re interested in.</p>
+
+            <p class="note">At present, spatial information is not widely exploited by search engines. However, by increasing the volume of spatial information presented to search engines, and the consistency with which it is provided, we expect search engines to begin offering spatial search functions. We already see evidence of this in the form of contextual search, such as prioritization of search results from nearby entities. In addition, search engines are beginning to offer more structured, custom searches that return only results that include certain [[SCHEMA-ORG]] types, like <a href="http://schema.org/Dataset">Dataset</a>, <a href="http://schema.org/Place">Place</a> or <a href="http://schema.org/City">City</a>.</p>
+          </section>
+          <section class="outcome">
+            <h4 class="subhead">Intended Outcome</h4>
+            <p>Information about spatial datasets and things is indexed by search engines.</p>
+
+            <p>Users can find spatial things using common search engines.</p>
+          </section>  
+          <section class="how">
+            <h4 class="subhead">Possible Approach to Implementation</h4>
+
+            <p>In general, you need to:</p>
+            <ol>
+            	<li>publish a HTML Web-page for the spatial dataset and each spatial thing that it describes; and</li>
+            	<li>make sure that those pages can be crawled.</li>
+            </ol>
+            
+				<p>The Web-page for the dataset is an entry-point for humans to browse and for the search engines to crawl your data. This landing page should provide descriptive metadata that helps users evaluate whether the dataset meets their needs (see <a href="#spatial-info-dataset-metadata">Best Practice 1: Include spatial metadata in dataset metadata</a> and [[DWBP]] <a href="https://www.w3.org/TR/dwbp/#DescriptiveMetadata">Best Practice 2: Provide descriptive metadata</a>), and may provide links to other service end-points, APIs or tools that will help a user work with the dataset. The landing page should be indexable by the search engines so that it can be discovered too!</p>
+
+        <p>To enable humans and Web-crawlers to find HTML pages for the spatial things, the "landing page" needs to include hyperlinks that can be followed. Where you have a larger collection of spatial things, you should support paging through the collection.</p> 
+
+				<p>You may also consider using <a href="https://www.sitemaps.org/index.html">Sitemaps</a> to direct the Web-crawler; noting that sitemaps currently are limited to several thousands of entries and will not work for larger datasets.</p>
+
+				<p>For very large datasets paging through thousands of pages is not useful for a human either. Consider supporting filtering and/or organize the spatial things into subsets, as described in <a href="#bp-exposing-via-api" class="sectionRef">section 12.6 Spatial Data Access</a>.</p>
+
+            <aside class="example">
+            	<p>In case of an address dataset, you could organize the spatial things (the addresses) by municipality, post code and street name to support a human user to get to a building with a few clicks.</p>
+            </aside>
+
+				<p>A pre-condition for this best practice is <a href="#globally-unique-ids">Best Practice 7: Use globally unique persistent HTTP URIs for spatial things</a> as persistent identifiers are essential to support reliable indexing and linking. Traditionally spatial datasets have not been maintained with stable identifiers for spatial things, but to share spatial data on the Web stable identifiers are a must. Sharing spatial data is more than "just" making the dataset available on the Web.</p>
+
+            <p>Each Web-page can likely be generated programmatically from the data you hold about the spatial thing, either directly from the data or by using an API that makes the data available on the Web.</p>
+
+            <aside class="example">
+            	<p>Possible implementation approaches for addressing this best practice in the context of an existing SDI are discussed in more detail in <a href="#convenience-apis">Best Practice 11: Expose spatial data through 'convenience APIs'</a> for additional information. For example, by using a proxy tool like <a href="https://github.com/interactive-instruments/ldproxy">ldproxy</a> or by mapping the data in the SDI dynamically to crawlable resources on the web using the [[R2RML]] standard and Linked Data Publication tools. Both approaches generate crawlable data from features in your spatial datasets at query time and allow to enrich the data on the Web with additional information and links.</p>
+            </aside>
+
+				<p>It is important to keep in mind that the HTML representations should not mainly be designed for the search engines, but they should present the data in a clear and understandable way to human users. The page about the spatial thing should be useful to a user and encourage others to link to the page when they share other information about the spatial thing. This typically will also improve the ranking of these pages in search results.</p>
+
+            <aside class="example">
+              <p>The <a href="http://maps.nanaimo.ca/data/property/">Property Search in the City of Nanaimo, Canada</a> provides a landing page and one page per property. The landing page offers a search capability and the option to browse by street. This data is indexed; a search for, for example, "2100 AARON WAY, NANAIMO, BC" in a popular search engine returns the Nanaimo data for this spatial thing as one of the first results.</p>
+              <p>The <a href="http://environment.data.gov.uk/bwq/profiles/">Bathing Water Quality Explorer for England</a> provides a landing page and one page per site. Sites can be searched, selected from a list or in a map.</p>
+              <p>In both cases, the pages of the spatial things are generated from the underlying data at request time.</p>
+              <p>The property Web-pages in Nanaimo also use [[MICRODATA]] annotations using [[SCHEMA-ORG]], which is discussed below.</p>
+            </aside>
+
+				<p>In addition to exposing the spatial data as linked HTML Web-pages, indexing by web-engines can be further enhanced by incorporating a description of the spatial thing as structured markup (in particular [[MICRODATA]] or [[JSON-LD]] annotations using [[SCHEMA-ORG]]) as this enables the search engines to make more detailed assumptions about your resource. It is important to note that this is not only helpful to search engines, but also to other tools that want to understand more about the semantics of the resource, for example, its location.</p>
+				
+				<p>In [[SCHEMA-ORG]], a spatial dataset is a <a href="http://schema.org/Dataset">Dataset</a> and a spatial thing is in general a <a href="http://schema.org/Place">Place</a> or an <a href="http://schema.org/Event">Event</a>. For some types of spatial things, more specific sub-types exist, for example <a href="http://schema.org/City">City</a> or <a href="http://schema.org/Mountain">Mountain</a>.</p> 
+				
+				<p>Location information about a spatial thing is typically provided using a geometry (<a href="http://schema.org/GeoCoordinates">GeoCoordinates</a> or <a href="http://schema.org/GeoShape">GeoShape</a>) or a <a href="http://schema.org/PostalAddress">PostalAddress</a>. [[SCHEMA-ORG]] coordinates are restricted to WGS 84 with longitude and latitude. Supported geometry types are points, line strings, polygons, boxes and circles.</p>
+				
+				<p>By using [[SCHEMA-ORG]] annotations, search engines and others can connect location information with other information, e.g. about the nature of the spatial thing, opening hours, contact details, etc.</p>
+				
+				<p>The use of [[SCHEMA-ORG]] for spatial data is in its early days and should be understood as an "emerging practice".</p>
+
+        <aside class="example" id="ex-schemaorg-dataset-and-place">
+				  <p>This code-snippet illustrates a [[JSON-LD]] annotation using a [[SCHEMA-ORG]] <a href="http://schema.org/Dataset">Dataset</a> for an address dataset in the Netherlands that may be embedded in the HTML of the Web-page. It includes a name, a description, the spatial coverage using a bounding box, the URL of the Web-page, and a link to another dataset containing this dataset. The same annotation could also be provided using [[MICRODATA]], but we use [[JSON-LD]] here as this presents the structured data in a more human-readable way.</p>
+              <pre id="ex-schemaorg-dataset" title="">&lt;script type="application/ld+json">
+{
+  "@context" : {
+    "@vocab" : "http://schema.org/"
+  },
+  "@type" : "Dataset",
+  "@id" : "http://www.ldproxy.net/bag/inspireadressen/",
+  "name" : "Adressen",
+  "description" : "INSPIRE Adressen afkomstig uit de basisregistratie Adressen, beschikbaar voor heel Nederland",
+  "url" : "http://www.ldproxy.net/bag/inspireadressen/",
+  "isPartOf" : {
+    "@type" : "Dataset",
+    "url" : "http://www.ldproxy.net/bag/"
+  },
+  "keywords" : "Adressen",
+  "spatialCoverage" : {
+    "@type" : "Place",
+    "geo" : {
+      "@type" : "GeoShape",
+      "box" : "47.975,3.053 53.504,7.24"
+    }
+  }
+}
+&lt;/script></pre>
+				  <p>This code-snippet illustrates a [[JSON-LD]] annotation using a [[SCHEMA-ORG]] <a href="http://schema.org/Place">Place</a> for the address of the "Anne Frank’s House" in that dataset. It includes the location, the URL of the Web-page, and the structured postal address information.</p>
+              <pre id="ex-schemaorg-place" title="">&lt;script type="application/ld+json">
+{
+  "@context" : {
+    "@vocab" : "http://schema.org/"
+  },
+  "@type" : "Place",
+  "@id" : "http://www.ldproxy.net/bag/inspireadressen/inspireadressen.3329155",
+  "url" : "http://www.ldproxy.net/bag/inspireadressen/inspireadressen.3329155",
+  "geo" : {
+    "@type" : "GeoCoordinates",
+    "longitude" : "4.8839893538143055",
+    "latitude" : "52.37520202332491"
+  },
+  "name": "Anne Franks House",
+  "description": "Museum house where Anne Frank &amp; her family hid from the Nazis in a secret annex, during WWII.",
+  "address" : {
+    "@type" : "PostalAddress",
+    "streetAddress" : "Prinsengracht 267",
+    "addressLocality" : "Amsterdam",
+    "postalCode" : "1016GV"
+  }
+}
+&lt;/script></pre>
+            </aside>
+            
+            <p>The Web-pages should also provide a mechanism to download data in the formats you decide to support. [[DWBP]] <a href="https://www.w3.org/TR/dwbp/#MultipleFormats">Best Practice 14: Provide data in multiple formats</a> provides guidance.</p>
+				
+				    <p>Typically, multiple formats for a resource are supported using two mechanisms: HTTP content negotiation and by adding format-specific file extensions to the resource URI like ".json", ".xml" or ".ttl". Content negotiation is the standard mechanism of HTTP and the format-specific URIs enable the use of clickable links to the resource in a specific format.</p>
+				
+				    <p>Search engines may also index resource representations in other formats than HTML.</p>
+
+            <aside class="example">
+              <p>At the time of writing, Google is indexing KML documents and supporting advanced searches that are restricted to KML documents. [[GML]] files are also indexed, but only like any other XML documents. JSON, including GeoJSON, is currently not indexed.</p>
+            </aside>
+
+            <div class="note">
+              <p>In 2016, these topics were analyzed in a testbed organized by Geonovum in the Netherlands. More details can be found in reports from the testbed: <a href="http://geo4web-testbed.github.io/topic4/">Spatial Data on the Web using the current SDI</a> and <a href="https://github.com/geo4web-testbed/topic3/wiki">Crawlable geospatial data using the ecosystem of the Web and Linked Data</a>.</p>
+              <p>The use of [[SCHEMA-ORG]] for describing spatial information is continually evolving; spatial data publishers should familiarize themselves with current practices. A useful <a href="https://developers.google.com/search/docs/guides/intro-structured-data">Introduction to Structured Data</a> is provided in Google's developer portal.</p>
+            </div>
+
+          </section>
+          <section class="test">
+            <h4 class="subhead">How to Test</h4>
+            <p>Using a Web browser,</p>
+            <ol>
+              <li>search for the landing page of your dataset, and</li>
+              <li>check that you can browse to human-readable HTML pages for each spatial thing that the dataset describes.</li>
+            </ol>
+            <p>Monitor the search consoles of the search engines about the progress in indexing your Web-pages and their structured data. In case any errors are reported, try to fix them.</p>
+          </section>
+          <section class="ucr">
+            <h4 class="subhead">Evidence</h4>
+            <p><span>Relevant requirements</span>: <a href="https://www.w3.org/TR/sdw-ucr/#BoundingBoxCentroid">R-BoundingBoxCentroid</a>, <a href="https://www.w3.org/TR/sdw-ucr/#Crawlability">R-Crawlability</a>, <a href="https://www.w3.org/TR/sdw-ucr/#Discoverability">R-Discoverability</a>, <a href="https://www.w3.org/TR/sdw-ucr/#Linkability">R-Linkability</a>, <a href="https://www.w3.org/TR/sdw-ucr/#MachineToMachine">R-MachineToMachine</a>.</p>
+          </section>
+          <section class="benefits">
+            <h4 class="subhead">Benefits</h4>
+            <ul class="benefitsList">
+              <li>Discoverability</li>
+            </ul>
+          </section>
+        </div>
+
+      </section>
+      <section id="bp-dataquality">
+        <h3>Spatial Data Quality</h3>
+        <p>[[DWBP]] provides a best practice discussing how the quality of data on the web should be
+          described (see [[DWBP]] <a href="https://www.w3.org/TR/dwbp/#quality">section 8.5 Data Quality</a> for
+          more details). This section is based on the Data Quality section from [[DWBP]] and adds a
+          best practice specific for spatial data, which concentrates on the accuracy of the positions in the data
+          - how close are they to the actual positions of the real world things?</p>
+        <p>In the Spatial Metadata section, we provided a <a href="#bp-crs-choice" class="sectionRef">Best Practice</a> on how
+          to deal with CRS in spatial data on the web. There is also a clear link between CRS and
+          data quality, because the accuracy of spatial data depends for a large part on the CRS
+          used. This can be seen as conformance of data with a "standard" - in this case, a (spatial
+          or temporal) reference system. This is how you can describe spatial data quality using
+          different vocabularies. We will provide an example in this section. </p>
+	      <p>For some uses, simply stating conformance to a published specification may be sufficient information on spatial data quality:</p>
+            <pre class="example" id="ex-geodcat-ap-dataset-conformance-with-specification" title="GeoDCAT-AP specification of a dataset conformance with the INSPIRE Regulation on spatial data and services interoperability">a:Dataset a dcat:Dataset ;
+  dct:conformsTo &lt;<a href="http://data.europa.eu/eli/reg/2010/1089/oj">http://data.europa.eu/eli/reg/2010/1089/oj</a>&gt; .
+
+&lt;<a href="http://data.europa.eu/eli/reg/2010/1089/oj">http://data.europa.eu/eli/reg/2010/1089/oj</a>&gt; a dct:Standard , foaf:Document ;
+  dct:title "COMMISSION REGULATION (EU) No 1089/2010 of 23 November 2010
+             implementing Directive 2007/2/EC of the European Parliament
+             and of the Council as regards interoperability of spatial
+             data sets and services"@en ;
+  dct:issued "2010-12-08"^^xsd:date .</pre>
+        <p>However, that specification makes no statement about the positional accuracy of the data, 
+          so on its own, it is only a useful quality statement for users to whom positional accuracy is not that important.</p>
+	  <div class="practice">
+          <p><span id="desc-accuracy" class="practicelab">Describe the positional accuracy of
+              spatial data</span></p>
+          <p class="practicedesc">Accuracy of spatial data should be specified in
+            machine-interpretable and human-readable form.</p>
+          <section class="axioms">
+            <h4 class="subhead">Why</h4>
+            <p>The amount of detail that is provided in spatial data and the resolution of the data
+              can vary. No measurement system is infinitely precise and in some cases the spatial
+              data can be intentionally generalized (e.g. merging entities, reducing the details,
+              and aggregation of the data) [[Veregin]]. 
+              Some spatial data applications, such as aircraft navigation, require highly accurate data.
+              For others, such as human navigation, a horizontal accuracy of a few metres is good enough.
+              For yet others, such as overlaying weather forecasts on a map, the map is only giving a general indication of place.
+              If the positional accuracy is published together with the data,
+              the user can determine whether it is appropriate to use for their application.
+              Potentially, this makes existing data more re-usable.</p>
+            <p class="note">It is important to understand the difference between precision and
+              accuracy. Seven decimal places of a latitude degree corresponds to about one
+              centimeter. Whatever the precision of the specified coordinates, the accuracy of
+              positioning on the actual earth's surface using WGS84 will only approach about a meter
+              horizontally and may have apparent errors of up to 100 meters vertically, because of
+              assumptions about reference systems, tectonic plate movements and which definition of
+              the earth's 'surface' is used.</p>
+          </section>
+          <section class="outcome">
+            <h4 class="subhead">Intended Outcome</h4>
+            <p>For many uses, the positional accuracy of the data is an important aspect of assessing
+	      its fitness for purpose (quality).
+	      As with other data quality statements, this can be a quantitative measure, a statement 
+	      of conformance to a standard or policy, or an assertion or report of fitness for a particular purpose.</p>
+          </section>
+          <section class="how">
+            <h4 class="subhead">Possible Approach to Implementation</h4>
+            <p>Describe the accuracy of spatial data in a way that is understandable for humans. </p>
+            <p>In addition, describe the accuracy of spatial data in a machine-readable format.
+              [[VOCAB-DQV]] is such a format. It is a vocabulary for describing data quality, including
+              the details of quality metrics and measurements. </p>
+	    <p>For observed (measured) datasets, it is possible to make specific quantitative statements
+	      about positional accuracy, based on knowledge of the equipment used to make the observations,
+	      and any processing carried out.</p> 
+	    <p>For <a>coverages</a>, the sampling distance is an effective way of indicating the amount of
+	      detail in the dataset - this is one of the meanings of the term "resolution".
+	      Alternatively, samples of the data could be independently checked against the real world, 
+	      and the results of that check reported.
+	      Either way, this is usually a statement of <a>absolute positional accuracy</a>, but for some uses, 
+	      relative positional accuracy is more important.</p>
+	    <p>Positional accuracy measurements, whether observed or asserted based on process,
+	      can be given using QualityMeasurement.</p>
+	    <p>For modelled datasets, for example in planning and construction, there is no 'real world' against
+	      which to assess the positional accuracy - but relative positional accuracy can still be stated.</p>
+	    <p>For many uses, a statement of the amount of detail provided is sufficient to assess fitness for purpose; 
+	      examples include "level of detail" (building models), "navigational purpose" (marine navigation),
+	      "equivalent scale" or "zoom level" (cartography).
+	      Sometimes, this is expressed as if it were a statement of positional accuracy.</p>
+	    <p>These can be expressed in the same way as for non-spatial data, using for example the QualityAnnotation,
+	      Standard, and QualityPolicy statements of [[VOCAB-DQV]].</p>
+            <aside class="example">
+              <p>examples:</p>
+              <ul>
+                <li>the ends of a 'sampling traverse' could be known in a national/global CRS to
+                  within ±5m, whilst the position of the samples themselves may be accurate to ±0.01
+                  along the traverse</li>
+                <li>a hydrographic survey may conform to the 'special order' survey specification in IHO S-44</li>
+		<li>a coverage dataset may have a ground sampling distance of 1000 metres</li>
+              </ul>
+            </aside>
+	    <p>The following example shows how DQV can express conformance to a specified positional accuracy</p>
+            <pre class="example" id="ex-geodcat-ap-dataset-conformance-with-specification2" title="GeoDCAT-AP specification of a dataset conformance with IHO's S44">a:Dataset a dcat:Dataset ;
+  dct:conformsTo &lt;<a href="https://www.iho.int/iho_pubs/standard/S-44_5E.pdf">https://www.iho.int/iho_pubs/standard/S-44_5E.pdf#Special</a>&gt; .
+
+&lt;<a href="https://www.iho.int/iho_pubs/standard/S-44_5E.pdf">https://www.iho.int/iho_pubs/standard/S-44_5E.pdf</a>&gt; a dct:Standard , foaf:Document ;
+  dct:title "IHO Standards for Hydrographic Surveys"@en ;
+  dct:issued "2008-02-01"^^xsd:date.</pre>
+            <p>The following example shows how DQV can express the amount of detail in a coverage dataset: </p>
+            <pre class="example" id="ex-dqv-dataset-quality" title="DQV specification of data quality">
+:myDataset a dcat:Dataset ;
+   dqv:hasQualityMeasurement :myDatasetPrecision, :myDatasetAccuracy .
+
+:myDatasetPrecision a dqv:QualityMeasurement ;
+   dqv:isMeasurementOf :spatialResolutionAsDistance ;
+   dqv:value "1000"^^xsd:decimal ;
+   sdmx-attribute:unitMeasure  &lt;http://www.wurvoc.org/vocabularies/om-1.8/metre>
+   .
+
+:spatialResolutionAsDistance  a  dqv:Metric;
+    skos:definition "Spatial resolution of a dataset expressed as distance"@en ;
+    dqv:expectedDataType xsd:decimal ;
+    dqv:inDimension dqv:precision
+    .
+            </pre>
+            <p>This example was taken from [[VOCAB-DQV]]. For more examples of expressing spatial data
+              precision and accuracy see DQV, <a
+                href="https://www.w3.org/TR/vocab-dqv/#h-expressdatasetaccuracyprecision">Express
+                dataset precision and accuracy</a>. 
+            </p>
+          </section>
+          <section class="test">
+            <h4 class="subhead">How to Test</h4>
+            <p>Check if the metadata contains at least one human and machine readable statement regarding positional accuracy </p>
+	    <p>Check that the kind of statement is relevant to the kind of data, e.g. not an absolute positional accuracy measure for Atlantis</p>
+	    <p>Checking that the accuracy statement is actually correct is beyond the scope of this best practice.</p>
+          </section>
+          <section class="ucr">
+            <h4 class="subhead">Evidence</h4>
+            <p><span>Relevant requirements</span>: <a
+                href="https://www.w3.org/TR/sdw-ucr/#MachineToMachine">R-MachineToMachine</a>, <a
+                href="https://www.w3.org/TR/sdw-ucr/#QualityPerSample">R-QualityPerSample</a>.</p>
+          </section>
+          <section class="benefits">
+            <h4 class="subhead">Benefits</h4>
+            <ul class="benefitsList">
+              <li>Reuse</li>
+              <li>Trust</li>
+            </ul>
+          </section>
+        </div>
+      </section>
+      <section id="bp-dataversioning">
+        <h3>Spatial Data Versioning</h3>
+        <p><a>Spatial things</a> and their attributes can change over time. For example, a lake may grow or shrink due to changes in climate, water extraction or any number of reasons. For many applications, it is important that information about spatial things is kept up to date. When new information is available, the data publisher may make this available on the Web according to their update schedule and policies. [[DWBP]] <a href="https://www.w3.org/TR/dwbp/#dataVersioning">section 8.6 Data Versioning</a> and <a href="https://www.w3.org/TR/dwbp/#AccessUptoDate">Best Practice 21: Provide data up to date</a> provide directly applicable guidance.</p>
+
+        <p>When dealing with change to a spatial thing, you should consider its lifecycle; in particular, how much change is acceptable before a spatial thing can no longer be considered as the same resource. Consider Eddystone Lighthouse for example: the “Eddystone Light”, a maritime navigation aid, has existed in (more or less) the same place on Eddystone Rocks since 1698. A single HTTP URI (such as <a href="http://dbpedia.org/resource/Eddystone_Lighthouse"><code>http://dbpedia.org/resource/Eddystone_Lighthouse</code></a>) is used to identify “the lighthouse on Eddystone rocks” for all that period. The lighthouse's attributes (such as its focal height, visible range and light characteristic) have changed over that period, but we still consider it to be the same lighthouse. However, if our interest is historic buildings, we would identify the four different structures that have stood on that site as different spatial things, from Winstanley's Eddystone Lighthouse (the first incarnation) to Douglass' Eddystone Lighthouse (the 4th and current incarnation). Incremental change for these structures during the entire period from 1698 is not appropriate; one structure replaces another and so each structure should be assigned a unique identifier. In summary, different things are important to different people!</p>
+
+        <p>Essentially, the decision to assign a new identifier in response to change depends on how <em>domain experts</em> think about the lifecycle of the spatial thing, which then manifests in a data modelling choice. [[DWBP]] <a href="https://www.w3.org/TR/dwbp/#dataVocabularies">section 8.9 Data Vocabularies</a> and <a href="#bp-expressing-spatial" class="sectionRef"></a> provide further guidance on the topic of data modelling; determining which concepts and relationships should be used to describe your area of interest.</p>
+
+        <p>Data publishers should not attempt to guess <em>all</em> the purposes for which someone might use or reference their data - ending up with a super-complex data model that tries to cover every possible use case. Instead, data publishers should try to help data consumers make informed decisions about the best way to use the data by providing good metadata. When it comes to spatial things, or <em>any</em> resource, that changes over time, it is important to provide metadata about the life cycle of those entities and the resources used to describe them. Given that information, data consumers can make considered choices about which resource they want to link to. [[DWBP]] <a href="https://www.w3.org/TR/dwbp/#metadata">section 8.2 Metadata</a> provides useful guidance.</p>
+
+        <p>All that said, if you consider that the change affects the fundamental nature of the spatial thing, then you should assign a new identifier. See <a href="#bp-identifiers" class="sectionRef"></a> for more details. Otherwise, read on for guidance on how to describe properties that change over time.</p>
+
+        <div class="practice">
+          <p><span id="desc-changing-properties" class="practicelab">Describe properties that change over time</span></p>
+          <p class="practicedesc">Spatial data should include metadata that allows a user to determine when it is valid for.</p>
+          <section class="axioms">
+            <h4 class="subhead">Why</h4>
+            <p><a>Spatial things</a> and their attributes change over time. Mostly, users are interested in current information. They need to be able to determine whether the published description of a spatial thing meets their needs. For example, is the published geographic extent of the City of Amsterdam relevant for a land-usage study of the nineteenth century? (<a href="http://www.gemeentegeschiedenis.nl">Gemeentegeschiedenis.nl</a>, "Municipality History", illustrates how the extent of Amsterdam has changed during the past 200-years, in <a href="http://www.gemeentegeschiedenis.nl/gemeentenaam/Amsterdam">HTML</a> and <a href="http://www.gemeentegeschiedenis.nl/gemeentenaam/json/Amsterdam">GeoJSON</a>). Where the information is available, a user may want to browse older versions of the published information to understand the nature of any changes or to find historical information.</p>
+          </section>
+          <section class="outcome">
+            <h4 class="subhead">Intended Outcome</h4>
+            <p>Users are provided with the most recent version of information about a spatial thing and its attributes by default.</p>
+            <p>Users can determine the time-period for which data is applicable.</p>
+            <p>If a version history of changes is available, users can browse through a set of changes to see how a spatial thing and its attributes have changed over time.</p>
+          </section>
+          <section class="how">
+            <h4 class="subhead">Possible Approach to Implementation</h4>
+
+            <p>When publishing information about a spatial thing that is subject to change there are three main approaches to consider:</p>
+            <ol>
+              <li>simply updating the description of the spatial thing in response to a change;</li>
+              <li>providing a series of immutable snapshots that describe the spatial thing at various points in its lifecycle; and</li>
+              <li>capturing a time-series of data values within an attribute of the spatial thing.</li>
+            </ol>
+
+            <p>Whichever approach is chosen, publishers of spatial data should consider how dataset metadata plays an important part in helping users determine whether a dataset is fit for their use. Particularly where the contents of a dataset change with time, statements about the (most recent) publication date, the frequency of update and the time-period for which the dataset is relevant (i.e. temporal extent) should be provided. Please refer to [[DWBP]] <a href="https://www.w3.org/TR/dwbp/#DescriptiveMetadata">section 8.2 Metadata</a> for more details about dataset metadata.</p> 
+
+            <p>A description of the lifecycle of the spatial things (e.g. what triggers a change and whether those changes are versioned etc.) should also be provided in either the dataset's metadata, schema or specification. For example, the UK's Digital National Framework policy states that data publishers must provide these lifecycle rules.</p>
+
+            <p>Approach (1) is lightweight and should only be used where there are no user requirements that require access to older descriptions of the spatial things. Data publishers simply replace the old description of the spatial thing with the amended description and keep users informed about updates by providing the appropriate metadata (e.g. when the data was changed). This may be achieved using dataset metadata (as outlined above) or by including the metadata attributes in the description of each spatial thing.</p>
+
+            <p>Where users are anticipated to need to understand <em>how</em> a spatial thing has changed over time, approaches (2) and (3) must be considered.</p>
+
+            <p>Approach (2) requires the data publisher to publish immutable resources that describe the spatial thing at specific points in time (i.e. "snapshots") and provide a mechanism for users to browse between those snapshots. Given that each snapshot of the spatial thing is published as a separate resource, this approach is suited to infrequent changes so that the number of snapshots does not become unwieldy.</p>
+
+            <p>The URI for the spatial thing, the <em>base</em> URI, should resolve to provide the current information and a link to its version history of snapshots. [[DWBP]] <a href="https://www.w3.org/TR/dwbp/#VersionHistory">Best Practice 8: Provide version history</a> describes how a version history may be implemented. Each snapshot resource within the version history must be uniquely identified; a common approach is to append a date/time stamp to the base URI as a version indicator. [[DWBP]] <a href="https://www.w3.org/TR/dwbp/#VersioningInfo">Best Practice 7: Provide a version indicator</a> provides relevant guidance.</p>
+
+            <aside class="example" id="ex-municp-history" title="Changing boundary of Amsterdam">
+              <p>The extent of the City of Amsterdam has changed during the last 200 years. This example, based on <a href="http://www.gemeentegeschiedenis.nl">Gemeentegeschiedenis.nl</a> ("Municipality history") (condensed and changed to reflect the recommendations in this best practice), shows how the version history of Amsterdam's boundary can be provided as a series of immutable snapshots in GeoJSON. </p> 
+
+              <p>The current information on Amsterdam including the current boundary: </p>
+              <pre>
+{
+ "uri": "http://www.gemeentegeschiedenis.nl/gemeentenaam/Amsterdam",
+ "name": "Amsterdam",
+ "inProvince": "Noord-Holland",
+ "cbscode": "0363",
+ "absorbed": "http://www.gemeentegeschiedenis.nl/gemeentenaam/Weesperkarspel",
+ "2016": {
+   "type": "FeatureCollection",
+   "features": [{
+   "type": "Feature",
+   "versionedUri": "http://www.gemeentegeschiedenis.nl/gemeentenaam/Amsterdam/2016",
+   "replaces": "http://www.gemeentegeschiedenis.nl/gemeentenaam/Amsterdam/2014",
+   "year": "2016", 
+   "geometry": {
+      "type": "MultiPolygon",
+      "coordinates": [...],
+}}]}}            
+              </pre>
+              <p>The previous boundary of Amsterdam: </p>
+              <pre>
+{
+ "2014": {
+    "type": "FeatureCollection",
+    "features": [{
+       "type": "Feature",
+       "versionedUri": "http://www.gemeentegeschiedenis.nl/gemeentenaam/Amsterdam/2014",
+       "replacedBy": "http://www.gemeentegeschiedenis.nl/gemeentenaam/Amsterdam/2016",
+       "replaces": "http://www.gemeentegeschiedenis.nl/gemeentenaam/Amsterdam/2013",
+       "year": "2014",
+       "geometry": {
+          "type": "MultiPolygon",
+          "coordinates": [...],
+}]}}   
+              </pre>
+            </aside>
+            
+            <p>Approach (3) is suitable where a spatial thing has a small number of attributes that are frequently updated. For example, the GPS-position of a runner or when streaming data from a sensor, such as the water level from a stream gauge.</p>
+
+            <p>With this approach, the description of the spatial thing must include a property that contains a sequentially-ordered set of data-points, each of which defines a time-stamp and the values for the time-varying attribute(s). By definition, this property can be considered as a time-series <a>coverage</a>. Standard data encodings are available for time-series data, including: [[TIMESERIESML]] for [[GML]], plus [[COVERAGE-JSON]] and [[SENSORTHINGS]] for JSON.</p>
+
+            <p class="note">The OGC [[MOVING-FEATURES-XML]] and [[MOVING-FEATURES-CSV]] specifications follow the pattern described above. A <code>trajectory</code> element is used to describe the position of a spatial thing, and varying attributes (such as orientation or rotation) can be added alongside the tuples in the trajectory. However, there is limited evidence of adoption outside of Japan.</p>
+
+            <aside class="example" id="ex-alpine-runner" title="Changing position of a runner traversing the Alps">
+              <p>This examples shows a snipped of a file storing the changing GPS position of <a href="http://www.movescount.com/moves/move121790545">a runner traversing the Alps</a>. The format is GPX, a common format for exchanging a series of GPS positions. For each track point, the coordinates as well as a timestamp are stored.</p>
+              <pre>
+&lt;gpx version="1.1">
+  &lt;trk>
+    &lt;name>Move&lt;/name>
+    &lt;trkseg>
+      &lt;trkpt lat="47.24239" lon="10.749514">
+        &lt;ele>784&lt;/ele>
+        &lt;time>2016-09-06T06:01:25.009Z&lt;/time>
+      &lt;/trkpt>
+      &lt;trkpt lat="47.242403" lon="10.749489">
+        &lt;ele>784&lt;/ele>
+        &lt;time>2016-09-06T06:01:26.009Z&lt;/time>
+      &lt;/trkpt>
+      [...]
+      &lt;trkpt lat="46.968127" lon="10.870573">
+        &lt;ele>1677&lt;/ele>
+        &lt;time>2016-09-06T17:41:50.009Z&lt;/time>
+      &lt;/trkpt>
+    &lt;/trkseg>
+  &lt;/trk>
+&lt;/gpx></pre>
+            </aside>
+          </section>
+          <section class="test">
+            <h4 class="subhead">How to Test</h4>
+            <p>...</p>
+          </section>
+          <section class="ucr">
+            <h4 class="subhead">Evidence</h4>
+            <p><span>Relevant requirements</span>: <a
+                href="https://www.w3.org/TR/sdw-ucr/#MachineToMachine">R-MachineToMachine</a>, <a
+                href="https://www.w3.org/TR/sdw-ucr/#MovingFeatures">R-MovingFeatures</a>, <a
+                href="https://www.w3.org/TR/sdw-ucr/#Streamable">R-Streamable</a></p>
+          </section>
+          <section class="benefits">
+            <h4 class="subhead">Benefits</h4>
+            <ul class="benefitsList">
+              <li>Comprehension</li>
+              <li>Trust</li>
+              <li>Access</li>
+            </ul>
+          </section>
+        </div>
+      </section>
+      <section id="bp-identifiers">
+        <h3>Spatial Data Identifiers</h3>
+        <p>The primary topics of any spatial dataset are <a>spatial things</a>, each described by a set of attributes and usually at least one geometry. How your spatial data is structured will depend on the vocabulary or data model you use (see <a href="#bp-expressing-spatial" class="sectionRef"></a> for further details on vocabulary choice). This will determine the types of entities that, along with the spatial things themselves, are important enough to be given identifiers so that statements can be made about them. Geometry objects are an example of an entity that is often assigned a unique identifier so that they can be referenced or reused.</p>
+
+        <p>To publish spatial data on the Web, we need to stitch the spatial things and their corresponding entities into the Web’s information space; contributing to the <em>Web of data</em>. First: [[WEBARCH]] <a href="https://www.w3.org/TR/webarch/#p38">Good Practice: Identify with URIs</a> states that "agents should provide URIs as identifiers for resources". Second: the <a href="http://5stardata.info">5 Star Data scheme</a> states: "&#9733;&#9733;&#9733;&#9733; use URIs to denote things, so that people can point at your stuff".</p>
+
+        <p>[[DWBP]] <a href="https://www.w3.org/TR/dwbp/#identifiersWithinDatasets">Best Practice 10: Use persistent URIs as identifiers within datasets</a> provides directly applicable guidance. When identifying resources, it advises:</p>
+        <ol>
+          <li>Seek and reuse existing URIs, ensuring that the URIs are persistent and they are published by a trusted group or organization; or</li>
+          <li>Create your own persistent URIs.</li>
+        </ol>
+
+        <p>Furthermore, given ubiquitous use of the Hyper Text Transfer Protocol (HTTP) on the Web, we SHOULD use HTTP URIs to identify resources in spatial data.</p>
+
+        <p class="note">We consider identifiers in the Web’s information space to be unaffected by the choice to serve HTTP content securely or not. For example, <code>http://example.org/country/suriname</code> and <code>https://example.org/country/suriname</code> both identify the same spatial thing - in this case the South American country of Suriname.</p>
+
+        <p>Resources identified with HTTP URIs can be specified as the target of links within the Web’s global information space, enabling information from different sources to be related and combined. This is the fundamental basis of 5&#9733; Linked Data: "&#9733;&#9733;&#9733;&#9733;&#9733; link your data to other data to provide context".</p>
+
+        <div class="practice">
+          <p><span id="globally-unique-ids" class="practicelab">Use globally unique persistent HTTP URIs for spatial things</span></p>
+          <p class="practicedesc">Use stable HTTP URIs to identify spatial things, re-using commonly used URIs where they exist and it is appropriate to do so.</p>
+          <section class="axioms">
+            <h4 class="subhead">Why</h4>
+            <p>The Web works with resources that are identified using HTTP URIs. We want <a>Spatial things</a> to be first class resources on the Web that we want to make statements about and relate to other resources. To do this, spatial things need to be addressable resources in the Web’s global information space which means they must be identified using HTTP URIs.</p>
+            
+            <p>This is a fundamentally different data publication approach to what is typical today where the dataset is (often) globally identified, but individual spatial things, or "<a>features</a>" in SDI parlance, are not - at least not with a persistent identifier.</p>
+
+            <p>The HTTP URIs used to identify spatial things need to be stable or persistent so that relationships that link them to other resources don’t break.</p>
+          </section>
+          <section class="outcome">
+            <h4 class="subhead">Intended Outcome</h4>
+            <p>Spatial things become part of the Web’s global information space enabling them be linked with other spatial things and other resources and for those links to be durable. In other words, spatial data becomes part of the Web of Data.</p>
+          </section>
+          <section class="how">
+            <h4 class="subhead">Possible Approach to Implementation</h4>
+            <p>The Web of data is made up of <em>subjects</em> and <em>objects</em>; the things we talk about and the things we refer to. For example, we could say that <strong>Anne Frank's House</strong> (the <em>subject</em>) is within <strong>the Municipality of Amsterdam</strong> (the <em>object</em>). In RDF, this looks like:</p>
+
+            <p><code>&lt;</code><a href="https://g.co/kg/m/02s5hd"><code>https://g.co/kg/m/02s5hd</code></a><code>&gt;</code> <a href="http://schema.org/containedInPlace"><code>schema:containedInPlace</code></a> <code>&lt;</code><a href="http://sws.geonames.org/2759793"><code>http://sws.geonames.org/2759793</code></a><code>&gt;</code> <code>.</code></p>
+
+            <p>When considering HTTP URIs for <em>objects</em> (e.g. the target of our hyperlinks) it makes sense to reuse existing identifiers. After all, you <em>are</em> trying to stitch your spatial data into the Web so that we can "link your data to other data" and achieve a &#9733;&#9733;&#9733;&#9733;&#9733; rating! Organizations such as <a href="http://dbpedia.org">DBPedia</a>, <a href="http://www.geonames.org">GeoNames</a> and government mapping and cadastral authorities (that publish national registers of addresses, buildings, etc.) are good sources of stable, authoritative URIs. The steps described for <a href="https://www.w3.org/TR/ld-bp/#how-to-find-existing-vocabularies">discovering existing vocabularies</a> [[LD-BP]] can be readily adapted to find more. For more details about how you might link to these authoritative identifiers, see <a href="#bp-linking" class="sectionRef"></a>.</p>
+
+            <p>However, HTTP URIs for <em>subjects</em> (e.g. the resource that we want to make statements about) can be trickier. If you are working purely with data then you can reuse existing URIs minted by other authorities for your <em>subject</em> URIs. But publishing spatial data on the Web means that the URIs for each spatial thing should resolve to Web pages or data resources that provide useful information (see <a href="#indexable-by-search-engines" class="sectionRef"></a>). An HTTP request will be directed to a host Web server, identified by the internet domain name (or IP address) in the requested URI. If you use a URI with an internet domain name where you have no control over how the Web server behaves, then there is no way for your statements to be included in the Web server's response.</p>
+
+            <p>To take control of how information about spatial things is presented, data publishers need to assign their subject spatial things HTTP URIs from an internet domain name where they have authority over how the Web server responds. Typically, this means minting new HTTP URIs. It's all worth considering that the use of a particular internet domain may reinforce the authority of the information served. For example, a URI for Anne Frank's House is: <a href="https://monumentenregister.cultureelerfgoed.nl/monuments?MonumentId=4296"><code>https://monumentenregister.cultureelerfgoed.nl/monuments?MonumentId=4296</code></a>. The use of the internet domain registered to the <a href="https://cultureelerfgoed.nl/">Cultural Heritage Agency of the Netherlands</a> gives the definition authenticity.</p>
+
+            <div class="note">
+              <p>The need to control what information is provided about a given spatial thing means that it is not uncommon for a spatial thing to be identified by multiple HTTP URIs. The equality between two URIs that refer to the same resource can be stated using a property such as <code>owl:sameAs</code>. Care must always be taken when using <code>owl:sameAs</code> to determine that the two URIs actually refer to the same resource, rather than two resources that are similar. Warning: don't say if you're not sure it's true!</p>
+              <p>For more information about the types of properties that can be used to link between spatial things, and between spatial things and other resources, see <a href="#bp-linking" class="sectionRef"></a>.</p>
+            </div>
+
+            <p>When minting your own URIs, [[DWBP]] <a href="https://www.w3.org/TR/dwbp/#identifiersWithinDatasets">Best Practice 10: Use persistent URIs as identifiers within datasets</a> cites the advice from GS1's SmartSearch Implementation Guideline [[GS1]] which suggests that your URIs should include the type of resource that is being identified to help human readability. Also, given the need for the HTTP URIs for spatial things to be used throughout their lifetime (and perhaps beyond) you should give some thought to designing a URI that is persistent.</p> 
+            <aside class="example" id="ex-amsterdam-station-uri">
+              <p>This URI identifies the Amsterdam Central train station: </p>
+              <p><code>https://brt.basisregistraties.overheid.nl/top10nl/id/gebouw/102625209</code></p>
+              <p>This URI was minted using the recommendations in the Dutch URI strategy. Although minted by the Kadaster, they chose to use the domain ‘basisregistraties.overheid.nl’ (which translates to ‘base registries . government . nl’) because this is expected to be a more persistent name than ‘kadaster.nl’. Even though the Kadaster is over a 100-years old, organization names are not considered persistent in general as organizations may merge or their names may change. ‘top10nl’ is the name of the dataset, and ‘gebouw’ means ‘building’ – giving the human reader of this URI a clue of what is being identified. The last part of the URI is the building number from the dataset.</p>
+            </aside>
+
+            <p>[[DWBP]] <a href="https://www.w3.org/TR/dwbp/#UniqueIdentifiers">Best Practice 9: Use persistent URIs as identifiers of datasets</a> cites the European Commission's Study on Persistent URIs [[PURI]] as a good source from which to gain insights about designing persistent URIs.</p>
+
+            <p>When an HTTP URI is resolved, the server will respond with a sequence of bytes: by its nature, HTTP can only serve <em>information resources</em> such as Web pages or JSON documents. Yet a spatial thing is actually a real or conceptual phenomenon - a lake is made from water not information! Using a single URI to refer to <em>both</em> the spatial thing and the page/document that describes the spatial thing introduces a URI collision. This can impose a cost in communication due to the effort required to resolve ambiguities. [[URLs-in-data]] has more to say on this subject, including recommending URI design patterns that enable differentiation between the spatial thing and the page/document that describes it.</p> 
+
+            <p>However, in most cases using a single URI for both spatial thing and the page/document is simpler to implement and meets the expectations of most end-users. As stated in [[WEBARCH]] <a href="https://www.w3.org/TR/2004/REC-webarch-20041215/#indirect-identification">section 2.2.3 Indirect Identification</a>, identifiers are commonly used in this way. There is no obligation to distinguish between the spatial thing and the page/document unless your application requires this.</p> 
+
+            <div class="note">
+              <p>While there is a cost to this conflation, problems can be mitigated by avoiding making statements that confuse spatial thing and the page/document, such as “Uluru is available in KML format”; e.g. <code>&lt;</code><a href="http://sws.geonames.org/7645281"><code>http://sws.geonames.org/7645281</code></a><code>&gt; dc:hasFormat ex:kml .</code></p>
+              <p>This statement is clearly not true; an ancient monolith covering more than 3 km<sup>2</sup> cannot be provided in XML!</p>
+            </div>
+
+            <p>HTTP URIs for spatial things should not include any indication of the data format used to encode the page/document as this may change as your systems evolve. That said, you may wish to provide a set of complementary resources that specify a particular format as part of your content negotiation strategy. For example, the URI <a href="http://sws.geonames.org/7645281/about.rdf"><code>http://sws.geonames.org/7645281/about.rdf</code></a> resolves to provide an RDF/XML encoding of the information about Uluru in the Northern Territory of Australia (<a href="http://sws.geonames.org/7645281"><code>http://sws.geonames.org/7645281</code></a>).</p>
+
+            <p>[[DWBP]] <a href="https://www.w3.org/TR/dwbp/#identifiersWithinDatasets">Best Practice 10: Use persistent URIs as identifiers within datasets</a> notes that URIs can be long. You may need to define identifiers that are locally unique within your spatial dataset and provide a mechanism to programmatically convert each local identifier to a URI. For example, the Metadata Vocabulary for Tabular Data [[TABULAR-METADATA]] achieves this using URI Templates as described in [[RFC6570]].</p>
+
+            <p>It is also good practice to use a redirection service to hide complex and potentially changing service end-point URLs, such as for a <a>Web Feature Service</a> behind well-designed URIs. This means that users don’t need to be aware of the complexities of the API or changes in endpoint URIs or API versions to request information about a particular spatial thing. For example, the URI <code>http://data.example.org/aan/id/perceel/aan.2528</code> could be used as proxy for the WFS GetFeature request <a href="http://geodata.nationaalgeoregister.nl/aan/wfs?VERSION=2.0.0&amp;SERVICE=WFS&amp;REQUEST=GetFeature&amp;featureID=aan.2528"><code>http://geodata.nationaalgeoregister.nl/aan/wfs?VERSION=2.0.0&amp;SERVICE=WFS&amp;REQUEST=GetFeature&amp;featureID=aan.2528</code></a>.</p>
+
+            <p>Finally, while it is simple to use a query-pattern URL to serve information about a resource identified with a URI from a third-party internet domain, e.g. <code>http://example.org/museums?q=http://sws.geonames.org/6618987</code>, these URLs are unsuitable as persistent identifiers. More often than not, your intended users will dereference the "official" URI, e.g. <code>http://sws.geonames.org/6618987</code>. That said, this kind of search operation does provide a useful mechanism to find particular spatial things. See <a href="#convenience-apis" class="sectionRef">Best Practice 11: Expose spatial data through 'convenience APIs'</a> for further details.</p>
+
+          </section>
+          <section class="test">
+            <h4 class="subhead">How to Test</h4>
+            <p>Check that within the data spatial things, such as countries, regions and people, are referred to by HTTP URIs or by short identifiers that can be converted to HTTP URIs. Ideally the URIs should resolve, however, they have value as globally scoped variables whether they resolve or not.</p>
+          </section>
+          <section class="ucr">
+            <h4 class="subhead">Evidence</h4>
+            <p><span>Relevant requirements</span>: 
+              <a href="https://www.w3.org/TR/sdw-ucr/#Linkability">R-Linkability</a>, 
+              <a href="https://www.w3.org/TR/sdw-ucr/#GeoreferencedData">R-GeoReferencedData</a>, 
+              <a href="https://www.w3.org/TR/sdw-ucr/#IndependenceOnReferenceSystems">R-IndependenceOnReferenceSystems</a>.</p>
+          </section>
+          <section class="benefits">
+            <h4 class="subhead">Benefits</h4>
+            <ul class="benefitsList">
+              <li>...</li>
+            </ul>
+          </section>
+        </div>
+      </section>
+      <section id="bp-expressing-spatial">
+        <h3>Spatial Data Vocabularies</h3>
+        <p>In this document, there is no section on formats for publishing spatial data on the web. The formats are basically the same as for publishing any other data on the web: XML, JSON, CSV, RDF, etc. Refer to [[DWBP]] <a href="https://www.w3.org/TR/dwbp/#dataFormats">section 8.6 Data Formats</a> for more information and best practices. </p>
+        <p>That being said, it is important to publish your spatial data with clear semantics, i.e. to provide information about the contents of your data. The primary use case
+          for this is you have information about a collection of SpatialThings and you want to
+          publish precise information about their attributes and how they are inter-related. Another
+          use case is the publication on the Web of a dataset that has a spatial component in a form
+          that search engines will understand. </p>
+        <p>Depending on the format you use, the semantics may already be described in some form. For example, in GeoJSON [[RFC7946]] this description is present in the specification. When using JSON it is possible to add semantics using a JSON-LD <code>@context</code> object. For providing semantics to search engines, using [[SCHEMA-ORG]] is a good option, as explained in <a href="#indexable-by-search-engines" class="sectionRef">Best Practice 4: Make your spatial data indexable by search engines</a>. </p>
+        <p>In a linked data setting, the attributes of a spatial thing can be described using existing vocabularies, where
+          each term has a published definition. [[DWBP]] <a href="https://www.w3.org/TR/dwbp/#ReuseVocabularies">Best Practice 15: Reuse vocabularies, preferably standardized ones</a> recommends using terms from an established widely used vocabulary. If you can't find a suitable existing vocabulary term, you should create
+          your own, and publish a clear definition for the new term (see [[LD-BP]]. We recommend that you link your own vocabulary to commonly used existing ones
+          because this increases its usefulness. We provide the mapping between some commonly used spatial vocabularies. </p>
+        <div class="issue" data-number="225">
+          <p>We must avoid being overly focused on RDF.</p>
+          <p>The [[LD-BP]] reference makes this section very RDF dependent. Is there a need /
+            justification for this? Are we saying that RDF is the only recommended way to publish
+            data and models on the Web? Web developers may not care about RDF vocabularies and maybe
+            they prefer a Swagger document (just to pick an example)?</p>
+          <p>To reduce the RDF focus, some text was added. </p>
+        </div>
+        <div class="note">
+          <p>The current list of RDF vocabularies / OWL ontologies for spatial data being considered
+            by the SDW WG are provided below. Some of these will be used in examples. Full details,
+            including mapping between vocabularies, pointers about inconsistencies in vocabularies
+            (if any are evident), and recommendations avoiding their use as these may lead to
+            confusion, will be published in a complementary <strong>NOTE: Comparison of geospatial
+              vocabularies</strong>.</p>
+          <p>The NOTE will be concerned with helping data publishers choose the right
+            spatial data format or vocabulary. It provides a methodology for
+            making that choice. We do this rather than recommending one vocabulary because this
+            recommendation would not be durable as vocabularies are released or amended. </p>
+          <p>Vocabularies can discovered from <a href="http://lov.okfn.org/dataset/lov/">Linked Open
+              Vocabularies (LOV)</a>; using search terms like 'location' or Tags <a
+              href="http://lov.okfn.org/dataset/lov/terms?q=place">place</a>, <a
+              href="http://lov.okfn.org/dataset/lov/vocabs?tag=Geography">Geography</a>, <a
+              href="http://lov.okfn.org/dataset/lov/vocabs?tag=Geometry">Geometry</a> and <a
+              href="http://lov.okfn.org/dataset/lov/vocabs?tag=Time">Time</a>.</p>
+          <ul>
+            <li><a href="https://www.w3.org/2003/01/geo/wgs84_pos">W3C WGS84 Position</a> [[W3C-BASIC-GEO]]</li>
+            <li><a href="http://schema.org">schema.org</a> [[SCHEMA-ORG]]</li>
+            <li><a href="http://www.opengis.net/ont/geosparql">OGC GeoSPARQL</a> [[GeoSPARQL]]</li>
+            <li><a href="http://geosemweb.org/sdwgeo">GeoSPARQL spatial ontology update proposal</a></li>
+            <li><a href="http://geovocab.org/spatial.html">neogeo</a> [[NeoGeo]]</li>
+            <li><a href="http://dbpedia.org/ontology/">DBpedia</a> (including <a
+                href="http://dbpedia.org/ontology/Place">dbpedia:Place</a>)</li>
+            <li><a href="http://data.ordnancesurvey.co.uk/ontology/geometry/">UK Ordnance Survey
+                geometry</a></li>
+            <li><a href="http://data.ordnancesurvey.co.uk/ontology/spatialrelations/">UK Ordnance
+                Survey spatial relations</a></li>
+            <li>UK Office for National Statistics
+                <code>http://statistics.data.gov.uk/def/statistical-geography#</code> and
+                <code>http://statistics.data.gov.uk/def/statistical-entity#</code> (URIs do not
+              resolve)</li>
+            <li><a href="http://rdf-vocabulary.ddialliance.org/xkos.html">XKOS</a> (used for
+              geographical hierarchies in some examples)</li>
+            <li><a href="http://dublincore.org/documents/2012/06/14/dcmi-terms/">Dublin core
+                metadata 'DC Terms'</a> [[DCTERMS]] (including <a href="http://purl.org/dc/terms/spatial"
+                >dct:spatial</a> and <a href="http://purl.org/dc/terms/coverage">dct:coverage</a>
+              etc.)</li>
+            <li>BBC's <a href="http://www.bbc.co.uk/ontologies/coreconcepts#terms_Place"
+              >Place</a></li>
+            <li><a href="https://www.w3.org/ns/locn#">ISA Programme Location Core Vocabulary</a> [[LOCN]]</li>
+            <li><a href="http://sw-portal.deri.org/ontologies/swportal#">SWPortal ontology</a>
+              includes definition of location</li>
+            <li><a href="https://www.w3.org/2006/vcard/ns#">vCard ontology</a> includes definition of
+              location</li>
+            <li><a href="https://www.w3.org/2005/Incubator/geo/XGR-geo-20071023/">GeoRSS OWL</a></li>
+            <li>stSPARQL from <a href="http://strabon.di.uoa.gr/">Strabon</a> system (see
+              publications <a href="http://www.strabon.di.uoa.gr/files/iswc-strabon.pdf"
+                >iswc-strabon.pdf</a> and <a href="http://www.strabon.di.uoa.gr/files/eswc2013.pdf"
+                >eswc2013.pdf</a>)</li>
+            <li><a href="http://d-nb.info/standards/elementset/gnd#PlaceOrGeographicName"
+                >gndo:#PlaceOrGeographicName</a></li>
+            <li><a href="http://data.ign.fr/def/ignf/20150505.en.htm">IGN ontology for describing
+                coordinate systems</a></li>
+            <li><a href="http://data.ign.fr/def/geometrie/20140822.en.htm">IGN ontology for
+                describing geometry</a> (re-using <a href="http://geovocab.org/spatial.html"
+                >NeoGeo</a> and <a href="http://www.opengis.net/ont/geosparql">geosparql</a>)</li>
+            <li><a href="http://data.ign.fr/def/geofla/20140822.en.htm">IGN ontology for describing
+                administrative units</a></li>
+            <li><a href="http://data.ign.fr/def/topo/20140416.en.htm">IGN ontology for describing
+                main features on the territory</a></li>
+            <li><a href="http://lov.okfn.org/dataset/lov/vocabs/igeo">INSEE ontology for describing
+                geometry</a></li>
+          </ul>
+          <p>No attempts have yet been made to rank these vocabularies; e.g. in terms of
+            expressiveness, adoption etc.</p>
+        </div>
+        <p class="note">The motivation behind the <a href="https://www.w3.org/ns/locn#">ISA Programme
+            Location Core Vocabulary</a> was establishing a <em>minimal core common</em> to existing
+          spatial vocabularies. However, experience suggests that such a <em>minimal common
+            core</em> is not very useful as one quickly need to employ specific semantics to meet
+          one's application needs.</p>
+        <p class="issue" data-number="37">Do we need a subclass of <a>SpatialThing</a> for
+            entities that do not have a clearly defined spatial extent; or a property that expresses
+            the fuzziness the extent?</p>
+        <section id="bp-expr-geo">
+          <h4>Describing location</h4>
+          <p>Location information is often a common thread running through such data and can be an important 'hook' for finding information and for integrating different datasets. There are different ways of describing the location of spatial things. You can use and/or refer to the name of a well-known named place, provide the location's coordinates as a geometry or describe it in relation to another location. These last two options are described in this section.</p>
+
+<div class="practice">
+<p><span id="describe-geometry" class="practicelab">Provide geometries on the Web in a usable way</span></p>
+<p class="practicedesc">Geometry data should be expressed in a way that allows its publication and use on the Web.</p>
+<section class="axioms">
+<h4 class="subhead">Why</h4>
+<p>The geospatial, Linked Data, and Web communities use different geometry formats and tools, which reflect different requirements with respect to data complexity and manipulation.</p>
+<p>When deciding how a geometry should be described, it is therefore necessary to consider the intended uses and the related user communities. Which may imply providing alternative geometry descriptions.</p>
+<p>This best practice helps with choosing the right format for describing geometries, based on aspects like intended use(s), performance, and tool support. It also helps when deciding on when using literals rather than structured objects for geometric representations is a good idea.</p>
+<div class="note">
+<p>Since <a>coordinate reference system</a> and axis order are two of the factors determining how a geometry is described, this best practice is strictly correlated to <a href="#bp-crs-choice"></a> and <a href="#bp-crs"></a>, to which we refer the reader for more information.</p>
+</div>
+</section>
+<section class="outcome">
+<h4 class="subhead">Intended Outcome</h4>
+<p>The format chosen to express geometry data should:</p>
+<ul>
+<li>Support the dimensionality of the geometry (from points - 0D - to volumes - 3D) - not all geometry formats support all dimensions;</li>
+<li>Be supported by the software tools used within data user community - the geospatial and Web communities use different tools, working with different geometry formats;</li>
+<li>Keep geometry descriptions to a size that is convenient for the intended applications - Web applications are typically not using detailed geometries;</li>
+<li>Support the <a>coordinate reference system</a> you need.</li>
 </ul>
+<p>Ideally, to enable their widest re-use, geometries should be described having in mind the geospatial, Linked Data and Web communities. This may not be always feasible, but the objective should at least be to describe geometries (also) for Web consumption.</p>
+</section>
+<section class="how">
+<h4 class="subhead">Possible Approach to Implementation</h4>
+<p>Steps to follow:</p>
+<ul>
+<li>Identify the intended uses and applications. In particular, it is important to verify if geometries need to be used in one or more of the following scenarios:
+<ul>
+<li>specific geospatial applications;</li>
+<li>linked data applications;</li>
+<li>Web consumption.</li>
+</ul>
+</li>
+<li>For each of the intended uses / applications, provide possibly alternative descriptions of geometries, considering:
+<ul>
+<li>The appropriate geometry dimensionality (0D - points, 1D - lines, 2D - surfaces, 3D - volumes). See <a href="#spatial-things-features-and-geometry" class="sectionRef"></a> for more information.</li>
+<li>The appropriate <a>coordinate reference system</a>(s). See <a href="#CRS-background" class="sectionRef"></a> for more information.</li>
+<li>The appropriate geometry encoding(s) / representation(s) - also considering the software tools that you anticipate your user community to employ. See <a href="#applicability-formatVbp" class="sectionRef"></a> for more information.</li>
+<li>The appropriate level of complexity.</li>
+</ul>
+</li>
+<li>Where multiple representations are required, consider offering as many as you can - balancing the benefit of ease of use against the cost of the additional storage or additional processing if converting on-the-fly. See [[DWBP]] <a href="https://www.w3.org/TR/dwbp/#Conneg">Best Practice 19: Use content negotiation for serving data available in multiple formats</a> for more information.
+<div class="note">
+<p>HTTP content negotiation only works for media-type, character set, encoding and language. Consequently, it is not possible to select one representation that conforms to a given "profile" (e.g. data model, complexity level, CRS) from several that all share the same media-type; e.g. asking for the GeoJSON features with "simple" geometries (compacted polygons or just points) not the "complex" geometries; or asking for the representation that uses CRS84 not Amersfoort-RD.</p>
+</div>
+</li>
+</ul>
+<p>It is important to note that the steps outlined above are interrelated. For instance, the dimensionality of a geometry determines the set of <a>coordinate reference systems</a> that can be used, as well as the geometry encodings / representations.</p>
+<p>Another issue to be considered when choosing the geometry format is whether the axis order is unambiguous - i.e., whether the order of the coordinates is, e.g., longitude/latitude or latitude/longitude. This specific topic is covered by <a href="#bp-crs"></a>.</p>
+<div class="note">
+<p>Multiple formats exist for representing geometries (and some of them are listed in <a href="#applicability-formatVbp" class="sectionRef"></a>). One of the issues to be considered when choosing the format(s) to be supported, it is whether to use literals or structured objects.</p>
+<ul>
+<li>For geometry literals, several solutions are available, like Well-Known Text (<a>WKT</a>) representations, <a href="https://en.wikipedia.org/wiki/Geohash">GeoHash</a> and
+other geocoding representations. The alternative is to use structured geometry objects as is possible, for example, in [[GeoSPARQL]].</li>
+<li>There are also several suitable binary data formats (e.g. <a href="https://developers.google.com/protocol-buffers/">Google's protocol buffers</a> for vector tiling); however, some binary formats do not (effectively) work on the Web as there are no software tools for working with those formats from within a typical Web application; to work with data in such formats, you must first download the data and then work with it locally.</li>
+<li>There are widespread practices for representing geometric data as linked data, such as using [[W3C-BASIC-GEO]] (<code>geo</code>) <code>w3cgeo:lat</code> and <code>w3cgeo:long</code> that are used extensively for describing <code>w3cgeo:Point</code> objects.</li>
+<li>Concrete geometry types are available, such as those defined in the OpenGIS [[SIMPLE-FEATURES]] Specification, namely 0-dimensional Point and MultiPoint; 1-dimensional curve LineString and MultiLineString; 2-dimensional surface Polygon and MultiPolygon; and the heterogeneous GeometryCollection. </li>
+</ul>
+</div>
+<p>Currently, there are two reference geometry formats widely used in the geospatial and Web communities, respectively, [[GML]] and GeoJSON [[RFC7946]].</p>
+<p>[[GML]] provides the ability to express any type of geometry, in any <a>coordinate reference system</a>, and up to 3 dimensions (from points to volumes).</p>
+<p>On the other hand, GeoJSON supports only one <a>coordinate reference system</a> (CRS84 - i.e., WGS84 longitude/latitude), and geometries up to 2 dimensions (points, lines, surfaces).</p>
+<p>To facilitate the use of geometry data on the Web, it is therefore desirable that [[GML]]-encoded geometries are made available also in GeoJSON, by applying not only the required <a>coordinate reference system</a> transformation, but, if needed, by simplifying the original geometry (e.g., by transforming a 3D geometry in a 2D one).</p>
+<div class="note">
+<p>Another approach to publishing geometries on the Web is to embed them directly in Web pages. This is, for instance, the approach used by [[SCHEMA-ORG]], which defines several terms to specify them (see <a href="#indexable-by-search-engines"></a> for more information).</p>
+<p>Typically, this is used just for 0D-2D geometries (points, lines, surfaces). Detailed and complex geometries cannot be published with this methodology, so also in this case only a very simplified representation of the original geometry can be published - e.g., the centroid and/or 2D bounding box.</p>
+</div>
+<p>Finally, RDF-based representations of geometries are used in the Linked Data community. This is achieved by using specific vocabularies, as [[W3C-BASIC-GEO]] (only for points) or [[GeoSPARQL]] (for points, lines, surfaces) - see <a href="#semantic-thing" class="sectionRef">Best Practice 10: Encoding spatial data</a> for more information.</p>
+<p>These geometry representations are either stored with the related data, or are maintained separately, and possibly denoted with HTTP URIs (see <a href="#ex-http-uris-for-geometries"></a>).</p>
+<p>RDF representations of geometries can support most geometry types and dimensions (at least, up to 2 dimensions), with any level of complexity, in any <a>coordinate reference system</a>. On the other hand, existing Semantic Web tools, as triple stores, are currently not efficient enough to perform spatial queries which are complex and/or on complex geometries. In the latter case, it is therefore preferable to maintain geometries separately, in software platforms designed for these specific tasks.</p>
+<p>It is nonetheless desirable to make available these geometries for Web consumption as said before for [[GML]]-encoded geometries - i.e., by publishing also simplified version of them, either in GeoJSON or embedded in Web pages.</p>
+<p>The following Turtle snippet shows the [[GeoDCAT-AP]] representation of the dataset in <a href="#ex-schemaorg-dataset-and-place"></a>. Here the bounding box is provided in multiple literal encodings (<a>WKT</a>, [[GML]], GeoJSON), by using property <code>locn:geometry</code> [[LOCN]].</p>
+<aside class="example" id="ex-geodcat-ap-bag-addresses" title="GeoDCAT-AP representation of dataset spatial coverage (bounding box) in multiple encodings">
+<pre>
+@prefix dcat: &lt;http://www.w3.org/ns/dcat#&gt; .
+@prefix dct:  &lt;http://purl.org/dc/terms/&gt; .
+@prefix locn: &lt;http://www.w3.org/ns/locn#&gt; .
+
+&lt;http://www.ldproxy.net/bag/inspireadressen/&gt; a dcat:Dataset ;
+  dct:title "Adressen"@nl ;
+  dct:title "Addresses"@en ;
+  dct:description "INSPIRE Adressen afkomstig uit de basisregistratie Adressen,
+                   beschikbaar voor heel Nederland"@nl ;
+  dct:description "INSPIRE addresses derived from the Addresses base registry,
+                   available for the Netherlands"@en ;
+  dct:isPartOf &lt;http://www.ldproxy.net/bag/&gt; ;
+  dcat:theme &lt;http://inspire.ec.europa.eu/theme/ad&gt; ;
+  dct:spatial [
+    a dct:Location ;
+    locn:geometry
+# Bounding box in WKT
+      "POLYGON((3.053 47.975,7.24 47.975,7.24 53.504,3.053 53.504,3.053 47.975))"^^geosparql:wktLiteral ,
+# Bounding box in GML
+      "&lt;gml:Envelope srsName=\"http://www.opengis.net/def/crs/OGC/1.3/CRS84\"&gt;
+         &lt;gml:lowerCorner&gt;3.053 47.975&lt;/gml:lowerCorner&gt;
+         &lt;gml:upperCorner&gt;7.24  53.504&lt;/gml:upperCorner&gt;
+       &lt;/gml:Envelope&gt;"^^geosparql:gmlLiteral ,
+# Bounding box in GeoJSON
+      "{ \"type\":\"Polygon\",\"coordinates\":[[
+           [3.053,47.975],[7.24,47.975],[7.24,53.504],[3.053,53.504],[3.053,47.975]
+         ]] }"^^https://www.iana.org/assignments/media-types/application/geo+json
+  ] .
+</pre>
+</aside>
+<p>In the above example, the <a>coordinate reference system</a> used for the bounding box is CRS84 (equivalent to WGS84, but with axis order longitude/latitude), which is explicitly specified in the [[GML]] encoding via attribute <code>@srsName</code>, and by using the relevant HTTP URI from the <a href="http://www.opengis.net/def/crs/EPSG/0">OGC CRS registry</a>. The <a>coordinate reference system</a> is not specified for the <a>WKT</a> encoding, since CRS84 is the default <a>coordinate reference system</a> for <a>WKT</a> in [[GeoSPARQL]], and therefore it can be omitted. The <a>coordinate reference system</a> is also not specified in the GeoJSON encoding, since CRS84 is the only supported <a>coordinate reference system</a> in GeoJSON [[RFC7946]].</p>
+<p>Always with reference to <a href="#ex-schemaorg-dataset-and-place" class="exampleRef"></a>, the following snippet shows the [[GML]] and the RDF representations of the entry in the BAG Dutch register concerning the building where Anne Frank's house is located. For the corresponding GeoJSON representation, see the relevant <a href="#ex-crs-geojson">example</a> in <a href="#bp-crs"></a>.</p>
+<aside class="example" id="ex-anne-frank-building-gml" title="GML description of a building, with detailed geometry">
+<p>The [[GML]] representation of Anne Frank's house building (taken from the <a href="http://geodata.nationaalgeoregister.nl/bag/wfs?VERSION=2.0.0&amp;SERVICE=WFS&amp;REQUEST=GetFeature&amp;typeName=pand&amp;cql_filter=bag:identificatie=363100012169587">BAG WFS endpoint</a>):</p>
+<pre>
+&lt;bag:pand gml:id=&quot;pand.3323294&quot;&gt;
+  &lt;bag:identificatie&gt;363100012169587&lt;/bag:identificatie&gt;
+  &lt;bag:bouwjaar&gt;1635&lt;/bag:bouwjaar&gt;
+  &lt;bag:status&gt;Pand in gebruik (niet ingemeten)&lt;/bag:status&gt;
+  &lt;bag:gebruiksdoel&gt;woonfunctie&lt;/bag:gebruiksdoel&gt;
+  &lt;bag:oppervlakte_min&gt;1&lt;/bag:oppervlakte_min&gt;
+  &lt;bag:oppervlakte_max&gt;21&lt;/bag:oppervlakte_max&gt;
+  &lt;bag:aantal_verblijfsobjecten&gt;20&lt;/bag:aantal_verblijfsobjecten&gt;
+  &lt;bag:geometrie&gt;
+    &lt;gml:MultiSurface srsDimension=&quot;2&quot; axisLabels="east north"
+                         srsName=&quot;urn:ogc:def:crs:EPSG::28992&quot;&gt;
+      &lt;gml:surfaceMember&gt;
+        &lt;gml:Polygon srsDimension=&quot;2&quot;&gt;
+          &lt;gml:exterior&gt;
+            &lt;gml:LinearRing&gt;
+              &lt;gml:posList&gt;
+                120749.725 487589.422  120752.55  487594.375  120751.227 487595.129
+                120732.539 487605.788  120723.505 487589.745  120721.387 487585.939
+                120740.668 487575.07   120743.316 487573.589  120747.735 487581.337
+                120751.564 487579.154  120755.411 487576.96   120750.935 487569.172
+                120755.941 487566.288  120764.369 487581.066  120749.725 487589.422
+                &lt;/gml:posList&gt;
+            &lt;/gml:LinearRing&gt;
+          &lt;/gml:exterior&gt;
+        &lt;/gml:Polygon&gt;
+      &lt;/gml:surfaceMember&gt;
+    &lt;/gml:MultiSurface&gt;
+  &lt;/bag:geometrie&gt;
+&lt;/bag:pand&gt;
+</pre>
+</aside>
+<p>It is worth noting that the [[GML]] snippet above also includes the explicit specification of the axis order (via attribute <code>@axisLabels</code>) and the number of dimension of the geometry (via attribute <code>@srsDimension</code>).</p>
+<p>The corresponding RDF representation is provided in the following Turtle snippet (taken from the <a href="https://bag.basisregistraties.overheid.nl/resource?subject=http%3A%2F%2Fbag.basisregistraties.overheid.nl%2Fbag%2Fdoc%2F2016083000000000%2Fpand%2F0363100012169587">BAG Linked Data service</a>). NB: The RDF representation below has been complemented with additional properties (marked with <code># Added</code>) for demonstration purposes.</p>
+<aside class="example" id="ex-anne-frank-building-rdf" title="RDF description of a building, with detailed geometry, bounding box, and centroid">
+<pre>
+@prefix bag:       &lt;http://bag.basisregistraties.overheid.nl/def/bag#&gt; .
+@prefix dct:       &lt;http://purl.org/dc/terms/&gt; .
+@prefix geosparql: &lt;http://www.opengis.net/ont/geosparql#&gt; .
+@prefix gml:       &lt;http://www.opengis.net/ont/gml#&gt; .
+@prefix locn:      &lt;http://www.w3.org/ns/locn#&gt; .
+@prefix pdok:      &lt;http://data.pdok.nl/def/pdok#&gt; .
+@prefix rdfs:      &lt;http://www.w3.org/2000/01/rdf-schema#&gt; .
+@prefix schema:    &lt;http://schema.org/&gt; .
+@prefix w3cgeo:    &lt;http://www.w3.org/2003/01/geo/wgs84_pos#&gt; .
+
+&lt;http://bag.basisregistraties.overheid.nl/bag/id/pand/0363100012169587&gt; 
+  a geosparql:Feature, bag:Pand ;
+  rdfs:label "Pand 0363100012169587"@nl;
+  rdfs:isDefinedBy &lt;http://bag.basisregistraties.overheid.nl/bag/doc/2016083000000000/pand/0363100012169587&gt; ;
+  bag:identificatiecode "0363100012169587"^^xsd:string;
+# Added
+  dct:identifier "363100012169587"^^xsd:string ;
+  bag:status &lt;http://bag.basisregistraties.overheid.nl/id/begrip/PandInGebruik_nietIngemeten&gt; ;
+  bag:oorspronkelijkBouwjaar "1635"^^xsd:gYear;
+# Added
+  dct:created "1635"^^xsd:gYear ;
+# Added
+  locn:address &lt;http://www.ldproxy.net/bag/inspireadressen/inspireadressen.3329155&gt; ;
+# Added
+  w3cgeo:lat  "52.3750856076095"^^xsd:float ;
+# Added
+  w3cgeo:long "4.88412047472359"^^xsd:float ;
+# Added
+  schema:box "52.3749004358275,4.88382018823377 52.3752539733183,4.88445185541417"^^xsd:string .
+  geosparql:hasGeometry &lt;http://bag.basisregistraties.overheid.nl/bag/id/geometry/5C1F8F11324717378B437B2CD12871FF&gt; ;
+  bag:geometriePand &lt;http://bag.basisregistraties.overheid.nl/bag/id/geometry/5C1F8F11324717378B437B2CD12871FF&gt;
+.
+
+&lt;http://bag.basisregistraties.overheid.nl/bag/id/geometry/5C1F8F11324717378B437B2CD12871FF&gt; 
+  a geosparql:Geometry, gml:Surface ;
+  geosparql:asWKT 
+    "POLYGON ((
+      4.884235252217925  52.375108067329755 , 4.884276231101587 52.37515275750655  , 
+      4.884256726627544  52.375159451429134 , 4.883981215233056 52.37525408134467  , 
+      4.8838501915846795 52.37510933464118  , 4.883819478089075 52.37507499685774  , 
+      4.884103718013221  52.374978516968966 , 4.884142753458582 52.37496537195161  , 
+      4.884206854242218  52.375035281028296 , 4.884263303626781 52.37501590054125  , 
+      4.8843200184035584 52.374996422289605 , 4.88425508456153  52.37492615022757  , 
+      4.884328888811774  52.37490054300959  , 4.884451143500816 52.375033882503686 , 
+      4.884235252217925  52.375108067329755
+    ))"^^geosparql:wktLiteral ;
+  pdok:asWKT-RD 
+    "POLYGON ((
+      120749.725 487589.422 , 120752.55 487594.375  ,   
+      120751.227 487595.129 , 120732.539 487605.788 ,
+      120723.505 487589.745 , 120721.387 487585.939 , 
+      120740.668 487575.07  , 120743.316 487573.589 , 
+      120747.735 487581.337 , 120751.564 487579.154 , 
+      120755.411 487576.96  , 120750.935 487569.172 , 
+      120755.941 487566.288 , 120764.369 487581.066 , 
+      120749.725 487589.422
+    ))"^^xsd:string ;
+# Added
+  geosparql:asWKT 
+    "&lt;http://www.opengis.net/def/crs/EPSG/0/28992&gt; POLYGON ((
+      120749.725 487589.422 , 120752.55 487594.375  ,   
+      120751.227 487595.129 , 120732.539 487605.788 ,
+      120723.505 487589.745 , 120721.387 487585.939 , 
+      120740.668 487575.07  , 120743.316 487573.589 , 
+      120747.735 487581.337 , 120751.564 487579.154 , 
+      120755.411 487576.96  , 120750.935 487569.172 , 
+      120755.941 487566.288 , 120764.369 487581.066 , 
+      120749.725 487589.422
+    ))"^^geosparql:wktLiteral
+.
+</pre>
+</aside>
+<p>The RDF representation above includes:</p>
+<ul>
+  <li>The detailed geometry of the building (<code>geosparql:asWKT</code> / <code>pdok:asWKT-RD</code>), in <a>WKT</a> and using multiple reference systems.</li>
+  <li>The bounding box (<code>schema:box</code>) and centroid (<code>w3cgeo:lat</code> and <code>w3cgeo:long</code>).</li>
+</ul>
+<p>The different <a>WKT</a> encodings in the example show alternative ways of specifying the <a>coordinate reference system</a> used.</p>
+<p>The two instances of property <code>geosparql:asWKT</code> follow the syntax recommended in [[GeoSPARQL]], where the specification of the <a>coordinate reference system</a> is required only if different from CRS84. By contrast, property <code>pdok:asWKT-RD</code> implies the use of a specific <a>coordinate reference system</a>, namely, <a href="http://epsg.io/28992">EPSG:28992</a> ("Amersfoort / RD New"). The axis order used is determined here by the <a>coordinate reference system</a>, and in both cases, it is longitude / latitude (more precisely, east/north for EPSG:28992). By contrast, the coordinates for the bounding box and centroid use WGS84, with axis order latitude / longitude.</p>
+<p><a href="#ex-anne-frank-building-rdf"></a> shows also how geometries for <a>spatial things</a> can be published as separate Web resources. This approach can be particularly suitable for giving access to huge geometries, consisting of hundreds of vertices (as the detailed geometry of the boundaries of a geographical region), without attaching them to the relevant spatial things. Moreover, this allows the same geometry to be linked from (i.e., re-used by) different spatial things. Finally, it is possible to use mechanisms (including HTTP content negotiation) to provide access to different representations / encodings of the geometry ([[GML]], <a>WKT</a>, GeoJSON, etc.), thus addressing different use cases. (On this topic, see also <a href="#entity-level-links"></a>).</p>
+<aside class="example" id="ex-http-uris-for-geometries" title="HTTP URIs for geometries">
+<p>As shown in <a href="#ex-amsterdam-station-uri" class="exampleRef"></a>, the following URI:</p>
+<p><code>https://brt.basisregistraties.overheid.nl/top10nl/id/gebouw/102625209</code></p>
+<p>denotes Amsterdam Central train station. However, its geometry is provided as a separate, standalone resource, denoted by the following URI:</p>
+<p><code>https://brt.basisregistraties.overheid.nl/top10nl/id/geometry/2525562935f2c33152e98f65f9d8d6ff</code></p>
+<p>A similar approach is used by Ordnance Survey. For instance, North Devon is denoted by the following URI:</p>
+<p><code>http://data.ordnancesurvey.co.uk/id/7000000000022933</code></p>
+<p>whereas its geometry is denoted by:</p>
+<p><code>http://data.ordnancesurvey.co.uk/id/geometry/22933-4</code></p>
+<p>An additional example is the API of the <a href="http://gadm.geovocab.org/">GADM-RDF project</a>, providing access to spatial linked data concerning administrative areas. For instance, the following URI <a href="http://gadm.geovocab.org/id/0/60"><code>http://gadm.geovocab.org/id/0/60</code></a> returns a description of administrative area "Germany", which links to the geometry of Germany's boundaries, provided via a separate URI: <a href="http://gadm.geovocab.org/id/0/60/geometry"><code>http://gadm.geovocab.org/id/0/60/geometry</code></a>.</p>
+<p>The geometry URIs operated by the GADM-RDF API resolve to different geometry representations / encodings (SVG included), that can be accessed via HTTP content negotiation or by appending the format extension to the URI. For instance, URI <a href="http://gadm.geovocab.org/id/0/60/geometry.geojson"><code>http://gadm.geovocab.org/id/0/60/geometry.geojson</code></a> returns the GeoJSON representation of the geometry. Direct links to the supported geometry representations / encodings are specified in the RDF and HTML representations of the geometry.</p>
+</aside>
+<div class="note">
+<p>This section needs to be completed with:</p>
+<ul>
+<li>Guidelines on how to provide geometries at different levels of <em>precision</em> and <em>complexity</em>, highlighting issues to be considered when simplifying geometries.</li>
+<li>More details about how WKT is used.</li>
+<li>An RDF example with embedded geometry</li>
+<li>Clarification on the differences between “coordinate positions” as a literal and the “geometry” as literal; the latter includes additional metadata</li>
+<li>Clarification on "formats" for geometries only (e.g., WKT) and those used also for features (e.g., GML, GeoJSON)</li>
+</ul>
+</div>
+</section>
+<section class="test">
+<h4 class="subhead">How to Test</h4>
+<p>Check if:</p>
+<ol>
+<li>Geometries are made available in possibly different formats and levels of complexity, considering their intended uses and their consumption on the Web.</li>
+<li>The chosen geometry descriptions comply with <a href="#bp-crs-choice"></a> and <a href="#bp-crs"></a>.</li>
+<li>The (possibly) alternative geometry descriptions can be accessible via standard mechanisms, as HTTP content negotiation.</li>
+</ol>
+</section>
+<section class="ucr">
+<h4 class="subhead">Evidence</h4>
+<p><span>Relevant requirements</span>: 
+<a href="https://www.w3.org/TR/sdw-ucr/#MultipleCRS">R-MultipleCRSs</a>,
+<a href="https://www.w3.org/TR/sdw-ucr/#BoundingBoxCentroid">R-BoundingBoxCentroid</a>, 
+<a href="https://www.w3.org/TR/sdw-ucr/#Compressible">R-Compressible</a>, 
+<a href="https://www.w3.org/TR/sdw-ucr/#CRSDefinition">R-CRSDefinition</a>, 
+<a href="https://www.w3.org/TR/sdw-ucr/#EncodingForVectorGeometry">R-EncodingForVectorGeometry</a>, 
+<a href="https://www.w3.org/TR/sdw-ucr/#IndependenceOnReferenceSystems">R-IndependenceOnReferenceSystems</a>, 
+<a href="https://www.w3.org/TR/sdw-ucr/#MachineToMachine">R-MachineToMachine</a>, 
+<a href="https://www.w3.org/TR/sdw-ucr/#SpatialMetadata">R-SpatialMetadata</a>, 
+<a href="https://www.w3.org/TR/sdw-ucr/#3DSupport">R-3DSupport</a>, 
+<a href="https://www.w3.org/TR/sdw-ucr/#TimeDependentCRS">R-TimeDependentCRS</a>, 
+<a href="https://www.w3.org/TR/sdw-ucr/#TilingSupport">R-TilingSupport</a>.</p>
+</section>
+<section class="benefits">
+<h4 class="subhead">Benefits</h4>
+<ul class="benefitsList">
+<li>...</li>
+</ul>
+</section>
+</div>
+          
+          <div class="practice">
+            <p><span id="relative-position" class="practicelab">Describe relative
+                positioning</span></p>
+            <p class="practicedesc">Provide a relative positioning capability in which one entity
+              can be positioned relative to another entity.</p>
+            <section class="axioms">
+              <h4 class="subhead">Why</h4>
+              <p>Geocentric coordinate reference systems describe position relative to the earth itself. It can also
+              be valuable or even necessary to describe the position of an entity relative to a second entity. In some cases, this is
+              a navigation convenience, for example a tour kiosk might be described as located between the Boston Common Frog Pond and the Park
+              Street T entrance, or in one's lower left view when looking up at the Statehouse. In other cases of moving or generalized  entities, it may be that the 
+              entity can only usefully be given a relative position. For example, a package is reported left on seat 32L1 on the #59 bus, or 
+              part number PRG5460 is always located at position (51, 73, 3) in Acme warehouses.
+              </p>
+            </section>
+            <section class="outcome">
+              <h4 class="subhead">Intended Outcome</h4>
+              <p>It should be possible to describe the location of an entity in relation to one or more other
+                entities or places, instead of specifying its own geocentric position or geometry.</p>
+              <p>The relative positioning descriptions should be machine-interpretable and/or
+                human-readable as required by the intended application. The positions and/or geometries of reference entities, if available, should be retrievable through their link relations. </p>
+            </section>
+            <section class="how">
+              <h4 class="subhead">Possible Approach to Implementation</h4>
+              <p>Positioning of one entity (A) relative to another referenced entity (B) is a combination of two factors: the referencing target, 
+              and the means of relative positioning. "Geocentric" referencing targets the planet itself or at least a fixed point on it. "Allocentric" 
+              referencing targets another entity. "Egocentric" referencing targets a particular field of view of an observer or camera. Positioning 
+              can take the form of a complete coordinate reference system (e.g. engineering CRS), a qualitative relation such as "beside", or a 
+              quantitative relation such as "30m northwest"</p>
+              <table id="relative-positioning-modes">
+        <caption>Combinations of relative positioning means and references</caption>
+        <tr>
+          <th></th>
+          <th>Engineering CRS</th>
+          <th>Qualitative Relation</th>
+          <th>Quantitative Relation</th>
+         </tr>
+         <tr>
+          <th>Geocentric   </th>
+          <td>Coordinate position A relative to a fixed earth datum</td>
+          <td>NA</td>
+          <td>NA</td>
+         </tr>
+         <tr>
+          <th>Allocentric   </th>
+          <td>Coordinate position A relative to a fixed, mobile, or generic entity B</td>
+          <td>A "next to" B</td>
+          <td>A "20m south" of B</td>
+        </tr>
+        <tr>
+          <th>Egocentric   </th>
+          <td>Coordinate position A within field of view B</td>
+          <td>A in "lower left corner" of field of view B</td>
+          <td>A "30 deg right of center" in field of view B</td>
+         </tr>
+       </table>
+              <ul>
+                <li>Descriptions of the positions of entities as explicit
+                  links to target entities. </li>
+                <li>Semantic descriptions of the target entities and type of positioning.</li>
+                <li>Encodings of the specific entity relations or the relative coordinate positions in the case of engineering CRS'</li>
+              </ul>
+              <aside class="example">
+                <p>"Metes and Bounds" are a widely-used system for defining land parcel boundary edges as cardinal directions and distances 
+                relative to survey markers or other landmarks. This would be considered allocentric quantitative relation type of relative positioning</p>
+              </aside>
+             <aside class="example">
+                <p>The positions of pixels an image captured by a satellite or other camera sensor are originally recorded relative to the field of view of the sensor.
+                  A model of the sensor optics, and platform position and orientation, together with transmission path effects (if available), may be used later to derive geocentric pixel positions.</p>
+              </aside>
+             <aside class="example">
+                <p>In hydrology, positions of river features and/or observations such as water depth are often recorded as distance along a stream feature relative to a well-known 
+                origin point such as a stream confluence. This provides a reproducible form of positioning even if the geometry of the stream feature has not been precisely determined.</p>
+              </aside>
+                    <aside class="example">
+                <p>Augmented or mixed reality content is presented to the viewer in positions both relative to the real-world entities that it augments and relative the viewer's
+                visual perspective on those entities. For example, an informational callout needs to be juxtaposed with its target but also occupy the user's field of view in a meaningful fashion.</p>
+              </aside>
+       </section>
+            <section class="test">
+              <h4 class="subhead">How to Test</h4>
+              <p>...</p>
+            </section>
+            <section class="ucr">
+              <h4 class="subhead">Evidence</h4>
+              <p><span>Relevant requirements</span>: <a
+                  href="https://www.w3.org/TR/sdw-ucr/#MachineToMachine">R-MachineToMachine</a>, <a
+                  href="https://www.w3.org/TR/sdw-ucr/#SamplingTopology">R-SamplingTopology</a>.</p>
+            </section>
+            <section class="benefits">
+              <h4 class="subhead">Benefits</h4>
+              <ul class="benefitsList">
+                <li>...</li>
+              </ul>
+            </section>
+          </div>
+        </section>
+
+        <section id="bp-geo-voc">
+          <h4>Publishing data with clear semantics</h4>
+          <p>In most cases, the effective use of information resources requires understanding thematic concepts in addition to the spatial ones; "spatial" is just a facet of the
+            broader information space. For example, when the <a href="http://www.brandweer.nl/amsterdam-amstelland">Dutch Fire Service</a> responded to an incident at a day care center, they needed to evacuate the children. In this case, the <em>2nd</em> closest alternative day care center was preferred because it was operated by the same organization as the one that was subject of the incident, and they knew who all the children were.</p>
+
+          <p>This best practice document provides mechanisms for determining how places and locations are related - but determining the compatibility or validity of thematic data elements is beyond our scope; we're not attempting to solve the problem of different views on the same/similar resources.</p>
+
+          <p>That said, there is one aspect of thematic semantics that must be mentioned. The most important semantic statement you can make when publishing spatial data - or any data - is to specify the <em>type</em> of a resource. For spatial things, there are several types that define "spatialness" (see <a href="#bp-expr-geo" class="sectionRef"></a>). But you should also consider non-spatial aspects when designating the type of a spatial thing. For example, should a fire incident occur at Amsterdam Central railway station, it might seem sensible for the Municipal Fire Department to designate a type such as <strong>Building</strong> or <strong>Station</strong> (the Dutch Government Base Registry defines Amsterdam Central railway station, identified as <a href="https://brt.basisregistraties.overheid.nl/top10nl/id/gebouw/102625209"><code>https://brt.basisregistraties.overheid.nl/top10nl/id/gebouw/102625209</code></a>, designates both of these types). However, the Fire Department are concerned with a <em>fire incident</em> - not the railway station itself. The fire incident is a spatial thing (it has spatial extent) but it is <em>not</em> the station. For example, the fire may spread to adjacent buildings. The Fire Department might designate their spatial thing as having type <strong>FireIncident</strong> or similar. Advice on how to assign a persistent identifier to the fire incident is provided in <a href="#globally-unique-ids" class="sectionRef">Best Practice 7: Use globally unique persistent HTTP URIs for spatial things</a>, and <a href="#bp-linking" class="sectionRef"></a> provides guidance on how one might relate the fire incident to other coincident spatial things such as Amsterdam Central railway station.</p>
+          
+          <div class="note">
+            <p><em>Thematic</em> semantics are out of scope for this best practice document. For associated best practices, please refer to [[DWBP]] <a href="https://www.w3.org/TR/dwbp/#metadata">section 8.2 Metadata</a>, <a href="https://www.w3.org/TR/dwbp/#StructuralMetadata">Best Practice 3: Provide structural metadata</a>; and [[DWBP]] <a href="https://www.w3.org/TR/dwbp/#dataVocabularies">section 8.9 Data Vocabularies</a>, <a href="https://www.w3.org/TR/dwbp/#ReuseVocabularies">Best Practice 15: Reuse vocabularies, preferably standardized ones</a> and <a href="https://www.w3.org/TR/dwbp/#ChooseRightFormalizationLevel">Best Practice 16: Choose the right formalization level</a>.</p>
+            <p>See also [[LD-BP]] <a href="https://www.w3.org/TR/ld-bp/#VOCABULARIES">Vocabularies</a>.</p>
+          </div>
+
+          <div class="practice">
+            <p><span id="semantic-thing" class="practicelab">Encoding spatial data</span></p>
+            <p class="practicedesc">Represent spatial data in a way that matches the needs of the target audiences.</p>
+            <section class="axioms">
+              <h4 class="subhead">Why</h4>
+              <p>Spatial data is used by a range of user communities, each with their own purposes, knowledge and preferred tools. Data publishers should consider which communities and purposes they want to serve and make appropriate choices for the approach to encoding data.  In general terms, data usefulness is increased when it can be used for more purposes.  This might involve providing data in several different formats. (See [[DWBP]] <a href="https://www.w3.org/TR/dwbp/#MultipleFormats">Best Practice 14: Provide data in multiple formats</a>.)</p>
+            </section>
+            <section class="outcome">
+              <h4 class="subhead">Intended Outcome</h4>
+              <p>Spatial data can be used easily and reliably by the target users.</p>
+            </section>
+            <section class="how">
+              <h4 class="subhead">Possible Approach to Implementation</h4>
+              <p>A high-level objective of these best practices is to highlight approaches that data publishers can take to maximize the ease of use of their spatial data via the web and hence present data in a way that meets the needs of as wide a range of users and applications as possible.</p>
+              <p>One way of classifying the applications of spatial data is as follows:</p>
+              <ol>
+			     <li>Web pages for people to read about spatial things</li>
+			     <li>Web mapping or visualization applications</li>
+  			     <li>Data integration - combining spatial data with other data</li>
+			     <li>Spatial Data Infrastructures</li>
+			  </ol>
+			 <p>Each of these has different needs: often it will be possible or desirable to support several of these application groups.</p>
+			 <p>The main objective is to encode data in a way that recipients can easily decode and understand. To decide this, you need to consider which purpose(s) and which audience(s) are you aiming to serve and the characteristics of the data that you want to share.  For example:</p>
+			<ul>
+			  <li>the volume of data</li>
+			  <li>how many spatial dimensions it covers (points, lines, areas, 3D)</li>
+			  <li>what kind of area it covers (one building, a town, a whole country)</li>
+			  <li>how frequently it changes</li>
+			  <li>the level of spatial precision that exists in the data and the precision needed by users</li>
+			</ul>
+			
+			<h5>1. Web pages for people to read about spatial things</h5>
+			<p>In <a href="#globally-unique-ids">Best Practice 7</a> we recommend use of HTTP URIs as a way of assigning identifiers to spatial things. The data publisher should offer the ability to look up ('dereference') such a URI to find out useful information about that spatial thing in human readable form (as well as machine readable formats - see the discussion below on data integration).  Each spatial thing therefore gets its own web page - in addition it might be useful to have web pages about groups of spatial things, but the 'page per thing' approach enables fine-grained linking of information.</p>
+			<p>To promote discovery of such web pages in search engines, each page should contain a clear text description of what it is, ideally in a way that distinguishes it from pages about other similar spatial things. Including metadata using the [[SCHEMA-ORG]] vocabulary, embedded as microdata, RDFa or as JSON-LD in the <em>&lt;head&gt;</em> section of the page can provide additional information to search engines to support more precise indexing.  See <a href="#indexable-by-search-engines">Best Practice 4: Making data indexable by search engines</a> for a more detailed discussion.</p>
+			<p>It is also very useful in such web pages to include links to descriptions of the spatial thing in other formats (typically machine-readable formats) as well as linking to related spatial things.</p>
+			<aside class="example">
+              <p>TO DO: Web pages about spatial thing example...</p>
+            </aside>
+			<h5>2. Web mapping or visualization applications</h5>
+			<p>A common application of spatial data on the Web is delivering map data in a tiled form, suitable for display in zoomable 'slippy maps'.  The Open Geospatial Consortium <a href="http://www.opengeospatial.org/standards/wmts">Web Map Tile Service</a> is an established standard for doing this.  Other approaches in common use include <a href="https://github.com/mapbox/mbtiles-spec">MBTiles</a> or 'Tile layers' in <a href="https://developers.google.com/maps/">Google Maps APIs</a></p>
+			<p>Another frequent requirement is to draw markers or polygons on top of a web map. A typical approach is for the browser to display a base map, then separately retrieve data about the spatial things of interest, typically as GeoJSON or KML files, then to combine the two using appropriate Javascript libraries.  For applications involving boundary polygons of geographical areas, a common consideration is how to make this process efficient at different zoom levels. A high level of detail is appropriate when zoomed in, but many areas may be visible when zoomed out, and delivering boundaries of all of those at full detail can lead to very large amounts of data and hence poor performance, so simplified lower resolution versions of polygons may be required.</p>
+			<aside class="example">
+                <p>TO DO: Mapping/visualization example...</p>
+              </aside>
+			<h5>3. Data integration - combining spatial data with other data</h5>
+			<p>Many important applications of spatial data involve combining it with other kinds of data: for example, opening times of nearby supermarkets, or statistical information on the economy of a town.  Often the Spatial Thing is at the center of the data analysis process.</p>
+			<p>Other applications involve distinguishing or selecting spatial things according to their non-spatial characteristics: hospitals with an emergency department, or restaurants that serve Japanese food.</p>
+			<p>To enable such questions to be answered using data from different sources, it is important to describe spatial things using shared identifiers and vocabularies.  This is described in [[DWBP]] <a href="https://www.w3.org/TR/dwbp/#identifiersWithinDatasets">Best Practice 10: Use persistent URIs as identifiers within datasets</a> and [[DWBP]]<a href="https://www.w3.org/TR/dwbp/#ReuseVocabularies">Best Practice 15: Reuse vocabularies, preferably standardized ones</a>.</p>
+            <p>From a spatial data perspective, the question of identifiers is discussed in <a href="#globally-unique-ids">Best Practice 7</a>.  How to relate a Spatial Thing to its geometry is described in <a href="#describe-geometry">Best Practice 8: Provide geometries on the Web in a usable way</a>.</p>
+            <p>A common approach to encoding data to enable data integration is Linked Data #linked-data and RDF. The spatial aspects of the data can either be included in the RDF data model, or the entity in question can link to an external web resource containing the geometry in one of the standard spatial data formats. Although RDF is well-suited to important aspects of best practice, including use of URIs as identifiers and re-use of vocabularies, other data formats are also consistent with this approach. Most spatial data formats enable associating attributes of an entity alongside its geometry.</p>	
+            <p>The publisher's choice of data model to represent the data will depend on what data is available and which audiences and purposes it seems most important to support. However, a reasonable general rule is that it is always useful to provide a label and a type for each entity in the data collection. (See [[DWBP]] <a href="https://www.w3.org/TR/dwbp/#ChooseRightFormalizationLevel">Best Practice 16: Choose the right formalization level</a>)</p>  
+            <p>A common way of specifying the location of a building is to use its postal address. Most spatial applications require an address to be turned into spatial coordinates, so that its location can be marked on a map, or compared with locations of other things, a process known as 'geocoding'.  Although a publisher could leave this process of geocoding to the data user, ideally the publisher should take responsibility for this as they are in a better position to check the accuracy of the results.  Different ways of specifying addresses can sometimes lead to errors in the geocoding process.</p>
+            <p>Common vocabularies for describing the address of a Spatial Thing include: <a href="https://schema.org/">schema.org</a>, <a href="https://www.w3.org/TR/vcard-rdf/">vCard</a> and <a href="https://www.w3.org/ns/locn">ISA Core Location (LOCN)</a>.</p>
+			<p><a href="https://what3words.com/">what3words</a> is an example of a service that assigns an alternative kind of address to a location - in this case a sequence of three common words associated with a 3m by 3m square on the ground.  It allows every location to be given such an address and what3words also provides a means to relate the address to latitude and longitude coordinates.  Like conventional addresses, converting to coordinates is necessary for many spatial data applications (e.g. to calculate the distance between points or whether a point is inside a region), but the process of conversion is more reliable and precise.</p>
+			<aside class="example">
+                <p>TO DO. data integration example. <a href="http://statistics.gov.scot">Scottish Government Statistics</a></p>
+              </aside>
+			<h5>4. Spatial Data Infrastructures</h5>
+			<p>In the section <a href="#why-are-traditional-sdi-not-enough">'Why are traditional Spatial Data Infrastructures not enough?'</a> the limitations of this approach with respect to web-based data sharing were explained.  Nonetheless this approach is a well-established and powerful way of distributing spatial data, based on open standards and suited to a community of expert users. It is thus one of the options a data publisher should consider when deciding how to encode their spatial data.</p>
+			<aside class="example">
+                <p>TO DO: SDI example...</p>
+              </aside>
 
 
-<p>The group is chaired by Kerry Taylor and <a href="http://research.google.com/pubs/EdParsons.html">Ed Parsons</a>. The W3C staff contact is <a href="http://philarcher.org">Phil Archer</a>. If you are member of the Working Group, and you want to gain a “push” right to this repository, please contact <a href="mailto:phila@w3.org">phila@w3.org</a>, providing your github ID.</p>
-</body>
+            <h4 class="subhead">Balancing quality and cost</h4>
+            <p>The four main classes of application above have a wide range of requirements.  To support such a wide range may require a lot of effort and cost on behalf of a data publisher. There are many aspects to the 'quality' of a spatial data publishing approach, but in general terms it relates to how well the data and approach to data delivery meet the needs of the target audience.  By choosing to concentrate on only some kinds of application the publisher can keep cost down.  Other factors to consider include performance (speed with which data is delivered), timeliness of updates - which can be a significant consideration if the underlying data changes frequently, software complexity or maintenance. </p>
+            <p>In many cases a mixture of technologies can be used together to find a good compromise of quality or performance and cost. The strengths of various approaches can be applied to the part of the publishing 'spectrum' that suits them best. For example, if using a Linked Data approach, one option is to keep all data in a triple store; but hybrid approaches are also possible, for example where geometrical information is stored and served from flat files, or where non-geometrical data and metadata is stored in a triple store and used to generate web pages and machine readable descriptions of spatial things, while geometrical data is indexed by software such as Lucene Spatial, PostGIS or ElasticSearch. Use of shared web-accessible identifiers for spatial things can help support the interconnections between a range of diverse information systems. </p>
+	          </section>
+            <section class="test">
+              <h4 class="subhead">How to Test</h4>
+              <p>TO DO...</p>
+            </section>
+            <section class="ucr">
+              <h4 class="subhead">Evidence</h4>
+              <p><span>Relevant requirements</span>: TO DO</p>
+            </section>
+            <section class="benefits">
+              <h4 class="subhead">Benefits</h4>
+              <ul class="benefitsList">
+                <li>TO DO...</li>
+              </ul>
+            </section>
+         </div>
+        </section>
+        <section id="bp-expr-tempo">
+          <h4>Temporal aspects of spatial data</h4>
+          <p>Temporal relationship types will be described here and be entered eventually as link
+            relationship types into the IANA [[LINK-RELATION-TYPES]] registry, just like the spatial relationships. </p>
+          <p>In the same sense as with spatial data, temporal data can be fuzzy.</p>
+          <aside class="example">In May 2015 the discovery was reported of a new human ancestor near
+            the fossil of "Lucy". The Australopithecine lived <em>about 3.4 million years ago
+            </em>in what is now Ethiopia, <em>around the same time </em>as Australopithecus
+            afarensis.</aside>
+          <p class="note">Retain section; point to where temporal data is discussed in detail
+            elsewhere in this document.</p>
+        </section>
+      </section>
+      <section id="bp-exposing-via-api">
+        <h3>Spatial Data Access</h3>
+        <p>In recent years, we have seen widespread emergence of Web applications that use spatial data.
+			 Often these applications do not access all the spatial data they use via the Web. While there 
+			 are good reasons for this, e.g. licensing restrictions, it is often the case, too, that the
+			 spatial data is not available via the Web at all, or in ways that application developers find
+			 too complex to use, or with insufficient or unclear quality-of-service commitments.</p>
+        <p>[[DWBP]] provides best practices discussing access to data using Web infrastructure (see [[DWBP]] <a
+            href="https://www.w3.org/TR/dwbp/#dataAccess">section 8.10 Data Access</a>). This
+          section provides additional insight for publishers of spatial data. </p>
+        <p>Making data available on the Web requires data publishers to provide some form of
+          access to the data. There are numerous mechanisms available, each providing varying
+          levels of utility and incurring differing levels of effort and cost to implement and
+          maintain. Publishers of spatial data should make their data available on the Web using
+          affordable mechanisms to ensure long-term, sustainable access to their
+          data.</p>
+        <p>When determining the mechanism to be used provide Web access to data, publishers need
+          to assess utility against cost. In order of increasing usefulness and cost:</p>
+        <ol>
+          <li>Bulk-download or streaming of the entire or pre-defined subsets of a dataset</li>
+          <li>Generalized spatial data access API</li>
+          <li>Bespoke API designed to support a particular type of use</li>
+        </ol>
+		  <p>Let's take a closer look at these options.</p>
+        <p>The download of a dataset - or a pre-defined subset of it - via a single HTTP 
+			 request is mainly covered by these [[DWBP]] best practices:</p>
+        <ul>
+          <li>[[DWBP]] <a href="https://www.w3.org/TR/dwbp/#BulkAccess">Best Practice 17: Provide bulk
+            download</a>,</li>
+          <li>[[DWBP]] <a href="https://www.w3.org/TR/dwbp/#ProvideSubsets">Best Practice 18: Provide 
+            Subsets for Large Datasets</a>, and</li>
+          <li>[[DWBP]] <a href="https://www.w3.org/TR/dwbp/#Conneg">Best Practice 19: Use content 
+            negotiation for serving data available in multiple formats</a>.</li>
+        </ul>
+		  <p>Providing bulk-download or streaming access to data is useful in any case and
+		    is relatively inexpensive to support as it relies on standard capabilities of web servers 
+		    for datasets that may be published as downloadable files stored on a server.
+		    However, this option is more complex for frequently changing datasets or real-time data.</p>
+		  <p>[[DWBP]] <a href="https://www.w3.org/TR/dwbp/#ProvideSubsets">Best Practice 18: 
+		    Provide Subsets for Large Datasets</a> explains why providing subsets is important
+		    and how this could be implemented. 
+		    Spatial datasets, particularly <a>coverages</a> such as satellite imagery, sensor
+		    measurement time-series and climate prediction data, are often very large. 
+		    In these cases, it is useful to provide subsets by having identifiers for conveniently
+		    sized subsets of large datasets that Web applications can work with.</p>
+		  <p>Effectively, breaking up a large coverage into pre-defined lumps that you can 
+		    access via HTTP GET requests is a <em>very simple</em> API.</p>
+		  <p>When a subset is provided, this should include information about the relationship to the
+		    complete dataset. In HTML, this could be descriptive text or it is implicitly clear for 
+		    humans in the way the subset is presented. In schema.org it could be <a 
+		    href="http://schema.org/isPartOf">schema:isPartOf</a> property. In RDF <a
+          href="https://www.w3.org/TR/prov-o/">PROV-O</a> could be used to describe the relationship
+          between the subset and the complete dataset as well as the mechanism used to derive
+			 the subset. In ISO 19115 metadata, the LI_Lineage element may be used for a similar 
+			 purpose. Etc.</p>
+		  <p>The use of APIs to access data is covered in [[DWBP]] by the following best practices:</p>
+		  <ul>
+		    <li>[[DWBP]] <a href="https://www.w3.org/TR/dwbp/#useanAPI">Best Practice 23: Make data 
+		      available through an API</a>,</li>
+		    <li>[[DWBP]] <a href="https://www.w3.org/TR/dwbp/#APIHttpVerbs">Best Practice 24: Use Web 
+		      Standards as the foundation of APIs</a>,</li>
+		    <li>[[DWBP]] <a href="https://www.w3.org/TR/dwbp/#documentYourAPI">Best Practice 25: Provide 
+		      complete documentation for your API</a>, and</li>
+		    <li>[[DWBP]] <a href="https://www.w3.org/TR/dwbp/#avoidBreakingChangesAPI">Best Practice 26: 
+		      Avoid Breaking Changes to Your API</a></li>
+		  </ul>
+        <p>For spatial data, <a>SDIs</a> have long been used to provide generalized access to 
+          spatial data via web services, typically using open standard specifications from the 
+          <a href="http://www.opengeospatial.org/">Open Geospatial Consortium</a> (OGC). 
+          The main examples are <a>Web Feature Service</a>, <a>Web Coverage Service</a>, <a>Sensor 
+          Observation Service</a>, <a>SensorThings</a> or [[GeoSPARQL]] for access to data, or <a>Web Map Service</a> 
+          and <a>Web Map Tile Service</a> for access to data rendered as map. Apart from 
+          the <a>Web Map Service</a>, the OGC standards have not seen widespread adoption 
+          beyond the geospatial expert community.</p>
+        <p>In addition, commercial offerings for publishing spatial data on the Web often provide
+          access via product-specific APIs, too. These APIs are typically not restricted to 
+          HTTP-based web service APIs in the sense of [[DWBP]] <a 
+            href="https://www.w3.org/TR/dwbp/#APIHttpVerbs">Best Practice 24: Use Web Standards 
+          as the foundation of APIs</a>, but include APIs targeted at a specific programming 
+          language, for example, JavaScript.</p>
+        <p>In the list of options above, a third option is included as sharing spatial data
+          on the Web using the first two options (bulk download or generalized APIs) may not
+          be sufficient for reaching application developers. Reasons for this include:</p>  
+        <ul>  
+          <li>Generalized spatial data access APIs, like the OGC standards, typically and 
+            intentionally cover a wide range of usages, including requirements of users that 
+            are geospatial experts, and they support a broad range of spatial things. While 
+            they are documented comprehensively, they are often not easy to understand and 
+            the "Time to First Successful Call" (see [[DWBP]] <a 
+              href="https://www.w3.org/TR/dwbp/#documentYourAPI">Best Practice 25: Provide 
+            complete documentation for your API</a>) may be too high for application 
+            developers. A typical convenience API is a simple API that implements complex requirements
+            and hides the complexity, e.g. coordinate reference system handling, from the 
+            application developer.</li>
+          <li>Spatial data as it is used by expert users may be complex. As users 
+            need to understand how the data is structured to work effectively with 
+            that data, this burdens the data user with significant effort before they 
+            can even perform simple queries on data they have downloaded or access through 
+            a generalized data access API.</li>
+          <li>Spatial datasets tend to be large, often too large for direct use in Web 
+            applications.</li> 
+        </ul>
+        <p>A useful 'bespoke API' mentioned in the third option provides convenience to 
+        developers of the targeted applications, because the API designer has thought about 
+        the needs of those developers when consuming the spatial data shared via the API.</p>
+        
+        <div class="practice">
+          <p><span id="convenience-apis" class="practicelab">Expose spatial data through
+              'convenience APIs'</span></p>
+          <p class="practicedesc">If you have a specific type of application in mind for 
+            your data, tailor a spatial data access API to meet that goal.</p>
+          <section class="axioms">
+            <h4 class="subhead">Why</h4>
+            <p>Providing access to spatial data via bulk download or generalized spatial 
+              data access APIs may be too complex for application developers with 
+              relatively simple requirements, if the spatial data or the API is complex 
+              to understand or too large to handle in a Web application. 
+              <strong>Convenience APIs</strong> are tailored to meet a specific goal;
+              enabling a user to engage with complex data structures using (a set of)
+              simple queries, including spatial search.</p>
+          </section>
+          <section class="outcome">
+            <h4 class="subhead">Intended Outcome</h4>
+            <p>The API provides a coherent set of queries and operations, including spatial 
+              ones, that help users get working with the data quickly to achieve common tasks. 
+              The API provides both machine readable data and human readable HTML markup.
+              The human-readable markup will also support search engine's Web crawlers 
+              to enable indexing of spatial data.</p>
+          </section>
+          <section class="how">
+            <h4 class="subhead">Possible Approach to Implementation</h4>
+            <p>The API should</p>
+            <ul>
+              <li>offer <em>both</em> machine readable data and human readable HTML that includes 
+                the structured metadata required by search engines seeking to index content
+                (see <a href="#indexable-by-search-engines" class="sectionRef">Best 
+                Practice 4: Make your entity-level data indexable by search engines</a> 
+                for details);</li>
+              <li>follow the architectural guidance of the [[DWBP]] <a 
+                href="https://www.w3.org/TR/dwbp/#APIHttpVerbs">Best Practice 24: Use Web 
+		          Standards as the foundation of APIs</a> and [[DWBP]] <a 
+		          href="https://www.w3.org/TR/dwbp/#Conneg">Best Practice 19: Use content 
+                negotiation for serving data available in multiple formats</a>;</li>
+              <li>be well documented and easy to understand, both in terms of the options 
+                to access / filter the data and of the data structures that are returned
+                (see [[DWBP]] <a href="https://www.w3.org/TR/dwbp/#documentYourAPI">Best 
+                Practice 25: Provide complete documentation for your API</a>);</li>
+              <li>return data in chunks fit for use in Web applications and are useful sets
+                of information. For large datasets, this is related to [[DWBP]] <a 
+                href="https://www.w3.org/TR/dwbp/#ProvideSubsets">Best Practice 18: Provide 
+                Subsets for Large Datasets</a>; this may be achieved, for example, by 
+                filtering options that return appropriately sized subsets of the specific 
+                dataset or by supporting paging (returning larger subsets in pages with
+                forward/backward links). For paging, some patterns have been established,
+                see for example <a href="https://www.w3.org/TR/ldp-paging/">W3C Linked 
+                Data Platform Paging</a> or <a 
+                  href="https://www.w3.org/community/hydra/wiki/Pagination">Hydra
+                pagination</a>. At the other end of the spectrum, overly small pieces of
+                data are inconvenient to use, too. Data should be packaged in lumps that 
+                are convenient to work with. An approach where very small, fine-grained 
+                units of information are published that require further HTTP requests 
+                to get the related information sufficient to determine context is not
+                useful;</li>
+              <li>support queries for <a>spatial things</a> based on user needs. For spatial data, 
+                typical needs that should be considered are neighborhood searches (e.g., 
+                "what is near me?" or "what is near this spatial thing?") and searching for 
+                things located in a specific area (e.g., an area shown as a map in an 
+                application). Users will often look for a particular spatial thing without 
+                knowing its identifier, too, in which case a fault-tolerant, free-text 
+                search on the name, label or other property may be useful.</li> 
+            </ul>
+
+            <aside class="example" id="ex-elda">
+              <p>The <a href="http://environment.data.gov.uk/bwq/">Environment Agency Bathing Water
+                Quality API</a> is implemented using the Epimorphic's <a
+                  href="http://epimorphics.github.io/elda/current/index.html">ELDA implementation</a> of the <a
+                  href="https://github.com/UKGovLD/linked-data-api/blob/wiki/Specification.md"
+                >Linked Data API</a> and enables configured queries against (general) SPARQL
+                endpoints to be exposed as RESTful web services.</p>
+            </aside>
+
+            <aside class="example">
+              <p>Use of <a href="http://www.opensearch.org/Home">OpenSearch</a> to find 
+                <a>SpatialThings</a>. For spatial or temporal searches use the <a
+                  href="http://www.opengeospatial.org/standards/opensearchgeo">OGC Geo and
+                Temporal extensions</a>.</p>
+            </aside>
+
+            <p>In a White Paper about open geospatial APIs [[OGC-API-WP]], the Open Geospatial Consortium (OGC) has defined the concept of the "OGC API Essentials" - a set of items defined in OGC standards and other open standards that are reusable modules for use in geospatial APIs. The White Paper provides <a href="http://docs.opengeospatial.org/wp/16-019r4/16-019r4.html#_ogc_api_essentials_initial_list">an initial list</a> and many of the identified standards are mentioned in this document. Reuse of standardized building blocks improves consistency and interoperability across APIs. It is recommended to consider the OGC API Essentials when defining an API to access spatial data.</p>
+
+            <aside class="example">
+				      <p>The APIs of <a href="http://data.ordnancesurvey.co.uk/docs">data.ordnancesurvey.co.uk</a> support both textual and spatial searches.</p>
+            </aside>
+
+            <p>If the data is already published in a <a>Spatial Data Infrastructure</a>, 
+              there are basically two options to publish the data via an additional
+              convenience API.</p>
+            <ol>   
+              <li>
+              <p>Reuse your existing spatial data infrastructure</p>
+              <p>Use a RESTful API as a wrapper, proxy or a shim layer can be created 
+                around SDI services. This aims at exposing 'generalized APIs' using 
+                'convenience APIs' to make the data easier to use. 
+                For example, in the geospatial domain there are a 
+                lot of <a>WFS</a> services providing spatial data. Content from the WFS 
+                service can be provided in this way as linked data, JSON or another
+                Web friendly format using simple, navigable resources. 
+                This approach is like the use of Z39.50 in 
+                the library community; that protocol is still used but 'modern' Web sites 
+                and Web services are wrapped around it.</p>
+              <aside class="example">
+                <p>An example of this approach of creating a convenience API that works 
+                  dynamically on top of WFS is the experimental <a 
+                  href="https://github.com/interactive-instruments/ldproxy">ldproxy</a>. 
+                  This requires relatively little effort and is an attractive option for quickly 
+                  exposing spatial data from existing WFS services on the Web. The approach is 
+                  to create an intermediate layer by introducing a proxy on top of the 
+                  WFS so the contained resources are made available. The proxy maps the 
+                  data and metadata to schema.org according to a provided mapping scheme; 
+                  assigns URIs to all resources based on a pattern; supports filtering 
+                  based on a property; makes each resource available in HTML, XML, JSON-LD, 
+                  [[GML]], GeoJSON; and generates links to data in other datasets managed in triple 
+                  stores using SPARQL queries. The API is documented and published using 
+                  Swagger.</p>
+              </aside>    
+              <aside class="example">
+                <p>A similar approach, but for a specific dataset is the <a
+                    href="https://app.swaggerhub.com/api/pdok/geluidskaarten/1.0">Geluidskaarten
+                  API</a> in SwaggerHub, based on a WFS service published in the Dutch geoportal <a
+                    href="http://www.pdok.nl">Publieke Dienstverlening op de Kaart (PDOK)</a>.</p>
+              </aside>  
+              <aside class="example">
+                <p>Mapping a URI template (as specified in [[RFC6570]]) to a <a>WFS</a>, <a>WCS</a> or <a
+                    href="http://www.opendap.org/">OPeNDAP</a> end-point is a very simple
+                  way of specifying a set of resources in the existing infrastructure.
+                  This will not address all API aspects described in this best practice,
+                  but it is a simple start.</p>
+                <p>One advantage of this approach is to be able to hide
+                  implementation details of the current backend in the URI. A Web service
+                  URL in general does not provide a good URI for a resource as it is unlikely to be
+                  persistent. A Web service URL is often technology and implementation dependent and
+                  in practice both are likely to change with time.</p>
+                <p>The <a href="#ex-elda">Environment Agency Bathing Water
+                  Quality API</a> example above uses URI templates, too. In this case, 
+                  the Linked Data API configuration uses URI templates to provide RESTful 
+                  access to SPARQL queries thereby taking away from the user the challenge 
+                  of writing generalized SPARQL queries and understanding the underpinning 
+                  data model.</p> 
+              </aside>  
+              </li>  
+              
+              <li>
+              <p>Provide parallel web-friendly access to the data as an alternative</p>
+              <p>A more effective route may be to provide an alternative 'Web friendly' 
+                access path to the spatial data is to create a new, complementary service
+                endpoint on top of the native storage of the dataset. This limits the 
+                load on your SDI compared to the first option, which may matter as the 
+                data access APIs of the SDI will continue to be used by expert users
+                and their complex data management tasks.</p>
+              <aside class="example">
+                <p>Expose the underpinning relational database via a SPARQL endpoint (using
+                something like <a href="http://www.melodiesproject.eu/content/ontop-spatial"
+                  >ontop-spatial</a>) and Linked Data API. The data may be mapped dynamically 
+                to resources on the Web using the [[R2RML]] standard and Linked Data 
+                Publication tools. This process also allows to enrich the data represented
+                in RDF with additional information and links. To maintain a direct link 
+                between the spatial things provided through the SDI and as Linked Data, 
+                use properties that link between the [[GML]] and RDF representations, for example,
+                by including an additional feature property 'rdf_seealso' in the [[GML]] encoding 
+                pointing to the RDF representation of the spatial thing.</p>
+                <figure>
+                  <img src="images/bp28-example.PNG"
+                    alt="Example of providing an alternative access path to spatial data" />
+                  <figcaption>Providing an alternative 'Linked Data friendly' access path to a WFS data
+                    source.</figcaption>
+                </figure>
+              </aside>    
+              </li>
+            </ol>
+          </section>
+          <section class="test">
+            <h4 class="subhead">How to Test</h4>
+            <p>See the "How to test" sections in [[DWBP]] <a 
+              href="https://www.w3.org/TR/dwbp/#useanAPI">Best Practice 23: Make data 
+		        available through an API</a>, [[DWBP]] <a 
+		        href="https://www.w3.org/TR/dwbp/#APIHttpVerbs">Best Practice 24: Use Web 
+		        Standards as the foundation of APIs</a> and [[DWBP]] <a 
+		        href="https://www.w3.org/TR/dwbp/#documentYourAPI">Best Practice 25: Provide 
+		        complete documentation for your API</a>.</p>
+          </section>
+          <section class="ucr">
+            <h4 class="subhead">Evidence</h4>
+            <p><span>Relevant requirements</span>: <a
+                href="https://www.w3.org/TR/sdw-ucr/#Compatibility">R-Compatibility</a>, <a
+                href="https://www.w3.org/TR/sdw-ucr/#LightweightAPI">R-LightweightAPI</a>, <a
+                href="https://www.w3.org/TR/sdw-ucr/#ReferenceDataChunks">R-ReferenceDataChunks</a>.</p>
+          </section>
+          <section class="benefits">
+            <h4 class="subhead">Benefits</h4>
+            <ul class="benefitsList">
+              <li>...</li>
+            </ul>
+          </section>
+        </div>
+        <div class="practice">
+          <p><span id="include-search-api" class="practicelab">(to be deleted)</span></p>
+          <p class="practicedesc"></p>
+          <section class="axioms">
+            <h4 class="subhead">Why</h4>
+          </section>
+          <section class="outcome">
+            <h4 class="subhead">Intended Outcome</h4>
+          </section>
+          <section class="how">
+            <h4 class="subhead">Possible Approach to Implementation</h4>
+          </section>
+          <section class="test">
+            <h4 class="subhead">How to Test</h4>
+          </section>
+          <section class="ucr">
+            <h4 class="subhead">Evidence</h4>
+          </section>
+          <section class="benefits">
+            <h4 class="subhead">Benefits</h4>
+          </section>
+        </div>
+        <div class="practice">
+          <p><span id="ids-for-chunks" class="practicelab">(to be deleted)</span></p>
+          <p class="practicedesc"></p>
+          <section class="axioms">
+            <h4 class="subhead">Why</h4>
+          </section>
+          <section class="outcome">
+            <h4 class="subhead">Intended Outcome</h4>
+          </section>
+          <section class="how">
+            <h4 class="subhead">Possible Approach to Implementation</h4>
+          </section>
+          <section class="test">
+            <h4 class="subhead">How to Test</h4>
+          </section>
+          <section class="ucr">
+            <h4 class="subhead">Evidence</h4>
+          </section>
+          <section class="benefits">
+            <h4 class="subhead">Benefits</h4>
+          </section>
+        </div>
+      </section>
+      <section id="bp-linking">
+        <h3>Linking Spatial Data</h3>
+        
+        <p>Links, in whatever machine-readable form, are important. In the wider Web, it is links that enable the discovery of web pages: from user-agents following a hyperlink to find related information to search engines using links to prioritize and refine search results. This section is concerned with the creation and use of those links to support discovery of the <a>SpatialThings</a> described in spatial datasets.</p>
+
+        <p>For data to be <em>on the Web</em>, the resources it describes need to be connected, or <em>linked</em>, to other resources. The <em>connectedness</em> of data is one of the fundamentals of the Linked Data approach that these best practices build upon.</p> 
+
+        <p>Just like any type of data, spatial data benefits massively from linking when publishing on the web. The widespread use of links within data is regarded as one of the most significant departures from contemporary practices used within SDIs. That's why this topic is included in this Best Practice.</p>
+
+        <p>[[DWBP]] identifies <em>Linkability</em> as one of the <a href="https://www.w3.org/TR/dwbp/#BP_Benefits">benefits</a> gained from implementing the Data on the Web best practices (see [[DWBP]] <a href="https://www.w3.org/TR/dwbp/#DataIdentifiers">section 8.7 Data Identifiers</a> <a href="https://www.w3.org/TR/dwbp/#UniqueIdentifiers">Best Practice 9: Use persistent URIs as identifiers of datasets</a> and <a href="https://www.w3.org/TR/dwbp/#identifiersWithinDatasets">Best Practice 10: Use persistent URIs as identifiers within datasets</a>). However, no discussion is provided about how to create the links that the use those persistent URIs. This section of the document extends [[DWBP]] by providing a best practice about <em>creating</em> links between the resources described inside spatial datasets.</p>
+
+        <div class="note">
+          <p>Discussion of links in these best practices are limited to simple links that relate exactly two resources: the <em>source</em> and <em>target</em>. Complex links that relate an arbitrary number of resources, such as described in [[XLINK11]] <a href="https://www.w3.org/TR/xlink11/#extended-link">section 5.1 Extended Links</a>, are out of scope.</p>  
+        </div>
+
+        <div class="practice">
+          <p><span id="entity-level-links" class="practicelab">Publish links between spatial things and related resources</span></p>
+          <p class="practicedesc">Bind spatial things into the Web of data using links to other resources, providing sufficient information for a user to determine whether the target resource specified in a link will be of use.</p>
+          <section class="axioms">
+            <h4 class="subhead">Why</h4>
+            <p>The <a href="http://5stardata.info">5&#9733; rating for Linked Open Data</a> asserts that to achieve the fifth star you must "link your data to other data to provide context". The benefits for consumers and publishers of linking to other data are <a href="http://5stardata.info/en/#addendum5">listed</a> as:</p>
+            <ul>
+              <li>You can discover more (related) data while consuming the data.</li>
+              <li>You can directly learn about the data schema.</li>
+              <li>You make your data discoverable.</li>
+              <li>You increase the value of your data.</li>
+              <li>Your own organization will gain the same benefits from the links as the [other] consumers.</li>
+            </ul>
+
+            <p>Geography is often described as the "glue that binds Linked Data"; the links between <a>spatial things</a> - and between other resources and spatial things - describe how the world around us is structured and interrelated and form an important facet of the Web of Data.</p>
+
+            <p>Spatial relationships can often be derived mathematically based on geometry - but this can be computationally expensive. <em>Topological</em> relationships such as these can be asserted, thereby removing the need to do geometry-based calculations. A useful secondary benefit is that these relationships are easier for humans to understand!</p>
+
+            <p>One issue that spatial data is more prone to than other domains is the non-unique naming. Different authorities and agencies seek to describe the world around them by publishing spatial data, and in doing so, each minting their own URIs (as recommended in <a href="#globally-unique-ids" class="sectionRef">Best Practice 7: Use globally unique persistent HTTP URIs for spatial things</a>). Where spatial things are of common interest to multiple agents, it is almost inevitable that a given spatial thing will end up being identified with several URIs. Given necessary due diligence, multiple identifiers may be linked, thereby supporting conflation of multiple sets of information and yielding new perspectives on spatial things. </p>
+
+            <p>There is always a cost to traversal of a link, even if it is just a few milliseconds delay and the need to parse a few hundred or thousand bytes returned in response to an HTTP request. In many cases, such as when dealing with large datasets and complex queries, the costs incurred from traversing a link may be significant in terms of time and data volumes. Before a user or software agent decides to traverse a link, they should be able to determine whether acquisition of the target resource, or data <em>about</em> the target resource, will support their application goals. For example, what format can one expect the response in, what type of resource is the target and how is that target related to the source resource?</p>
+
+            <p>Links by their nature are a directional relationship between source and target. Most often, a link is published within the dataset that describes the source resource specified in the link, enabling users to browse through information; traversing the links they find in documents (i.e. <em>outbound</em> links). While many links specify source and target resources that are described in the same dataset, it is commonplace, and encouraged as per the 5&#9733; rating, to link <em>between</em> datasets, thereby 'stitching' together the Web of data. In these situations, a link refers to some remote target resource. A dataset access API may interpret such links to enable a user to specify a well-known URI of a spatial thing they are interested in (for example from popular data repositories such as <a href="http://www.geonames.org/">GeoNames</a>, <a href="https://www.wikidata.org/">Wikidata</a> or <a href="http://dbpedia.org/">DBpedia</a>) in order to search for related information (see <a href="#convenience-apis" class="sectionRef">Best Practice 11: Expose spatial data through 'convenience APIs'</a> for more on APIs and search). But how does a user know of the existence of a link referring <em>to</em> their target spatial thing (and potentially identifying a related resource that is useful for their intended goal) when that link is published within a remote dataset resource (i.e. an <em>inbound</em> link)?</p>
+
+            <p>Making these inbound links discoverable makes the Web of data symmetric; e.g. where both inbound and outbound links are visible to data users who may then choose to traverse them. However, links provide a secondary benefit in terms of a citation; indicating some subjective trustworthiness of the data (e.g. "it's good enough quality for me to use"). Not only do such link-based citations convey the value of the dataset in a way that the original publisher can objectively quantify (and hence continue to publish and maintain those datasets), but they can provide a subjective indication of quality; like a search engine’s page ranking algorithm, the larger the number of sources of inbound links, the greater the likelihood that a given dataset is of high quality.</p>
+          </section>
+
+          <section class="outcome">
+            <h4 class="subhead">Intended Outcome</h4>
+            <p>Spatial things are related to other resources in the Web of data using links with appropriate semantics.</p>
+            <p>Links can be identified and traversed by humans and software agents.</p>
+            <p>Sufficient information is provided to help humans and software agents determine whether traversal of a given link meets their goals.</p>
+            <p>Humans and software agents can find resources that link <em>to</em> and <em>from</em> a given spatial thing.</p>
+          </section>
+          <section class="how">
+            <h4 class="subhead">Possible Approach to Implementation</h4>
+
+            <p>Before we get into the details of linking spatial data it's worth stating some ground-rules that should be followed when linking any types of resource in the Web of data.</p>
+            <ol>
+              <li>
+                <p>Use formats that support Web linking (as defined in [[WEBARCH]] <a href="https://www.w3.org/TR/webarch/#hypertext">section 4.4 Hypertext</a>)</p>
+                <p>Earlier in this document (<a href="#linked-data" class="sectionRef"></a>) we explained that Linked Data requires only that the formats used to publish data support Web linking. In other words, linking spatial data does not automatically mean the use of RDF; links can also be created, for example, using [[GML]], HTML or JSON-LD. The two key points from [[WEBARCH]] are:</p>
+                <ul>
+                  <li><strong><em>Good practice: Link identification</em></strong> &mdash; A [data format] specification SHOULD provide ways to identify links to other resources [...].</li>
+                  <li><strong><em>Good practice: Web linking</em></strong> &mdash; A [data format] specification SHOULD allow Web-wide linking, not just internal document linking.</li>
+                </ul>
+                <p>The examples used in this best practice illustrate some of the data formats and mechanisms that support Web linking.</p>
+              </li>
+              <li>
+                <p>Follow the principles for <strong>4&#9733; &mdash; Linked</strong> [[WEB-DATA]]</p>
+                <ul>
+                  <li>
+                    <p>Always use global identifiers when linking between documents, so that link identifiers can be taken out of context and shared globally.</p>
+                    <div class="note">
+                      <p>Obviously, this principle is predicated on the use of global identifiers for resources. As such, we consider <a href="#globally-unique-ids" class="sectionRef">Best Practice 7: Use globally unique persistent HTTP URIs for spatial things</a> as a prerequisite for linking.</p>
+                    </div>
+                  </li>
+                  <li>
+                    <p>Links should be typed (explicitly or implicitly), so that clients can decide which link to follow when they are traversing a web of interlinked resources to reach application goals.</p>
+                    <pre class="example" id="ex-webdata2-typed-links" title="HTTP response Link header with IANA Link Relation types">
+HTTP/1.1 200 OK
+Link: &lt;http://www.gemeentegeschiedenis.nl/gemeentenaam/Amsterdam/2014&gt;; rel="predecessor-version"
+Content-type: application/geo+json
+Connection: close
+
+{...}
+                    </pre>
+                    <p>This example, using HTTP Link headers (as defined in [[RFC5988]]), illustrates the use of IANA [[LINK-RELATION-TYPES]] to define the link type. According to the IANA registry, <code>predecessor-version</code> <em>points to a resource containing the predecessor version in the version history</em> (as defined in [[RFC5829]] "Link Relation Types for Simple Version Navigation between Web Resources").</p>
+                    <div class="note">
+                      <p>In simple links involving only two resources, the <em>role</em>, or type, of each resource are implicit and can be inferred from the link relation type. It can be useful to include other information to help users judge whether to follow a link such as human-readable labels and hints about the target resource type. Of course, often target resources and the links that refer to them are maintained by different parties, so such hints should be assumed as prescriptive; they may or may not turn out to be true. For example, [[RFC5988]] "Web Linking" defines several additional attributes including: <code>hreflang</code> &mdash; hints at the language or languages that the target resource is available in; <code>type</code> &mdash; indicates the media-type expected; and <code>title</code> &mdash; labels the link target such that it can be used as a human-readable identifier etc.</p>
+                      <p>Also note that [[DWBP]] <a href="https://www.w3.org/TR/dwbp/#Conneg">Best Practice 19: Use content negotiation for serving data available in multiple formats</a> recommends the use of <a href="https://www.w3.org/DesignIssues/Conneg">content negotiation</a> to help ensure that a user or software agent is provided with useful content when they traverse a link and resolve the target resource. <span style="background-color:yellow">However, HTTP Request headers are limited to specifying media-type, character set, encoding (e.g. for compression) and language. There is no mechanism to request that data is provided according to a particular data model or 'profile' (see [[RFC6906]] "profile" Link Relation Type), nor request data in a particular coordinate reference system.</span> </p>
+                    </div>
+                    
+                  </li>
+                  <li>
+                    <p>Make links as specific as possible. If the linked resource supports fragment identification, and the link logically should be to a fragment of the resource (and not just the resource as a whole), try to use fragment identifiers when possible.</p>
+                    <div class="note">
+                      <p>Being as specific as possible with links is important; e.g. refer to a particular <a>spatial thing</a> rather than the dataset in which that spatial thing is described. That said, we encourage publication of data about spatial things as independently resolvable resources (e.g. so that they can be accessed by search engine's Web crawlers, see <a href="#indexable-by-search-engines" class="sectionRef">Best Practice 4: Make your spatial data indexable by search engines</a>) which means that fragment identifiers are usually not required.</p>
+                    </div>
+                  </li>
+                </ul>
+              </li>
+            </ol>
+
+            <p>Now that we've set some ground rules for Web linking, we need to consider the types of relationship that might be used in spatial data.</p>            
+            <ol>
+              <li>
+                <p>Synonyms and equality</p>
+                <p>As described above, it is not uncommon for a spatial thing to be identified using more than one URI (also known as the "non-unique naming problem"). If you think that this is the case, the property <code>owl:sameAs</code> may be used to express this. However, caution is advised as <code>owl:sameAs</code> is an extremely strong statement; literally "these two URIs identify the same resource". As there is only <em>one</em> spatial thing, all the properties and attributes returned when resolving any of the equated URIs are considered to apply to that spatial thing. Given that spatial data is often published by different parties, each concerned with their own perspective, the spatial thing equality is often difficult to determine and depends heavily on the semantics involved.</p>
+                <p>So, the advice is: if in doubt, don't use <code>owl:sameAs</code>.</p>
+
+                <p>By way of example, let's explore some data for Edinburgh.</p> 
+
+                <p>The <em>City of Edinburgh Council Area</em> (e.g. the geographical area that Edinburgh City Council is responsible for) is identified by the <a href="https://www.ons.gov.uk">Office for National Statistics</a> (the recognized national statistical institute of the UK) using their GSS code (a 9 character alpha numeric identifier) <code>S12000036</code> and the URI <a href="http://statistics.data.gov.uk/id/statistical-geography/S12000036"><code>http://statistics.data.gov.uk/id/statistical-geography/S12000036</code></a>. At the same time, the devolved government in Scotland, operating under its own jurisdiction, retains the GSS code but uses the URI <a href="http://statistics.gov.scot/id/statistical-geography/S12000036"><code>http://statistics.gov.scot/id/statistical-geography/S12000036</code></a>. Furthermore, the <a href="https://www.ordnancesurvey.co.uk">Ordnance Survey</a> maintain yet another URI for the City of Edinburgh Council Area as part of its 'Boundary Line' service that contains administrative and statistical geography areas in the UK: <a href="http://data.ordnancesurvey.co.uk/id/7000000000030505"><code>http://data.ordnancesurvey.co.uk/id/7000000000030505</code></a>. Similarly, Geonames identifies Edinburgh, a <em>second-order administrative division</em>, as <a href="http://sws.geonames.org/2650225"><code>http://sws.geonames.org/2650225</code></a>. All of these URIs refer to the same <a>spatial thing</a> and are equated using <code>owl:sameAs</code>.</p>
+
+                <pre class="example" id="ex-linking-equality-edinburgh" title="Asserting equality between URIs for the City of Edinburgh Council Area (TTL format)">
+@prefix owl:          &lt;http://www.w3.org/2002/07/owl#&gt; .
+@prefix scotgov-stat: &lt;http://statistics.gov.scot/id/statistical-geography/&gt; .
+@prefix ukgov-stat:   &lt;http://statistics.data.gov.uk/id/statistical-geography/&gt; .
+@prefix osuk:         &lt;http://data.ordnancesurvey.co.uk/id/&gt; .
+@prefix geonames:     &lt;http://sws.geonames.org/&gt; .
+
+scotgov-stat:S12000036 owl:sameAs ukgov-stat:S12000036 .
+osuk:7000000000030505 owl:sameAs ukgov-stat:S12000036 .
+geonames:2650225 owl:sameAs ukgov-stat:S12000036 .
+                </pre>
+
+                <p>Also note that in this [[TURTLE]] snippet one could easily include additional properties to help users determine whether the link is worth traversing, such as providing human-readable labels and specifying the <em>type</em> designated by each data publisher.</p>
+
+                <p>In contrast, the resource identified by <a href="http://data.ordnancesurvey.co.uk/id/50kGazetteer/81103"><code>http://data.ordnancesurvey.co.uk/id/50kGazetteer/81103</code></a> defines Edinburgh as a <a href="http://data.ordnancesurvey.co.uk/ontology/50kGazetteer/NamedPlace">named place</a> of type <a href="http://data.ordnancesurvey.co.uk/ontology/50kGazetteer/City">city</a>. This is not the same as the <em>City of Edinburgh Area</em> and therefore use of the <code>owl:sameAs</code> relationship is inappropriate.</p>
+
+                <div class="note">
+                  <p>The mechanics of determining whether the information provided when resolving two or more URIs does indeed describe the same spatial thing is a complex topic all in its own right and way beyond the scope of best practice document. Tools such as <a href="http://openrefine.org">Open Refine</a> and the <a href="http://silkframework.org">Silk Linked Data Integration Framework</a> are designed to work with, transform and integrate heterogeneous data sources. Their documentation may provide further insight regarding these challenges.</p>
+                </div>
+
+                <div class="note">
+                  <p>The very strong semantics of the <code>owl:sameAs</code> property has led to several similar sounding, but semantically weaker, properties being defined. These include:</p>
+                  <ul>
+                    <li>
+                      <p><a href="http://www.bbc.co.uk/ontologies/coreconcepts#terms_sameAs">http://www.bbc.co.uk/ontologies/coreconcepts/sameAs</a>, defined by the BBC, whose description states that the property:</p>
+                      <p style="margin-left: 40px"><em>Indicates that something is the same as something else, but in a way that is slightly weaker than owl:sameAs. Its purpose is to connect separate identities of the same thing, whilst keeping separation between the original statements of each.</em></p>
+                    </li>
+                    <li>
+                      <p>and the widely used <a href="https://schema.org/sameAs">schema:sameAs</a> defined by [[SCHEMA-ORG]] whose description states:</p>
+                      <p style="margin-left: 40px"><em>URL of a reference Web page that unambiguously indicates the item's identity. E.g. the URL of the item's Wikipedia page, Freebase page, or official website.</em></p>
+                    </li>
+                  </ul>
+                </div>
+
+                <p>The lack of equality between the <em>City of Edinburgh [Administrative] Area</em> and the <a href="http://data.ordnancesurvey.co.uk/ontology/50kGazetteer/NamedPlace">named place</a> <em>Edinburgh</em> spatial things illustrates a gap in best practice. Clearly, these two resources are strongly related, but it is not clear which property one would use to assert that relationship. Unlike administrative areas that have clearly defined boundaries, places often have ill-defined, fuzzy boundaries that are based on human perception of ‘place’; you can’t always define a boundary for a place. For example, <a href="http://data.ordnancesurvey.co.uk/id/50kGazetteer/81103">Edinburgh</a> the <a href="http://data.ordnancesurvey.co.uk/ontology/50kGazetteer/NamedPlace">named place</a>, published as part of Ordnance Survey’s 50K Gazetteer, is described using only a notional point geometry; no information is provided about the geometric extent. Other examples of places with ill-defined, fuzzy geometries include the <em>American West</em> and <em>Renaissance Italy</em>. The relationships between places, with their ill-defined (or even absent) geometrical extents, defy description using the topological relationships, such as those described below, which are computed mathematically from geometry.</p> 
+
+                <p>We propose the use of a <em>qualitative</em> assertion based on human perceptions to relate places that are deemed to be the same: <strong>samePlaceAs</strong>. The <span style="background-color:yellow">proposed definition to be published in [[SCHEMA-ORG]]</span> is:</p>
+
+                <div style="margin-left: 40px">
+                  <p><a href="http://schema.org/Thing"><code>Thing</code></a> &gt; <a href="http://schema.org/Property"><code>Property</code></a> &gt; <span style="background-color:yellow"><code>samePlaceAs</code></span></p>
+                  <p>Used to relate two places that are perceived to be the same; the physical extents of the two places should be broadly comparable but do not need to be equal in a topological or geometric sense.</p>
+                  <p><strong>Values expected to be one of these types:</strong> <a href="http://schema.org/Place"><code>Place</code></a></p>
+                  <p><strong>Used on these types:</strong> <a href="http://schema.org/Place"><code>Place</code></a></p>
+                </div>
+
+                <p>Given that the notion of <em>place</em> concerns a social perspective, we consider it to be distinct from <em>location</em> which is based on geometry. As a result, <code>samePlaceAs</code> can be used to assert the imprecise, social perceptions about the equality of places. <code>samePlaceAs</code> does not overlap with the topological relationships described later in this best practice document that can be computed from geometry.</p>
+
+                <p>As with all assertions of an imprecise nature that lack formal semantics, <code>samePlaceAs</code> may have limited value for semantic reasoning. Exactly what constitutes the ‘same place’ will always be somewhat debatable. For example, is <a href="http://dbpedia.org/resource/Byzantium">ancient Byzantium</a> the same place as <a href="http://dbpedia.org/resource/Istanbul">modern Istanbul</a>? Is a historical hotel that was moved across the street to save it from demolition in a redevelopment scheme that same place that it used to be?</p>
+              </li>
+              <li>
+                <p>Spatial relationships</p>
+                <p>Topological relationships between <a>spatial things</a> can be computed based on assessment of their geometry. [[GeoSPARQL]] defines families of topological relationships (based on the <a href="https://en.wikipedia.org/wiki/DE-9IM">DE-9IM</a> pattern) that, in mathematical terms, specify the spatial dimension of the intersections of the interiors, boundaries and exteriors of two geometric objects that may be 2-dimensional (e.g. area), 1-dimensional (e.g. linear) or 0-dimensional (e.g. point).</p>
+                <p>Most commonly used are the simple feature relationship family, described in [[SIMPLE-FEATURES]] section <span style="text-decoration: underline;">6.1.15.3 Named spatial relationship predicates based on the DE-9IM</span>. The set of seven named relationships, or <em>spatial predicates</em>, and their associated [[GeoSPARQL]] properties are listed below:</p>
+                <ul>
+                  <li><strong>Equals</strong> &mdash; <a href="http://www.opengis.net/ont/geosparql#sfEquals"><code>geosparql:sfEquals</code></a></li>
+                  <li><strong>Disjoint</strong> &mdash; <a href="http://www.opengis.net/ont/geosparql#sfDisjoint"><code>geosparql:sfDisjoint</code></a></li>
+                  <li><strong>Touches</strong> &mdash; <a href="http://www.opengis.net/ont/geosparql#sfTouches"><code>geosparql:sfTouches</code></a></li>
+                  <li><strong>Crosses</strong> &mdash; <a href="http://www.opengis.net/ont/geosparql#sfCrosses"><code>geosparql:sfCrosses</code></a></li>
+                  <li><strong>Within</strong> &mdash; <a href="http://www.opengis.net/ont/geosparql#sfWithin"><code>geosparql:sfWithin</code></a></li>
+                  <li><strong>Contains</strong> &mdash; <a href="http://www.opengis.net/ont/geosparql#sfContains"><code>geosparql:sfContains</code></a></li>
+                  <li><strong>Intersects</strong> &mdash; <a href="http://www.opengis.net/ont/geosparql#sfIntersects"><code>geosparql:sfIntersects</code></a></li>
+                </ul>
+                <p>We recommend use of the Simple Features relation families for describing topological relations between points, lines and areas. Further details are provided in [[GeoSPARQL]] section <span style="text-decoration: underline;">7 Topology Vocabulary Extension</span>.</p>
+
+                <pre class="example" id="ex-linking-geosparql-sfcrosses" title="Asserting topological relationship 'crosses' (JSON format)">
+&lt;script type="application/hal+json"&gt;
+{
+  "ex:type-nl": "brug",
+  "ex:type-en": "bridge",
+  "ex:name": "Lelieslius",
+  "_links": {
+    "self": { "href" : "http://data.example.org/topo/ams/brug/Leliesluis" },
+    "curies": [ 
+      { 
+        "name": "geosparql", 
+        "href": "http://www.opengis.net/ont/geosparql#{rel}", 
+        "templated": true 
+      } , {
+        "name": "ex",
+        "href": "http://data.example.org/def/topo#{rel}",
+        "templated": "true"
+      } 
+    ],
+    "geosparql:sfCrosses": { "href" : "http://data.example.org/topo/ams/kanaal/Prinsengracht" }
+  }, 
+  "_embedded": {
+    "ex:type-nl": "kanaal",
+    "ex:type-en": "canal",
+    "ex:name": "Prinsengracht",
+    "_links": {
+      "self": { "href" : "http://data.example.org/topo/ams/kanaal/Prinsengracht" }
+    }
+  }
+}
+&lt;/script&gt;
+                </pre>
+
+                <p>The example above uses the <a href="http://stateless.co/hal_specification.html">Hypertext Application Language</a> (HAL) conventions for expressing hyperlinks in JSON. It illustrates how one would indicate using <code>geosparql:crosses</code> that two linear features, a bridge and a canal, cross over each other.</p>
+
+                <div class="note">
+                  <p>The spatial predicates specified in [[GeoSPARQL]] describe 2-dimensional topological relations. There is no evidence of common practice for describing 3-dimensional topological relationships.</p>
+                </div>
+
+                <p>In addition to the mathematically precise spatial predicates described above, several vocabularies define similar relationships but without the formal mathematical underpinning. For example, [[SCHEMA-ORG]] defines a pair of basic containment relationships for use with <a href="http://schema.org/Place"><code>schema:Place</code></a>:</p>
+                <ul>
+                  <li><a href="http://schema.org/containsPlace"><code>schema:containsPlace</code></a>: <em>The basic containment relation between a place and another that it contains.</em></li>
+                  <li><a href="http://schema.org/containedInPlace"><code>schema:containedInPlace</code></a>: <em>The basic containment relation between a place and one that contains it.</em></li>
+                </ul>
+
+                <p>It is also commonplace to use spatial relationships to convey distance (e.g. <em>at</em>, <em>nearby</em> or <em>far-away</em>) and direction (e.g. <em>left</em>, <em>inFrontOf</em>, <em>astern</em> and <em>below</em>). However, we find no evidence that points to use of common vocabularies to express these relationships -  perhaps because these relationships are often subjective and dependent on application context (e.g. the meaning of “near” will be quite different between an endurance cycling App and the App I use to find the Bluetooth tag attached to my house keys!).</p>
+
+                <p>Two notable examples of distance relations are:</p>
+                <ul>
+                  <li><a href="http://xmlns.com/foaf/spec/#term_based_near"><code>foaf:based_near</code></a> which states "<em>We do not say much about what 'near' means in this context; it is a 'rough and ready' concept.</em>"; and</li>
+                  <li><a href="http://www.geonames.org/ontology#nearby"><code>geonames:nearby</code></a> which simply states, "<em>A feature close to the reference feature</em>".</li>
+                </ul>
+
+                <pre class="example" id="ex-linking-geonames-nearby" title="Asserting distance spatial relationship using GeoNames ontology (GeoJSON [RFC7946] format)">
+&lt;script type="application/geo+json"&gt;
+{
+  "id" : "http://sws.geonames.org/6618987/",
+  "type": "Feature",
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [ [ ... ] ]
+  },
+  "properties": {
+    "http://www.geonames.org/ontology#name": "Anne Frank's House",
+    "http://www.geonames.org/ontology#nearby" : 
+      [ "http://sws.geonames.org/6950949/",
+        "http://sws.geonames.org/6951798/",
+        "http://sws.geonames.org/6944503/",
+        ... ]
+  }
+}
+&lt;/script&gt;
+                </pre>
+
+                <p>This example snippet, adapted to use [[RFC7946]] GeoJSON format, shows a list of features (e.g. Westerkerk, Homomonument and Westertoren) that are deemed '<a href="http://sws.geonames.org/6618987/nearby.rdf">nearby</a>' Anne Frank's House according to <a href="http://www.geonames.org">GeoNames</a>.</p>
+
+                <div class="note">
+                  <p>The [[RFC7159]] JSON format provides only simple primitive types; string, number, boolean etc. The lack of a datatype for URIs means that they must be encoded as strings. As such, conventions (such as those defined in <a href="http://stateless.co/hal_specification.html">HAL</a>) are required to tell applications that a given string value is a URI. However, [[RFC7946]] GeoJSON does not define any conventions for describing URIs and forbids any extension of the data format specification.</p>
+                  <p>To mitigate this, details about object types etc. included in data payload should be provided in the documentation for the API or service end-point from which the data is accessed. See [[DWBP]] <a href="https://www.w3.org/TR/dwbp/#documentYourAPI">Best Practice 25: Provide complete documentation for your API</a> for further details.</p>
+                </div>
+
+              </li>
+              <li>
+                <p>Domain-specific relationships involving <a>spatial things</a></p>
+
+                <p>In addition to the spatial relationships that are applicable to a wide variety of domains, there are a huge number of cases where asserting a relationship between <a>spatial thing</a> is useful. Clearly, enumerating all these cases is more than we can do here - but we can look at some of those that commonly occur.</p>
+
+                <p>First, there are the properties used to describe relationships between spatial things in a <em>gazetteer</em>. These properties are often used in combination with spatial predicates to describe the relationship between administrative units. For example, <a href="https://www.ordnancesurvey.co.uk">Ordnance Survey</a> define specific properties to describe the relationships between the administrative units used within the UK: <a href="http://data.ordnancesurvey.co.uk/ontology/admingeo/county"><code>county</code></a>, <a href="http://data.ordnancesurvey.co.uk/ontology/admingeo/district"><code>district</code></a>, <a href="http://data.ordnancesurvey.co.uk/ontology/admingeo/ward"><code>ward</code></a>, etc.</p>
+
+                <pre class="example" id="ex-linking-gazetteer-edinburgh" title="Asserting gazetteer relationships for the City of Edinburgh Council Area (TTL format)">
+@prefix rdfs:      &lt;http://www.w3.org/2000/01/rdf-schema#&gt; .
+@prefix geosparql: &lt;http://www.opengis.net/ont/geosparql#&gt; .
+@prefix admingeo:  &lt;http://data.ordnancesurvey.co.uk/ontology/admingeo/&gt; .
+
+&lt;http://data.ordnancesurvey.co.uk/id/7000000000030505&gt;
+  a admingeo:District ;
+  rdfs:label "City of Edinburgh" ;
+  admingeo:gssCode "S12000036" ;
+  admingeo:ward
+    &lt;http://data.ordnancesurvey.co.uk/id/7000000000043412&gt; , 
+    &lt;http://data.ordnancesurvey.co.uk/id/7000000000043415&gt; , 
+    &lt;http://data.ordnancesurvey.co.uk/id/7000000000043411&gt; ,
+    ... ;
+  geosparql:sfTouches
+    &lt;http://data.ordnancesurvey.co.uk/id/7000000000036552&gt; , 
+    &lt;http://data.ordnancesurvey.co.uk/id/7000000000030509&gt; , 
+    &lt;http://data.ordnancesurvey.co.uk/id/7000000000030634&gt; , 
+    &lt;http://data.ordnancesurvey.co.uk/id/7000000000030632&gt; ;
+  ...
+  .
+                </pre>
+
+                <p>The example snippet above, provided in [[TURTLE]] format, shows the relationships between the <a href="http://data.ordnancesurvey.co.uk/id/7000000000030505">City of Edinburgh</a> <a href="http://data.ordnancesurvey.co.uk/ontology/admingeo/District">district</a> and the <a href="http://data.ordnancesurvey.co.uk/ontology/admingeo/Ward">electoral wards</a> it contains. Also note that complementary use of <a href="http://www.opengis.net/ont/geosparql#sfTouches"><code>geosparql:sfTouches</code></a> to relate the <a href="http://data.ordnancesurvey.co.uk/id/7000000000030505">City of Edinburgh</a> to its adjacent districts; Midlothian, West Lothian etc.</p>
+
+                <p>A second domain where relationships between <a>spatial things</a> and non-spatial resources occur is earth observing. The example below, provided in [[GML]], relates a monitoring point at Deddington on the Nile River, Tasmania, to the sensor that is deployed there (using the <code>sams:hostedProcedure</code> property) and relates that monitoring point to the waterbody whose properties are being measured (using the <code>sam:sampledFeature</code> property). Here, the links are defined using [[XLINK11]].</p>
+
+                <pre class="example" id="ex-linking-gml-monitoring-point" title="Asserting spatial relationship for sensing/earth observation using [XLINK11] and [GML]">
+&lt;wml2:MonitoringPoint gml:id="xsd-monitoring-point.example"
+  xmlns:wml2="http://www.opengis.net/waterml/2.0"
+  xmlns:gml="http://www.opengis.net/gml/3.2" 
+  xmlns:sam="http://www.opengis.net/sampling/2.0"
+  xmlns:sams="http://www.opengis.net/samplingSpatial/2.0"
+  xmlns:xlink="http://www.w3.org/1999/xlink"&gt;
+  &lt;gml:description&gt;Hydrological monitoring point for Nile river at 
+    Deddington, South Esk catchment, Tasmania&lt;/gml:description&gt;
+  &lt;gml:identifier codeSpace="http://www.example.com/"&gt;
+    http://www.example.com/catchment/south-esk/mpoint/deddington
+  &lt;/gml:identifier&gt;
+  &lt;sam:sampledFeature xlink:href="http://sws.geonames.org/2155327/" 
+    xlink:title="Nile river"/&gt; 
+  &lt;sams:shape&gt;
+    &lt;gml:Point gml:id="location_deddington"&gt;
+      &lt;gml:pos srsName="urn:ogc:def:crs:EPSG::4326"&gt;
+        -41.814935 147.568517
+      &lt;/gml:pos&gt; 
+    &lt;/gml:Point&gt;
+  &lt;/sams:shape&gt;
+  &lt;sams:hostedProcedure&gt;
+    &lt;wml2:ObservationProcess gml:id="sensor:4c40fd3acdbf"&gt;
+      &lt;wml2:processType xlink:href="http://www.opengis.net/def/waterml/2.0/processType/Sensor" 
+        xlink:title="Sensor"/&gt;
+      &lt;wml2:processReference xlink:href="http://www.example.com/sensor/00d97bbc-77ca-4b3d-91ca-4c40fd3acdbf/conf/1489405706" 
+        xlink:title="Sensor configuration (updated:2017-03-13)"/&gt;
+    &lt;/wml2:ObservationProcess&gt;
+  &lt;/sams:hostedProcedure&gt;
+  ...
+&lt;/wml2:MonitoringPoint&gt;
+                </pre>
+
+                <p>For further information about sensors, sampling, observations and measurements, please refer to [[OandM]] and [[VOCAB-SSN]].</p>
+
+                <div class="note">
+                  <p>[[GML]] adopted the [[XLINK11]] standard to represent links between resources. At the time of adoption, XLink was the only W3C-endorsed standard mechanism for describing links between resources within XML documents. The <a href="http://www.opengeospatial.org/">Open Geospatial Consortium</a> anticipated broad adoption of XLink over time - and, with that adoption, provision of support within software tooling. While XML Schema, XPath, XSLT and XQuery etc. have seen good software support over the years, this never happened with XLink. The authors of [[GML]] note that given the lack of widespread support, use of Xlink within [[GML]] provided no significant advantage over and above use a bespoke mechanism tailored to the needs of [[GML]].</p>
+                </div>
+
+                <p>Our final example of a domain-specific relationship concerns creative works. For example, one may want to indicate the location a social media message was sent from. In the example below, we assume that Maurits, a tourist in Amsterdam, wants to comment on his visit to Anne Frank's House. His social media App uses the [[GEOLOCATION-API]] to determine his location (<code>Lat=52.37590</code> and <code>Long=4.88452</code>) and suggests several places that Maurits might choose from in order to geo-tag his message. Maurits wants people to know roughly where he is, so he chooses "Amsterdam-Centrum" and presses 'send'. The App encodes the message in [[SCHEMA-ORG]] and pushes the message to the server for distribution. The geo-information is provided using the <a href="http://schema.org/locationCreated"><code>schema:locationCreated</code></a> property.</p>
+
+                <pre class="example" id="ex-linking-schema-locationCreated" title="Asserting location that a creative work was created using [SCHEMA-ORG] (JSON-LD format)">
+&lt;script type="application/ld+json"&gt;
+{
+  "@context" : {
+    "@vocab" : "http://schema.org/"
+  },
+  "@id" : "http://app.example.com/message/867a52e3-6687-4471-b1f2-c7561673552e",
+  "@type" : "Message",
+  "sender" : { "@type" : "Person", "name" : "Maurits" },
+  "datePublished" : "2017-03-12", 
+  "locationCreated" : {
+    "@id" : "https://g.co/kg/m/0gh6_3j"
+    "@type" : "Place",
+    "name" : "Amsterdam-Centrum"
+  }
+}
+&lt;/script&gt;
+                </pre>
+
+                <p>If Maurits had wanted to indicate that the subject of the photograph he took moments later was Leliesluis bridge, then the following [[SCHEMA-ORG]] markup and <a href="http://schema.org/mainEntity"><code>schema:mainEntity</code></a> property could be used:</p>
+
+                <pre class="example" id="ex-linking-schema-mainEntity" title="Asserting the subject of a creative work using [SCHEMA-ORG] (JSON-LD format)">
+&lt;script type="application/ld+json"&gt;
+{
+  "@context" : {
+    "@vocab" : "http://schema.org/"
+  },
+  "@id" : "http://app.example.com/user/Maurits/photo/e35f1132-461e-4acb-8a76-a5d622a85958",
+  "@type" : "Photograph",
+  "sender" : { "@type" : "Person", "name" : "Maurits" },
+  "datePublished" : "2017-03-12", 
+  "mainEntity" : {
+    "@id" : "http://data.example.org/topo/ams/brug/Leliesluis"
+    "@type" : "Bridge",
+    "name" : "Leliesluis bridge",
+    "geo" : {
+      "@type" : "GeoCoordinates",
+      "longitude" : "4.88435",
+      "latitude" : "52.37608"
+    }
+  }
+}
+&lt;/script&gt;
+                </pre>
+              </li>
+            </ol>
+
+            <p>Other than the specific guidance above about use of <code>owl:sameAs</code>, <code style="background-color:yellow">schema:samePlaceAs</code> and the [[GeoSPARQL]] simple features relations, we are not recommending specific vocabularies for spatial linking. Instead, we hope to have introduced patterns that show the types of spatial linking that might be used and leave it to spatial data publishers to determine which specific vocabulary best suits their purpose. In this regard, [[DWBP]] <a href="https://www.w3.org/TR/dwbp/#dataVocabularies">section 8.9 Data Vocabularies</a> and, in particular, [[DWBP]] <a href="https://www.w3.org/TR/dwbp/#ReuseVocabularies">Best Practice 15: Reuse vocabularies, preferably standardized ones</a> are highly relevant.</p>
+
+            <p>Now that we know how to link and the relation types that might be used, it's time to consider <em>what</em> we should link to.</p>
+
+            <ol>
+              <li>
+                <p>Describe what you know &mdash; but stop there.</p>
+                <p>Data publishers should assert the relationships that they know about and that they think will be of interest to their user community; through equality statements, spatial relations or domain-specific relations etc.</p>
+                <p>Publishers should try to avoid making assumptions about what the user may or may not know. For example, they may lack the expertise or resources to calculate a topological relationship, or lack the domain knowledge to determine how two spatial things are related, if at all. As the data publisher, you are likely to be in a better position to make these judgements than the user &mdash; so help them out by making these relationships clear.</p>
+              </li>
+              <li>
+                <p>Link to the <a>spatial thing</a>.</p>
+                <p>The geometry description or extent of a <a>spatial thing</a> may be expressed using an object with its own URI. For example:</p>
+                <pre class="example" id="ex-linking-geometry-edinburgh" title="Independently identified geometry extent for the City of Edinburgh Council Area (TTL format)">
+@prefix rdfs:      &lt;http://www.w3.org/2000/01/rdf-schema#&gt; .
+@prefix admingeo:  &lt;http://data.ordnancesurvey.co.uk/ontology/admingeo/&gt; .
+@prefix geom:      &lt;http://data.ordnancesurvey.co.uk/ontology/geometry/&gt;
+
+&lt;http://data.ordnancesurvey.co.uk/id/7000000000030505&gt;
+  a admingeo:District ;
+  rdfs:label "City of Edinburgh" ;
+  geom:extent &lt;http://data.ordnancesurvey.co.uk/id/geometry/30505-11&gt; .
+
+&lt;http://data.ordnancesurvey.co.uk/id/geometry/30505-11&gt;
+  a geom:AbstractGeometry ;
+  geom:asGML "&lt;gml:MultiPolygon&gt;...&lt;/gml:MultiPolygon&gt;"^^rdf:XMLLiteral ;
+  geom:hectares 27300.411 .
+                </pre>
+
+                <p>As can be seen in the example above, the geometry <a href="http://data.ordnancesurvey.co.uk/id/geometry/30505-11"><code>30505-11</code></a> is an <em>attribute</em> of the <a href="http://data.ordnancesurvey.co.uk/id/7000000000030505">City of Edinburgh</a>. If your intent is to make a statement about, or refer to, the real-world entity then make sure you link to the spatial thing rather than the geometry. Furthermore, note that the geometry record may be updated and re-published with a new identifier, for example, if the city boundary was resurveyed and would then result in a broken link.</p>
+                <p>Data publishers should also be aware of a common pattern used in the publication of Linked Data, where the <a>spatial thing</a> and the information resource that describes it are identified separately &mdash; often, but not always, using <code>/id</code> as part of the URI for spatial thing, and <code>/doc</code> for the corresponding page/document/record. When the URI for the spatial thing is resolved, a <code>HTTP 303 (see other)</code> response is used to redirect the browser to the page/document/record URL. For example:</p>
+                <ul>
+                  <li><a href="http://statistics.gov.scot/id/statistical-geography/S12000036"><code>http://statistics.gov.scot<span style="text-decoration: underline;">/id</span>/statistical-geography/S12000036</code></a> redirects to <a href="http://statistics.gov.scot/doc/statistical-geography/S12000036"><code>http://statistics.gov.scot<span style="text-decoration: underline;">/doc</span>/statistical-geography/S12000036</code></a></li>
+                  <li><a href="http://dbpedia.org/resource/Anne_Frank_House"><code>http://dbpedia.org<span style="text-decoration: underline;">/resource</span>/Anne_Frank_House</code></a> redirects to <a href="http://dbpedia.org/page/Anne_Frank_House"><code>http://dbpedia.org<span style="text-decoration: underline;">/page</span>/Anne_Frank_House</code></a></li>
+                </ul>
+                <p>While this disambiguation has its advantages, it often seems to confuse users (and even some experts). Be aware of this <em>redirect</em> pattern, and make sure you use the correct URI i.e. the identifying one &mdash; especially if you're copying the URI from a browser's address bar which usually ends up showing the page/document/record URL.</p>
+              </li>
+              <li>
+                <p>Link to <a>spatial things</a> from popular repositories.</p>
+                <p>Linking with URIs from popular repositories may improve discoverability of your data. Not only does this provide users with better context by enabling them to browse the information published by the popular repository, it also helps relate your data with datasets from other parties who have also used those URIs as points of reference.</p>
+                <p>There are many popular repositories containing sets of identifiers for spatial things; the following list suggests the primary sources worth checking:</p>
+                <ul>
+                  <li><a href="http://www.geonames.org">GeoNames</a></li>
+                  <li><a href="https://www.wikidata.org/">Wikidata</a></li>
+                  <li><a href="http://dbpedia.org">DBpedia</a></li>
+                  <li>
+                    <p>National open spatial datasets such as are made available by for example the UK and Dutch governments.</p>
+                    <p>Finding out which national open spatial datasets are available, and how they can be accessed, currently requires some insider knowledge &mdash; in most cases because these datasets are often not easily discoverable. Look for national data portals / geoportals such as <a href="http://nationaalgeoregister.nl/geonetwork/srv/dut/catalog.search">Nationaal Georegister</a> (Dutch national register of spatial datasets) or <a href="https://data.overheid.nl">Dataportaal van de Nederlandse overheid</a> (Dutch national governmental data portal).</p>
+                  </li>
+                </ul>
+                <p>Once you've found well-known URIs for spatial things that you want to link to, proceed to create links using properties such as those described above &mdash; <code>owl:sameAs</code> (if you're careful!) and <a href="http://www.opengis.net/ont/geosparql#sfWithin"><code>geosparql:sfWithin</code></a>, or perhaps qualitative relationships like <a href="http://www.geonames.org/ontology#nearby"><code>geonames:nearby</code></a> or the <em>proposed</em> <code>schema:samePlaceAs</code>.</p>
+                <p>However, don't try to make links to <em>everything</em>. It is not always feasible to link your spatial things to well-known resources. For example, if you were maintaining a registry of cultural heritage in Amsterdam, it would be reasonably simple to look up identifiers for the city's 50 or so museums and map these to your spatial things. But it would be a huge task for, say, a topographic mapping agency to cross-reference their entire catalogue of named places containing tens of thousands of spatial things with third-party resources (although in the spirit of crowd-sourcing, if someone else found those links useful, they may take on the task of relating the spatial things and publishing those relationships to the Web as a complementary resource!). In essence, you should only create the data that you have the resources to maintain.</p>
+              </li>
+            </ol>
+
+            <p>Finally, we need to consider how to bring symmetry to discovery of links. It's easy for a user to discover links when they are embedded in the document or data record they are working with &mdash; whether they are <em>inbound</em> or <em>outbound</em> links, all the information they need to decide whether to traverse them should be available. However, we need to consider the situation where another party publishes a dataset that refers to <em>your</em> <a>spatial things</a>. Or perhaps, a set of relationships between <a>spatial things</a> in two (or more) datasets has been developed by an agent that owns neither of the source datasets. How would a client application know that these links existed? To finish this best practice, we describe several mechanisms that might be used to help a user discover remotely published links.</p>
+
+            <ol>
+              <li>
+                <p>Help search engines find your links.</p>
+                <p>Discovery is the staple of search engines. As with the document Web, links in the Web of data will be used to support and refine search algorithms.</p>
+                <p>If your spatial data is indexable by the search engines, the links defined therein will be visible to them. Please refer to <a href="#indexable-by-search-engines" class="sectionRef">Best Practice 4: Make your spatial data indexable by search engines</a>.</p>
+              </li>
+              <li>
+                <p>Publish your links to a third-party service.</p>
+                <p>Because the links we define use global identifiers for both the source and target resources, they do not need any context to be useful (e.g. one doesn't need any prior knowledge to determine that the URI <a href="http://dbpedia.org/resource/Anne_Frank_House"><code>http://dbpedia.org/resource/Anne_Frank_House</code></a> identifies Anne Frank's House). This means that our links can be published independently from the datasets where they were originally defined.</p>
+                <p>The service <a href="http://sameas.org">&lt;sameAs&gt;</a> provides an example of this in practice &mdash; albeit only for links using the <code>owl:sameAs</code> relation type. The HTTP GET request <a href="http://sameas.org/store/freebase/n3?uri=%3Chttp%3A%2F%2Frdf.freebase.com%2Fns%2Fm.02s5hd%3E"><code>http://sameas.org/store/freebase/n3?uri=&lt;http://rdf.freebase.com/ns/m.02s5hd&gt;</code></a> produces the following result in [[N-TRIPLES]] format:</p>
+                <pre class="example" id="ex-linking-sameas-service" title="Discovering links from the &amp;lt;sameAs> service ([N-TRIPLES] format)">
+HTTP/1.1 200 OK
+Connection:close
+Content-Length:864
+Content-Type:text/n3
+Date:Mon, 13 Mar 2017 16:12:04 GMT
+
+@prefix owl:  &lt;http://www.w3.org/2002/07/owl#&gt; .
+@prefix rdfs: &lt;http://www.w3.org/2000/01/rdf-schema#&gt; .
+@prefix dc:   &lt;http://purl.org/dc/elements/1.1/&gt; .
+@prefix dct:  &lt;http://purl.org/dc/terms/&gt; .
+@prefix foaf: &lt;http://xmlns.com/foaf/0.1/&gt; .
+
+&lt;http://sameas.org/rdf?uri=http%3A%2F%2Frdf.freebase.com%2Fns%2Fm.02s5hd&gt;
+  dc:creator "sameAs.org/store/freebase" ;
+  dc:title "Co-references from sameAs.org/store/freebase for http://rdf.freebase.com/ns/m.02s5hd" ;
+  foaf:primaryTopic "http://rdf.freebase.com/ns/m.02s5hd" ;
+  dct:license &lt;http://creativecommons.org/publicdomain/zero/1.0/&gt; .
+
+&lt;http://rdf.freebase.com/ns/m.02s5hd&gt; owl:sameAs
+    &lt;http://dbpedia.org/resource/Anne_Frank_House&gt; ,
+    &lt;http://rdf.freebase.com/ns/m.02s5hd&gt; ,
+    &lt;http://rdf.freebase.com/ns/en.the_annexe&gt; ,
+    &lt;http://rdf.freebase.com/ns/guid.9202a8c04000641f80000000002c15ec&gt; .
+                </pre>
+                <p>Sets of links can be published in any of the data formats that support Web linking. However, it is worth noting that tabular data, as described in [[TABULAR-DATA-PRIMER]], may provide a reasonably compact form while retaining the semantics associated with each of the link relation types used.</p>
+                <p>While this is an example of a convenient mechanism to discover alternate identifiers for a given resource, it is ad-hoc. A client application would need to be configured to query an arbitrary number of known service end-points to discover links published across all the domains deemed of interest. As such, this kind of approach is only likely to be useful where one can alert the user community which services they should refer to.</p>
+              </li>
+              <li>
+                <p>Publish metadata about collections of links in a standard way.</p>
+                <p>A data publisher may consider publishing summary information about their datasets and the links defined in them using the Vocabulary of Interlinked Datasets [[VoID]].</p>
+                <p>In [[VoID]], <a href="https://www.w3.org/TR/void/#linkset" class="externalDFN">Linksets</a> provide summary description of the relationships between two datasets; identifying the source and target datasets, the link relation type(s) used plus optional metadata such as URI templates for identifying participating resources and the number of links specified for each relation type, and may describe <em>technical features</em> such as APIs through which the participating datasets can be accessed.</p>
+                <p>[[VoID]] dataset and linkset descriptions may be published at <code>/.well-known/void</code> on each domain (using the <code>.well-known</code> pattern defined in [[RFC5758]]) making them easy to find. Applications could be configured to harvest [[VoID]] descriptions from the Internet domains of data publishers in their community, enabling them to build a searchable graph of relationships between datasets &mdash; a <em>Data Network</em>. Because this information is summarized at the set level, the data network graph is convenient to work with, allowing simple discovery of numbers and relation types of both <em>inbound</em> and <em>outbound</em> links within a given dataset. Once the presence of interesting links within a dataset has been identified, the user would then work directly with the dataset in question (or the API through which it is accessed) to acquire the detailed information about specific links defined in that dataset.</p>
+                <p>Interactions such as those described above would be quite intensive for a human using a browser. However, the [[VoID]] descriptions could be used to drive a software agent that hides much of the complexity from the user; for example, automatically harvesting individual links once a set-level relationship is considered interesting, and then allowing the user to traverse those links either forwards or backwards.</p>
+                <aside class="example">
+                  <p><a href="https://www.osi.ie/">Ordnance Survey Ireland</a> (OSi) publish Ireland's authoritative geospatial information as <a>Linked Data</a> from their <a href="http://data.geohive.ie/">data.geohive.ie</a> platform. In addition to offering a human-browsable interface and downloadable data dumps, they use <a href="http://linkeddatafragments.org/">Linked Data Fragments</a>, and specifically a [[TRIPLE-PATTERN-FRAGMENTS]] <a href="http://vma01.adaptcentre.ie/">server</a> which uses [[VoID]] descriptions, to enable users to explore the datasets via a SPARQL endpoint. For example, <a href="http://vma01.adaptcentre.ie/boundaries-links">Boundaries &mdash; links with the LOD cloud</a> provides a starting point to find links between the authoritative spatial things published by OSi and <em>similar</em> spatial things from <a href="http://dbpedia.org">DBpedia</a>; e.g.</p>
+                  <pre id="ex-linking-osi-similarto">
+@prefix ov:       &lt;http://open.vocab.org/terms/&gt; .
+
+&lt;http://data.geohive.ie/resource/county/2AE19629143D13A3E055000000000001&gt;
+      ov:similarTo &lt;http://dbpedia.org/resource/County_Carlow&gt; .
+                  </pre>
+                </aside>
+                <aside class="example">
+                  <p>This was the aim of the <a href="http://portal.sirf.net/about-sirf">Spatial Identifier Reference Framework</a> (SIRF), developed by <a href="http://csiro.au">CSIRO</a>. The project team describe SIRF as "a <em>Linked Data bridge</em> between Spatial Data Infrastructures and the general information Web". In summary, when a spatial dataset was registered with SIRF, URIs would be automatically created for each of the <a>spatial things</a> described in that dataset. Where identifiers in the collection of datasets were deemed to refer to the same <a>spatial thing</a> a <em>crosswalk</em> (such as <code>owl:sameAs</code>) would be created to link those identifiers and bind together different representations of the same <a>spatial thing</a>, and thereby enable users to browse information from multiple sources as a coherent whole. The SIRF application is driven by the [[VoID]] descriptions it creates for each registered dataset.</p>
+                </aside>
+                <div class="issue" data-number="36">
+                  <p>The use of [[VoID]] needs further discussion; is there enough evidence of its adoption in the wild? Also, the Triple Pattern Fragments server needs a bit more investigation to determine exactly how much the [[VoID]] descriptions are used.</p>
+                </div>
+              </li>
+            </ol>
+
+          </section>
+          <section class="test">
+            <h4 class="subhead">How to Test</h4>
+            <p>...</p>
+          </section>
+          <section class="ucr">
+            <h4 class="subhead">Evidence</h4>
+            <p><span>Relevant requirements</span>: 
+              <a href="https://www.w3.org/TR/sdw-ucr/#Linkability">R-Linkability</a>, 
+              <a href="https://www.w3.org/TR/sdw-ucr/#MachineToMachine">R-MachineToMachine</a>, 
+              <a href="https://www.w3.org/TR/sdw-ucr/#SpatialRelationships">R-SpatialRelationships</a>, 
+              <a href="https://www.w3.org/TR/sdw-ucr/#SpatialOperators">R-SpatialOperators</a>, 
+              <a href="https://www.w3.org/TR/sdw-ucr/#Discoverability">R-Discoverability</a>.</p>
+          </section>
+          <section class="benefits">
+            <h4 class="subhead">Benefits</h4>
+            <ul class="benefitsList">
+              <li>...</li>
+            </ul>
+          </section>
+        </div>
+        <div class="practice">
+          <p><span id="find-related-data" class="practicelab">(to be deleted)</span></p>
+          <p class="practicedesc"></p>
+          <section class="axioms">
+            <h4 class="subhead">Why</h4>
+          </section>
+          <section class="outcome">
+            <h4 class="subhead">Intended Outcome</h4>
+          </section>
+          <section class="how">
+            <h4 class="subhead">Possible Approach to Implementation</h4>
+          </section>
+          <section class="test">
+            <h4 class="subhead">How to Test</h4>
+          </section>
+          <section class="ucr">
+            <h4 class="subhead">Evidence</h4>
+          </section>
+          <section class="benefits">
+            <h4 class="subhead">Benefits</h4>
+          </section>
+        </div>
+      </section>
+      <!-- end best practices -->
+    </section>
+    <section id="bp-notaligned">
+      <h2>Other best practices</h2>
+      <p class="note">This section is a placeholder for best practices that were in the FPWD but have not yet
+        been placed in the new doc structure. They may be removed, merged, or moved.</p>
+
+      <section id="bp-minimum">
+        <h3>Minimum content for spatial things</h3>
+        <div class="practice">
+          <p><span id="minimum" class="practicelab">(to be deleted)</span></p>
+          <p class="practicedesc">Removed - merged with <a href="#semantic-thing" class="sectionRef">BP10</a></p>
+          <section class="axioms">
+            <h4 class="subhead">Why</h4>
+          </section>
+          <section class="outcome">
+            <h4 class="subhead">Intended Outcome</h4>
+          </section>
+          <section class="how">
+            <h4 class="subhead">Possible Approach to Implementation</h4>
+          </section>
+          <section class="test">
+            <h4 class="subhead">How to Test</h4>
+          </section>
+          <section class="ucr">
+            <h4 class="subhead">Evidence</h4>
+          </section>
+          <section class="benefits">
+            <h4 class="subhead">Benefits</h4>
+          </section>
+        </div>
+      </section>
+
+      <section id="bp-crs-encoding">
+        <h3>More about coordinate reference systems</h3>
+        <div class="practice">
+          <p><span id="bp-crs" class="practicelab">State how coordinate values are encoded</span></p>
+          <p class="practicedesc">Provide enough information for users to determine how coordinate values are encoded.</p>
+          <section class="axioms">
+            <h4 class="subhead">Why</h4>
+            <p>The geometry of <a>spatial things</a> is described using coordinates; for example, <a>latitude</a> and <a>longitude</a>. Because coordinates describe a position relative to a datum (e.g. zero latitude is the equator and zero longitude is the prime meridian - often the Greenwich Meridian), it is important to understand both the datum and the units that are used for coordinates along with the order which the coordinate axes are defined: the <a>coordinate reference system</a> (CRS). Spatial data is published in a wide variety of CRS. This variety can create confusion and inconsistencies in using and interpreting spatial data. Unless the CRS is known, errors are likely to be introduced when determining the position of a spatial thing on the Earth and makes comparing or combining spatial data from different sources extremely problematic.</p>
+          </section>
+          <section class="outcome">
+            <h4 class="subhead">Intended Outcome</h4>
+            <p>Sufficient information is provided to enable coordinates to be related to the correct position, thereby enabling spatial data to be correctly interpreted by humans and software agents.</p>
+            <p>Spatial data from different sources can be combined without introducing unwarranted positional errors.</p>
+          </section>
+          <section class="how">
+            <h4 class="subhead">Possible Approach to Implementation</h4>
+            <p>A user of spatial data will need to know:</p>
+            <ol>
+              <li>which coordinate value relates to which axis;</li>
+              <li>what units used for each coordinate; and</li>
+              <li>what datum is used</li>
+            </ol>
+
+            <div class="note">
+              <p>There is a predominant view that "I just need to use Lat and Long - and I'm done".</p>
+              <p>Although the clear majority of spatial data published on the Web uses WGS 84 Long/Lat (as used by GPS), we <em>strongly</em> recommend that spatial data is published with all the necessary information to interpret coordinate values. Even where it the use of latitude and longitude angular measurements is obvious; the choice of datum and units of measurement have an impact. In particular, angular measurements appearing as floating point numbers are mostly likely to be provided in decimal degrees, may be radians or gons (also known as grads).</p>
+              <p>The problem that the assumption of a "predominant view" leads to ambiguity. For example, many spatial data users work entirely with information provided in their national coordinate reference system (such as the <em>Dutch Amersfoort / RD</em> <a href="http://epsg.io/28992">EPSG:28992</a> or <em>British National Grid</em> <a href="http://epsg.io/27700">EPSG:27700</a>) which make all coordinates in WGS 84 Long/Lat (especially the negative numbers) utterly perplexing.</p>
+              <p>In practice, a publisher not documenting their CRS and presuming that latitude and longitude can be treated as cartesian is often bailed out by fuzzy use cases and software that takes care of projections. However, CRS and coordinate axis order ambiguity leads sooner or later to serious and avoidable errors, while ignorance of datums and map projections leads to broken applications. Furthermore, these practices will also become less and less tenable as new applications such as Augmented Reality require higher data precision and accuracy.</p>
+            </div>
+
+            <p>There are four common ways that this information can be provided:</p>
+            <ol>
+              <li>
+                <p>Provide each coordinate value with explicit labels and provide metadata to indicate what each label means.</p>
+                <pre class="example" id="ex-crs-sepatate-axes-lables-w3c-basic-geo" title="Coordinate position provided using [W3C-BASIC-GEO]">
+@prefix w3cgeo: &lt;http://www.w3.org/2003/01/geo/wgs84_pos#&gt; .
+@prefix dcterms: &lt;http://purl.org/dc/terms/&gt; .
+
+:myPointOfInterest a w3cgeo:SpatialThing ;
+    dcterms:description "Anne Frank's House, Amsterdam."
+    w3cgeo:lat "52.37514"^^xsd:float ;
+    w3cgeo:long "4.88412"^^xsd:float ;
+    .
+                </pre>
+                <p>The labels (or terms) <code>w3cgeo:lat</code> and <code>w3cgeo:long</code> are provided by the [[W3C-BASIC-GEO]] vocabulary which states that it is:</p>
+                <p style="margin-left: 40px"><em>A vocabulary for representing latitude, longitude and altitude information in the WGS84 geodetic reference datum.</em></p>
+                <p>The terms themselves (plus <code>w3cgeo:alt</code>) are defined with all the necessary information as follows:</p>
+                <ul>
+                  <li><em><strong>lat:</strong> The WGS84 latitude of a Spatial Thing (decimal degrees).</em></li>
+                  <li><em><strong>long:</strong> The WGS84 longitude of a Spatial Thing (decimal degrees).</em></li>
+                  <li><em><strong>alt:</strong> The WGS84 altitude of a Spatial Thing (decimal meters above the local reference ellipsoid).</em></li>
+                </ul>
+
+                <pre class="example" id="ex-crs-sepatate-axes-lables-schema-geocoordinate" title="Coordinate position provided using JSON-LD and [SCHEMA-ORG]">
+&lt;script type="application/ld+json"&gt;
+{
+  "@context" : {
+    "@vocab" : "http://schema.org/"
+  },
+  "myPointOfInterest" : {
+    "@type" : "Place",
+    "geo" : {
+      "@type": "GeoCoordinates",
+      "latitude": "52.37514",
+      "longitude": "4.88412"
+    }
+  }
+}
+&lt;/script&gt;
+                </pre>
+                <p>In the example above, the labels <code>latitude</code> and <code>longitude</code> are defined in [[SCHEMA-ORG]], as indicated by the JSON-LD key <code>@vocab</code>. The associated definitions in [[SCHEMA-ORG]] are:</p>
+                <ul>
+                  <li><em><strong>latitude:</strong> The latitude of a location. For example 37.42242 (WGS 84).</em></li>
+                  <li><em><strong>longitude:</strong> The longitude of a location. For example -122.08585 (WGS 84).</em></li>
+                </ul>
+
+                <div class="note">
+                  <p>The definitions provided in [[SCHEMA-ORG]] do not indicate the unit of measure. However, we have included this example as [[SCHEMA-ORG]] is very commonly used. The unit of measure used for <code>latitude</code> and <code>longitude</code> are decimal degrees, and decimal meters is used for the remaining coordinate position property <code>elevation</code>.</p>
+                </div>
+
+                <p>The metadata for axis labels may also be provided in the documentation for an API from which the spatial data is accessed. For more information on documenting APIs, please refer to [[DWBP]] <a href="https://www.w3.org/TR/dwbp/#documentYourAPI">Best Practice 25: Provide complete documentation for your API</a>.</p>
+              </li>
+              <li>
+                <p>Use a data format that specifies axes, their order, datum and unit of measurement for coordinates.</p>
+                <pre class="example" id="ex-crs-geojson" title="Coordinates encoded using GeoJSON [RFC7946] in HTTP response">
+HTTP/1.1 200 OK
+Date: Sun, 05 Mar 2017 17:12:35 GMT
+Content-length: 543
+Connection: close
+Content-type: application/geo+json
+
+{
+  "type": "Feature",
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [ [4.884235, 52.375108], [4.884276, 52.375153], 
+        [4.884257, 52.375159], [4.883981, 52.375254], 
+        [4.883850, 52.375109], [4.883819, 52.375075], 
+        [4.884104, 52.374979], [4.884143, 52.374965], 
+        [4.884207, 52.375035], [4.884263, 52.375016], 
+        [4.884320, 52.374996], [4.884255, 52.374926], 
+        [4.884329, 52.374901], [4.884451, 52.375034], 
+        [4.884235, 52.375108] ]
+      ]
+  },
+  "properties": {
+    "name": "Anne Frank's House"
+  }
+}
+                </pre>
+                <p>The media type <code>application/geo+json</code> is used to designate that content is provided in GeoJSON format, as specified in [[RFC7946]].</p>
+                <p>[[RFC7946]] <a href="https://tools.ietf.org/html/rfc7946#section-4">Section 4. Coordinate Reference System</a> provides all the necessary information to interpret the coordindates, stating that:</p>
+                <p style="margin-left: 40px"><em>The coordinate reference system for all GeoJSON coordinates is a geographic coordinate reference system, using the World Geodetic System 1984 (WGS 84) [WGS84] datum, with longitude and latitude units of decimal degrees.  This is equivalent to the coordinate reference system identified by the Open Geospatial Consortium (OGC) URN urn:ogc:def:crs:OGC::CRS84.  An OPTIONAL third-position element SHALL be the height in meters above or below the WGS 84 reference ellipsoid.  In the absence of elevation values, applications sensitive to height or depth SHOULD interpret positions as being at local ground or sea level.</em></p>
+
+                <pre class="example" id="ex-crs-schema-geoshape" title="Coordinate position provided using JSON-LD and [SCHEMA-ORG]">
+&lt;script type="application/ld+json"&gt;
+{
+  "@context" : {
+    "@vocab" : "http://schema.org/"
+  },
+  "myPlaceOfInterest" : {
+    "@type" : "Place",
+    "name" : "Anne Frank's House",
+    "geo" : {
+      "@type": "GeoShape",
+      "polygon": "52.375108,4.884235 52.375153,4.884276 
+                  52.375159,4.884257 52.375254,4.883981 
+                  52.375109,4.883850 52.375075,4.883819 
+                  52.374979,4.884104 52.374965,4.884143 
+                  52.375035,4.884207 52.375016,4.884263 
+                  52.374996,4.884320 52.374926,4.884255 
+                  52.374901,4.884329 52.375034,4.884451 
+                  52.375108,4.884235"
+    }
+  }
+}
+&lt;/script&gt;
+
+
+
+                </pre>
+                <p>The [[SCHEMA-ORG]] definition of <code>GeoShape</code> states:</p>
+                <p style="margin-left: 40px"><em>The geographic shape of a place. A GeoShape can be described using several properties whose values are based on latitude/longitude pairs. Either whitespace or commas can be used to separate latitude and longitude; whitespace should be used when writing a list of several such points.</em></p>
+
+                <div class="note">
+                  <p>In these two previous examples, we see a prime example of why coordinate axis-order is important: GeoJSON [[RFC7946]] uses Long/Lat while [[SCHEMA-ORG]] uses Lat/Long. Getting the axis order in the wrong order puts Anne Frank's House somewhere off the coast of Somalia rather than the Netherlands!</p>
+                </div>
+              </li>
+              <li>
+                <p>State within the data itself which <a>coordinate reference system</a> is used.</p>
+                <pre class="example" id="ex-crs-gml" title="Coordinate reference system stated in [GML]">
+&lt;gml:Polygon srsDimension="2" axisLabels="east north" 
+             srsName="http://www.opengis.net/def/crs/EPSG/0/28992"&gt;
+  &lt;gml:exterior&gt;
+    &lt;gml:LinearRing&gt;
+      &lt;gml:posList&gt;
+        120749.725 487589.422  120752.55  487594.375  120751.227 487595.129
+        120732.539 487605.788  120723.505 487589.745  120721.387 487585.939
+        120740.668 487575.07   120743.316 487573.589  120747.735 487581.337
+        120751.564 487579.154  120755.411 487576.96   120750.935 487569.172
+        120755.941 487566.288  120764.369 487581.066  120749.725 487589.422
+      &lt;/gml:posList&gt;
+    &lt;/gml:LinearRing&gt;
+  &lt;/gml:exterior&gt;
+&lt;/gml:Polygon&gt;
+                </pre>
+                <p>The example above encodes the polygon for Anne Frank's House in [[GML]]. The XML attribute <code>srsName</code> (<em>srs</em> meaning "spatial reference system") refers to the <em>Amersfoort / RD</em> CRS (<a href="http://epsg.io/28992">EPSG:28992</a>) used in the Netherlands. Also note that additional useful information (<code>srsDimension</code> and <code>axisLabels</code>) is provided within the document for easy reference.</p>
+
+                <pre class="example" id="ex-crs-wktLiteral-BAG" title="Coordinate reference system stated in [GeoSPARQL] WKT (JSON-LD encoding)">
+{
+  "@context": {
+    "geosparql" : "http://www.opengis.net/ont/geosparql#" ,
+    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#" ,
+    "asWKT" : {
+      "@id" : "http://www.opengis.net/ont/geosparql#asWKT" ,
+      "@type" : "geosparql:wktLiteral"
+    }
+  } ,
+  "@id" : "http://example.org/register/id/building/0363100012169587" ,
+  "@type" : "http://www.opengis.net/ont/geosparql#Feature" ,
+  "rdfs:label" : "Building 0363100012169587" ,
+  "geosparql:hasGeometry": {
+    "geosparql:asWKT" : "&lt;http://www.opengis.net/def/crs/EPSG/0/4326&gt; 
+                        POLYGON ((52.375108 4.884235, 52.375153 4.884276, 
+                                  52.375159 4.884257, 52.375254 4.883981, 
+                                  52.375109 4.883850, 52.375075 4.883819, 
+                                  52.374979 4.884104, 52.374965 4.884143, 
+                                  52.375035 4.884207, 52.375016 4.884263, 
+                                  52.374996 4.884320, 52.374926 4.884255, 
+                                  52.374901 4.884329, 52.375034 4.884451, 
+                                  52.375108 4.884235))"
+  }
+}
+                </pre>
+                <p>The "Well Known Text" (<a>WKT</a>) encoding, itself defined in [[SIMPLE-FEATURES]], is extended by [[GeoSPARQL]] to include designation of the coordinate reference system used. The example above encodes the polygon as a [[GeoSPARQL]] <code>wktLiteral</code> data type, designating the coordinate reference system as <code>&lt;http://www.opengis.net/def/crs/EPSG/0/4326&gt;</code> (<a href="http://epsg.io/4326">EPSG:4326</a>) - WGS 84 Lat/Long.</p>
+
+                <div class="note">
+                  <p>When using the <code>wktLiteral</code> datatype specified in [[GeoSPARQL]], the <a>coordinate reference system</a> URI may be omitted. In such a case, WGS 84 Long/Lat (<code>urn:ogc:def:crs:OGC::CRS84</code>) is used. Please refer to [[GeoSPARQL]] <strong>Requirement 11</strong> for more details.</p>
+                  <p>The Basisregistraties Adressen en Gebouwen (BAG - the Dutch "Basic Registers for Addresses and Buildings"), provided by <a href="https://www.kadaster.nl/">Kadaster</a>, uses this default behavior. Anne Frank's House, is identified using the URI <a href="http://bag.basisregistraties.overheid.nl/bag/id/pand/0363100012169587"><code>http://bag.basisregistraties.overheid.nl/bag/id/pand/0363100012169587</code></a>. <a href="https://bag.basisregistraties.overheid.nl/resource?subject=http%3A%2F%2Fbag.basisregistraties.overheid.nl%2Fbag%2Fdoc%2F2013090600000000%2Fpand%2F0363100012169587">HTML</a>, <a href="https://bag.basisregistraties.overheid.nl/resource?subject=http%3A%2F%2Fbag.basisregistraties.overheid.nl%2Fbag%2Fdoc%2F2013090600000000%2Fpand%2F0363100012169587&amp;format=json">JSON</a>, <a href="https://bag.basisregistraties.overheid.nl/resource?subject=http%3A%2F%2Fbag.basisregistraties.overheid.nl%2Fbag%2Fdoc%2F2013090600000000%2Fpand%2F0363100012169587&amp;format=ttl">TTL</a> and <a href="http://bag.basisregistraties.overheid.nl/resource?subject=http%3A%2F%2Fbag.basisregistraties.overheid.nl%2Fbag%2Fdoc%2F2013090600000000%2Fpand%2F0363100012169587&amp;format=xml">XML</a> representations are available.</p>
+                </div>
+              </li>
+              <li>
+                <p>Describe the coordinate reference system in the dataset metadata.</p>
+                <pre class="example" id="ex-crs-dataset-metadata" title="Coordinate reference system stated in [GeoDCAT-AP] (TTL encoding)">
+@prefix ex:      &lt;http://data.example.org/datasets/&gt; .
+@prefix dcat:    &lt;http://www.w3.org/ns/dcat#&gt; .
+@prefix dcterms: &lt;http://purl.org/dc/terms/&gt; .
+@prefix skos:    &lt;http://www.w3.org/2004/02/skos/core#&gt; .
+
+ex:ExampleDataset 
+  a dcat:Dataset ;
+  dcterms:conformsTo &lt;http://www.opengis.net/def/crs/EPSG/0/32630&gt; .
+
+&lt;http://www.opengis.net/def/crs/EPSG/0/32630&gt; 
+  a dcterms:Standard, skos:Concept ;
+  dcterms:type &lt;http://inspire.ec.europa.eu/glossary/SpatialReferenceSystem&gt; ;
+  dcterms:identifier "http://www.opengis.net/def/crs/EPSG/0/32630"^^xsd:anyURI ;
+  skos:prefLabel "WGS 84 / UTM zone 30N"@en ;
+  skos:inScheme &lt;http://www.opengis.net/def/crs/EPSG/0/&gt; .
+                </pre>
+                <p>The example above illustrates how to describe the coordinate reference system used for a dataset within [[GeoDCAT-AP]] metadata. The <code>conformsTo</code> property from [[DCTERMS]] is used to assert the relationship between dataset and CRS in the same way that conformance with a <em>standard</em> is expressed in [[VOCAB-DQV]].</p>
+                <p>For more information about dataset metadata, please refer to <a href="#spatial-info-dataset-metadata" class="sectionRef">Best Practice 1: Include spatial metadata in dataset metadata</a>.</p>
+
+                <pre class="example" id="ex-crs-sepatate-axes-lables-tabular-data" title="Coordinate position provided using column in tabular data">
+GID,On Street,Long,Lat,Species,Trim Cycle,Diameter at Breast Ht,Inventory Date,Comments,Protected
+1,ADDISON AV,-122.156485,37.440963,Celtis australis,Large Tree Routine Prune,11,10/18/2010,,
+2,EMERSON ST,-122.156749,37.440958,Liquidambar styraciflua,Large Tree Routine Prune,11,6/2/2010,,
+6,ADDISON AV,-122.156299,37.441151,Robinia pseudoacacia,Large Tree Routine Prune,29,6/1/2010,cavity or decay; trunk decay; codominant leaders; included bark; large leader or limb decay; previous failure root damage; root decay;  beware of BEES,YES
+                </pre>
+                <p>In this example (adapted from the City of Palo Alto tree operations database and published as <a href="https://fusiontables.google.com/DataSource?docid=1XKUADil8qq1PT6xkJV3FF9bqLAZj2tBXwTTI_rc#rows:id=1">tabular data</a> and as an <a href="https://fusiontables.google.com/DataSource?docid=1XKUADil8qq1PT6xkJV3FF9bqLAZj2tBXwTTI_rc#map:id=3">interactive map</a>) the coordinate position of each tree is specified using separate columns (<code>Long</code> and <code>Lat</code>) as recommended in approach (1) above.</p>
+
+                <p>As shown in the abridged tabular metadata document, the columns <code>Long</code> and <code>Lat</code> are mapped onto the definitions provided by [[W3C-BASIC-GEO]] to ensure that the meaning of the data values in those columns is clear:</p> 
+
+                <pre class="example" id="ex-crs-sepatate-axes-lables-tabular-metadata" title="Abridged tabular metadata providing column meanings">
+{
+  "@context": ["http://www.w3.org/ns/csvw", {"@language": "en"}],
+  "@id": "http://example.org/tree-ops-db",
+  "url": "tree-ops-db.csv",
+  "dc:title": "Tree Operations",
+  ...
+  "tableSchema": {
+    "columns": [{
+      "name": "GID",
+      "titles": [
+        "GID",
+        "Generic Identifier"
+      ],
+      "dc:description": "An identifier for the operation on a tree.",
+      "datatype": "string",
+      "required": true, 
+      "suppressOutput": true
+    }, {
+      "name": "on_street",
+      "titles": "On Street",
+      "dc:description": "The street that the tree is on.",
+      "datatype": "string"
+    }, {
+      "name": "Long",
+      "titles": "Longitude",
+      "dc:description": "The WGS84 longitude of the tree (decimal degrees).",
+      "propertyUrl": "http://www.w3.org/2003/01/geo/wgs84_pos#long"
+      "datatype": {
+        "base": "number",
+        "minimum": "-180",
+        "maximum": "180"
+      }
+    }, {
+      "name": "Lat",
+      "titles": "Latitude",
+      "propertyUrl": "http://www.w3.org/2003/01/geo/wgs84_pos#lat"
+      "dc:description": "The WGS84 latitude of the tree (decimal degrees).",
+      "datatype": {
+        "base": "number",
+        "minimum": "-90",
+        "maximum": "90"
+      }
+    },
+    ...
+    "primaryKey": "GID",
+    "aboutUrl": "http://example.org/tree-ops-ext#gid-{GID}"
+  }
+}
+                </pre>
+
+                <div class="note">
+                  <p>Please refer to [[TABULAR-DATA-PRIMER]] <a href="https://www.w3.org/TR/tabular-data-primer/#geospatial">section 6.2 How do you support geospatial data?</a> for more details on working with geospatial content in tabular data.</p>
+                </div>
+
+              </li>
+            </ol>
+          </section>
+          <section class="test">
+            <h4 class="subhead">How to Test</h4>
+            <p>For a given spatial data publication, users can find information about the coordinate axes, their order and unit of measurement, plus the datum used.</p>
+          </section>
+          <section class="ucr">
+            <h4 class="subhead">Evidence</h4>
+            <p><span>Relevant requirements</span>: 
+              <a href="https://www.w3.org/TR/sdw-ucr/#DeterminableCRS">R-DeterminableCRS</a>, 
+              <a href="https://www.w3.org/TR/sdw-ucr/#CRSDefinition">R-CRSDefinition</a>, 
+              <a href="https://www.w3.org/TR/sdw-ucr/#GeoreferencedData">R-GeoreferencedData</a>, 
+              <a href="https://www.w3.org/TR/sdw-ucr/#LinkingCRS">R-LinkingCRS</a>.
+            </p>
+          </section>
+        </div>
+      </section>
+    </section>
+   
+    <section id="conclusions">
+      <h2>Conclusions</h2>
+    </section>
+    <section class="appendix" id="applicability-formatVbp">
+      <h2>Applicability of common formats to implementation of best practices</h2>
+      <p>The Spatial Data on the Web working group is working on recommendations about the use of
+        formats for publishing spatial data on the web, specifically about selecting the most
+        appropriate format. There may not be one most appropriate format: which format is best may
+        depend on many things. This section gives two tables that both aim to be helpful in
+        selecting the right format in a given situation. These tables may in future be merged or
+        reworked in other ways. </p>
+      <p>The first table is a matrix of the common formats, showing in general terms how well these
+        formats help achieve goals such as discoverability, granularity etc. </p>
+      <table id="x-ref_formatVbp">
+        <caption>An attempt at matrix of the common formats (GeoJSON, [[GML]], RDF, JSON-LD) and what
+          you can or can't achieve with it. (<span style="background-color:yellow">source:
+            @eparsons</span>)</caption>
+        <tr>
+          <th>Format</th>
+          <th>Openness</th>
+          <th>Binary/text</th>
+          <th>Usage</th>
+          <th>Discoverability</th>
+          <th>Granular links</th>
+          <th>CRS Support</th>
+          <th>Verbosity</th>
+          <th>Semantics vocab?</th>
+          <th>Streamable</th>
+          <th>3D Support</th>
+        </tr>
+        <tr>
+          <td><a href="https://www.esri.com/library/whitepapers/pdfs/shapefile.pdf">ESRI
+            Shape</a></td>
+          <td>Open'ish</td>
+          <td>Binary</td>
+          <td>Geometry only attributes and metadata in linked DB files</td>
+          <td>Poor</td>
+          <td>In Theory?</td>
+          <td>Yes</td>
+          <td>Lightweight</td>
+          <td>No</td>
+          <td>No</td>
+          <td>Yes</td>
+        </tr>
+        <tr>
+          <td>GeoJSON [[RFC7946]]</td>
+          <td>Open</td>
+          <td>Text</td>
+          <td>Geometry and attributes inline array</td>
+          <td>Good ?</td>
+          <td>In Theory?</td>
+          <td>No</td>
+          <td>Lightweight</td>
+          <td>No</td>
+          <td>No</td>
+          <td>No</td>
+        </tr>
+        <tr>
+          <td><a
+              href="http://www.autodesk.com/techpubs/autocad/acadr14/dxf/ascii_dxf_file_format_al_u05_b.htm"
+              >DXF</a></td>
+          <td>Proprietary</td>
+          <td>Binary</td>
+          <td>Geometry only attributes and metadata in linked DB files</td>
+          <td>Poor</td>
+          <td>Poor</td>
+          <td>No</td>
+          <td>Lightweight</td>
+          <td>No</td>
+          <td>No</td>
+          <td>Yes</td>
+        </tr>
+        <tr>
+          <td>[[GML]]</td>
+          <td>Open</td>
+          <td>Text</td>
+          <td>Geometry and attributes inline or xlinked</td>
+          <td>Good ?</td>
+          <td>In Theory ?</td>
+          <td>Yes</td>
+          <td>Verbose</td>
+          <td>No</td>
+          <td>No</td>
+          <td>Yes</td>
+        </tr>
+        <tr>
+          <td><a href="http://www.opengeospatial.org/standards/kml">KML</a></td>
+          <td>Open</td>
+          <td>Text</td>
+          <td>Geometry and attributes inline or xlinked</td>
+          <td>Good ?</td>
+          <td>In Theory ?</td>
+          <td>No</td>
+          <td>Lightweight</td>
+          <td>No</td>
+          <td>Yes?</td>
+          <td>Yes</td>
+        </tr>
+      </table>
+      <p>The second table is much more detailed, listing the currently much-used formats for spatial
+        data, and scoring each format on a lot of detailed aspects.</p>
+      <table id="detailed-format-matrix">
+        <caption>An attempt at a matrix of the formats for spatial data in current use and detailed
+          aspects. (<span style="background-color:yellow">source: @portele</span>)</caption>
+        <tr>
+          <th> </th>
+          <th> GML </th>
+          <th> GML-SF0 </th>
+          <th> JSON-LD </th>
+          <th> GeoSPARQL (vocabulary) </th>
+          <th> schema.org </th>
+          <th> GeoJSON </th>
+          <th> KML </th>
+          <th> GeoPackage </th>
+          <th> Shapefile </th>
+          <th> GeoServices / Esri JSON </th>
+          <th> Mapbox Vector Tiles </th>
+        </tr>
+        <tr>
+          <td> Governing Body </td>
+          <td> OGC, ISO </td>
+          <td> OGC </td>
+          <td> W3C </td>
+          <td> OGC </td>
+          <td> Google, Microsoft, Yahoo, Yandex </td>
+          <td> Authors (now in IETF process) </td>
+          <td> OGC </td>
+          <td> OGC </td>
+          <td> Esri </td>
+          <td> Esri </td>
+          <td> Mapbox </td>
+        </tr>
+        <tr>
+          <td> Based on </td>
+          <td> XML </td>
+          <td> GML </td>
+          <td> JSON </td>
+          <td> RDF </td>
+          <td> HTML with RDFa, Microdata, JSON-LD </td>
+          <td> JSON </td>
+          <td> XML </td>
+          <td> SQLite, SF SQL </td>
+          <td> dBASE </td>
+          <td> JSON </td>
+          <td> Google protocol buffers </td>
+        </tr>
+        <tr>
+          <td> Requires authoring of a vocabulary/schema for my data (or use of existing ones) </td>
+          <td> Yes (using XML Schema) </td>
+          <td> Yes (using XML Schema) </td>
+          <td> Yes (using @context) </td>
+          <td> Yes (using RDF schema) </td>
+          <td> No, schema.org specifies a vocabulary that should be used </td>
+          <td> No </td>
+          <td> No </td>
+          <td> Implicitly (SQLite tables) </td>
+          <td> Implicitly (dBASE table) </td>
+          <td> No </td>
+          <td> No </td>
+        </tr>
+        <tr>
+          <td> Supports reuse of third party vocabularies for features and properties </td>
+          <td> Yes </td>
+          <td> Yes </td>
+          <td> Yes </td>
+          <td> Yes </td>
+          <td> Yes </td>
+          <td> No </td>
+          <td> No </td>
+          <td> No </td>
+          <td> No </td>
+          <td> No </td>
+          <td> No </td>
+        </tr>
+        <tr>
+          <td> Supports extensions (geometry types, metadata, etc.) </td>
+          <td> Yes </td>
+          <td> No </td>
+          <td> Yes </td>
+          <td> Yes </td>
+          <td> Yes </td>
+          <td> No (under discussion in IETF) </td>
+          <td> Yes (rarely used except by Google) </td>
+          <td> Yes </td>
+          <td> No </td>
+          <td> No </td>
+          <td> No </td>
+        </tr>
+        <tr>
+          <td> Supports non-simple property values </td>
+          <td> Yes </td>
+          <td> No </td>
+          <td> Yes </td>
+          <td> Yes </td>
+          <td> Yes </td>
+          <td> Yes (in practice: not used) </td>
+          <td> No </td>
+          <td> No </td>
+          <td> No </td>
+          <td> No </td>
+          <td> No </td>
+        </tr>
+        <tr>
+          <td> Supports multiple values per property </td>
+          <td> Yes </td>
+          <td> No </td>
+          <td> Yes </td>
+          <td> Yes </td>
+          <td> Yes </td>
+          <td> Yes (in practice: not used) </td>
+          <td> No </td>
+          <td> No </td>
+          <td> No </td>
+          <td> No </td>
+          <td> No </td>
+        </tr>
+        <tr>
+          <td> Supports multiple geometries per feature </td>
+          <td> Yes </td>
+          <td> Yes </td>
+          <td> n/a </td>
+          <td> Yes </td>
+          <td> Yes (but probably not in practice?) </td>
+          <td> No </td>
+          <td> Yes </td>
+          <td> No </td>
+          <td> No </td>
+          <td> No </td>
+          <td> No </td>
+        </tr>
+        <tr>
+          <td> Support for Coordinate Reference Systems </td>
+          <td> any </td>
+          <td> any </td>
+          <td> n/a </td>
+          <td> many </td>
+          <td> WGS84 latitude, longitude </td>
+          <td> WGS84 longitude, latitude with optional elevation </td>
+          <td> WGS84 longitude, latitude with optional elevation </td>
+          <td> many </td>
+          <td> many </td>
+          <td> many </td>
+          <td> WGS84 spherical mercator projection </td>
+        </tr>
+        <tr>
+          <td> Support for non-linear interpolations in curves </td>
+          <td> Yes </td>
+          <td> Only arcs </td>
+          <td> n/a </td>
+          <td> Yes (using GML) </td>
+          <td> No </td>
+          <td> No </td>
+          <td> No </td>
+          <td> Yes, in an extension </td>
+          <td> No </td>
+          <td> No </td>
+          <td> No </td>
+        </tr>
+        <tr>
+          <td> Support for non-planar interpolations in surfaces </td>
+          <td> Yes </td>
+          <td> No </td>
+          <td> n/a </td>
+          <td> Yes (using GML) </td>
+          <td> No </td>
+          <td> No </td>
+          <td> No </td>
+          <td> No </td>
+          <td> No </td>
+          <td> No </td>
+          <td> No </td>
+        </tr>
+        <tr>
+          <td> Support for solids (3D) </td>
+          <td> Yes </td>
+          <td> Yes </td>
+          <td> n/a </td>
+          <td> Yes (using GML) </td>
+          <td> No </td>
+          <td> No </td>
+          <td> No </td>
+          <td> No </td>
+          <td> No </td>
+          <td> No </td>
+          <td> No </td>
+        </tr>
+        <tr>
+          <td> Feature in a feature collection document has URI (required for ★★★★) </td>
+          <td> Yes, via XML ID </td>
+          <td> Yes, via XML ID </td>
+          <td> Yes, via @id keyword </td>
+          <td> Yes </td>
+          <td> Yes, via HTML ID </td>
+          <td> No </td>
+          <td> Yes, via XML ID </td>
+          <td> No </td>
+          <td> No </td>
+          <td> No </td>
+          <td> No </td>
+        </tr>
+        <tr>
+          <td> Support for hyperlinks (required for ★★★★★) </td>
+          <td> Yes </td>
+          <td> Yes </td>
+          <td> Yes </td>
+          <td> Yes </td>
+          <td> Yes </td>
+          <td> No </td>
+          <td> No </td>
+          <td> No </td>
+          <td> No </td>
+          <td> No </td>
+          <td> No </td>
+        </tr>
+        <tr>
+          <td> Media type </td>
+          <td> application/gml+xml </td>
+          <td> application/gml+xml with profile parameter </td>
+          <td> application/ld+json </td>
+          <td> application/rdf+xml, application/ld+json, etc. </td>
+          <td> text/html </td>
+          <td> application/vnd.geo+json </td>
+          <td> application/vnd.google-earth.kml+xml, application/vnd.google-earth.kmz </td>
+          <td> - </td>
+          <td> - </td>
+          <td> - </td>
+          <td> - </td>
+        </tr>
+        <tr>
+          <td> Remarks </td>
+          <td> comprehensive and supporting many use cases, but requires strong XML skills </td>
+          <td> simplified profile of GML </td>
+          <td> no support for spatial data, a GeoJSON-LD is under discussion </td>
+          <td> GeoSPARQL also specifies related extension functions for SPARQL; other spatial
+            vocabularies exist, see&#160;??? </td>
+          <td> schema.org markup is indexed by major search engines </td>
+          <td> supported by many mapping APIs </td>
+          <td> focussed on visualisation of and interaction with spatial data, typically in Earth
+            browsers liek Google Earth </td>
+          <td> used to support "native" access to spatial data across all enterprise and personal
+            computing environments, including mobile devices </td>
+          <td> supported by almost all GIS </td>
+          <td> mainly used via the GeoServices REST API </td>
+          <td> used for sharing spatial data in tiles, mainly for display in maps </td>
+        </tr>
+      </table>
+    </section>
+    <section class="appendix" id="auth-id-sources">
+      <h2>Authoritative sources of geographic identifiers</h2>
+      <div style="background-color:yellow">
+        <p>Content from Appendix B has been integrated into <a href="#entity-level-links">Best Practice 14: Publish links between spatial things and related resources</a>. This <em>stub</em> appendix has been left so that sequential ordering of the appendices does not change in this draft.</p>
+      </div>
+    </section>
+    <section class="appendix" id="requirements">
+      <h2>Cross reference of use case requirements against best practices</h2>
+      <table id="x-ref_ucrVbp">
+        <caption>Cross reference of requirements against best practices</caption>
+        <thead>
+          <tr>
+            <th>UC Requirements</th>
+            <th>Best Practice</th>
+          </tr>
+        </thead>
+        <tbody>
+        </tbody>
+      </table>
+    </section>
+    <section class="appendix" id="glossary">
+      <h2>Glossary</h2>
+      <div class="issue" data-number="212">
+        <p>Glossary section needs improving; see existing sources of definitions.</p>
+        <p>Consider adopting definitions from, or aligning definitions with the <a
+            href="http://www.isotc211.org/Terminology.htm">ISO/TC 211 Glossary</a> - see <a
+            href="http://registry.it.csiro.au/sandbox/iso-tc211/terms">linked data
+          prototype</a>.</p>
+        <p>For example, the <a>Coverage</a> definition is considered unclear and potentially
+          inconsistent with the <a href="http://registry.it.csiro.au/sandbox/iso-tc211/terms/99">ISO
+            definition of Coverage</a>.</p>
+      </div>
+      <div class="issue" data-number="222">
+        <p>Need consistency in how we cite existing specifications.</p>
+        <p>Why do some references go to the glossary (e.g. WFS) and some to the references (e.g.
+          SPARQL)? Maybe WFS etc. should be added to the references, too, and the text should include
+          a link both to the glossary and the references?</p>
+      </div>
+	    <p><dfn>absolute positional accuracy</dfn>: 
+		    closeness of reported coordinate values to values accepted as or being true (ISO 19159-2)</p>
+      <p><dfn data-lt="Coverage|Coverages|Coverage Function">Coverage</dfn>: A coverage is a function that describe characteristics of real-world phenomena that vary over space and/or time. Typical examples are temperature, elevation and precipitation. A coverage is typically represented as a data structure containing a set of such values, each associated with one of the elements in a spatial, temporal or spatiotemporal domain. Typical spatial domains are point sets (e.g. sensor locations), curve sets (e.g. contour lines), grids (e.g. orthoimages, elevation models), etc. A property whose value varies as a function of time may be represented as a temporal coverage or time-series [[ISO-19109]] §8.8.</p>
+      <p><dfn data-lt="CRS|Coordinate Reference System|Coordinate Reference Systems">Coordinate Reference System (CRS)</dfn>: A
+        coordinate-based local, regional or global system used to locate geographical entities. Also known as <em>Spatial Reference System</em>.
+          <span style="background-color:yellow">Compare with the <a
+            href="http://registry.it.csiro.au/sandbox/iso-tc211/terms/703">ISO
+          definition</a>.</span></p>
+      <p><dfn data-lt="dimension|dimensions|dimensional|dimensionality">Dimension (geometry)</dfn>: <span style="background-color:yellow">[re-phrased from Wikipedia: <a href="https://en.wikipedia.org/wiki/Dimension">https://en.wikipedia.org/wiki/Dimension</a>]</span> In physics and mathematics, the dimension of a mathematical space (or object) is informally defined as the minimum number of coordinates needed to specify any point within it. Thus, a point has no dimension (0D), whereas a line has a dimension of one (1D) because only one coordinate is needed to specify a point on it – for example, the point at 5 on a number line. A surface such as a plane or the surface of a cylinder or sphere has a dimension of two (2D) because two coordinates are needed to specify a point on it – for example, both a latitude and longitude are required to locate a point on the surface of a sphere. The inside of a cube, a cylinder or a sphere is three-dimensional (3D) because three coordinates are needed to locate a point within these spaces. <span style="background-color:yellow">Compare with the <a href="http://registry.it.csiro.au/sandbox/iso-tc211/terms/213">ISO definition</a></span>. [[ISO-19107]]</p>
+      <p><dfn data-lt="ellipsoid|ellipsoids">Ellipsoid</dfn>: An ellipsoid is a closed quadric surface that is a three-dimensional analogue of an ellipse. In <em>geodesy</em>, a <strong>reference ellipsoid</strong> is a mathematically defined surface that approximates the <a>geoid</a>.</p>
+      <p><dfn>Extent</dfn>: The area covered by something. Within this document, we always imply
+        spatial extent; e.g. size or shape that may be expresses using coordinates. </p>
+      <p><dfn data-lt="feature|features">Feature</dfn>: Abstraction of real world phenomena. <span
+          style="background-color:yellow">Compare with the <a
+            href="http://registry.it.csiro.au/sandbox/iso-tc211/terms/168">ISO
+          definition</a>.</span>
+        [[ISO-19101]] §4.11</p>
+      <p><dfn data-lt="Geocoding|Forward geocoding|reverse geocoding">Geocoding</dfn>: Forward
+        geocoding, often just referred to as geocoding, is the process of converting addresses into
+        geographic coordinates. Reverse geocoding is the opposite process; converting geographic
+        coordinates to addresses. <span style="background-color:yellow">Compare with the <a
+            href="http://registry.it.csiro.au/sandbox/iso-tc211/terms/195">ISO
+          definition</a>.</span></p>
+      <p><dfn>Geohash</dfn>: A <a>geocoding</a> system with a hierarchical spatial data structure
+        which subdivides space into buckets. Geohashes offer properties like arbitrary precision and
+        the possibility of gradually removing characters from the end of the code to reduce its size
+        (and gradually lose precision). As a consequence of the gradual precision degradation,
+        nearby places will often (but not always) present similar prefixes. The longer a shared
+        prefix is, the closer the two places are. <span style="background-color:yellow"><a
+            href="https://en.wikipedia.org/wiki/Geohash">wikipedia</a></span></p>
+      <p><dfn data-lt="Geographic information|Geospatial data">Geographic information (also
+          geospatial data)</dfn>: Information concerning phenomena implicitly or explicitly
+        associated with a location relative to the Earth. <span style="background-color:yellow"
+          >Compare with the <a href="http://registry.it.csiro.au/sandbox/iso-tc211/terms/205">ISO
+            definition</a>.</span>
+        [[ISO-19101]] §4.16.</p>
+      <p><dfn data-lt="Geographic information system|GIS">Geographic information system (GIS)</dfn>:
+        An information system dealing with information concerning phenomena associated with location
+        relative to the Earth. <span style="background-color:yellow">Compare with the <a
+            href="http://registry.it.csiro.au/sandbox/iso-tc211/terms/207">ISO
+          definition</a>.</span>
+        [[ISO-19101]] §4.18</p>
+      <p><dfn>Geometry</dfn>: An ordered set of n-dimensional points; can be used to model the spatial extent or shape of a <a>spatial thing</a></p>
+      <p><dfn>Geoid</dfn>: An equipotential surface where the gravitational field of the Earth has the same value at all locations. This surface is perpendicular to a plumb line at all points on the Earth's surface and is roughly equivalent to the mean sea level excluding the effects of winds and permanent currents such as the Gulf Stream.</p>
+      <p><dfn>Hypermedia</dfn>: <span style="background-color:yellow">to be added</span></p>
+      <p><dfn data-lt="IoT|Internet of Things">Internet of Things (IoT)</dfn>: The network of
+        physical objects or "things" embedded with electronics, software, sensors, and network
+        connectivity, which enables these objects to be controlled remotely and to collect and
+        exchange data.</p>
+      <p><dfn data-lt="JavaScript Object Notation|JSON">JavaScript Object Notation (JSON)</dfn>: A
+        lightweight, text-based, language-independent data interchange format defined in
+        [[RFC7159]]. It was derived from the ECMAScript Programming Language Standard. JSON defines
+        a small set of formatting rules for the portable representation of structured data.</p>
+      <p><dfn data-lt="latitude|lat">Latitude</dfn>: The angular distance north or south of the equator. Often abbreviated to <em>Lat</em>.</p>
+      <p><dfn data-lt="link|links">Link</dfn>: A typed connection between two resources that are
+        identified by Internationalized Resource Identifiers (IRIs) [[RFC3987]], and is comprised
+        of: (i) a context IRI, (ii) a link relation type, (iii) a target IRI, and (iv) optionally,
+        target attributes. Note that in the common case, the IRI will also be a URI [[RFC3986]],
+        because many protocols (such as HTTP) do not support dereferencing IRIs [[RFC5988]].</p>
+      <p><dfn>Linked data</dfn>: The term ‘Linked Data’ refers to an approach to publishing data
+        that puts linking at the heart of the notion of data, and uses the linking technologies
+        provided by the Web to enable the weaving of a global distributed database [[LDP-PRIMER]].</p>
+      <p><dfn data-lt="longitude|long|lon">Longitude</dfn>: The angular distance east or west of the prime meridian. Often abbreviated to <em>Long</em>.</p>
+      <p><dfn data-lt="Open-world assumption|open world assumption|OWA">Open-world assumption
+          (OWA)</dfn>: In a formal system of logic used for knowledge representation, the open-world
+        assumption asserts that the truth value of a statement may be true irrespective of whether
+        or not it is known to be true. This assumption codifies the informal notion that in general
+        no single agent or observer has complete knowledge. In essence, from the absence of a
+        statement alone, a deductive reasoner cannot (and must not) infer that the statement is
+        false. <span style="background-color:yellow"><a
+            href="https://en.wikipedia.org/wiki/Open-world_assumption">wikipedia</a></span></p>
+      <p><dfn data-lt="Resource description framework|RDF">Resource Description Framework
+          (RDF)</dfn>: A directed, labeled graph data model for representing information in the Web.
+        It may be serialized in several data formats such as N-Triples [[N-TRIPLES]], XML
+        [[RDF-SYNTAX-GRAMMAR]], Terse Triple Language (“turtle” or TTL) [[TURTLE]] and JSON-LD
+        [[JSON-LD]].</p>
+      <p><dfn>Semantic web</dfn>: The term “Semantic Web” refers to World Wide Web Consortium's
+        vision of the Web of <a>linked data</a>. Semantic Web technologies enable people to create
+        data stores on the Web, build vocabularies, and write rules for handling data.</p>
+      <p><dfn>SPARQL</dfn>: A query language for <a>RDF</a>; it can be used to express queries
+        across diverse data sources [[SPARQL11-OVERVIEW]].</p>
+      <p><dfn>Spatial data</dfn>: Data describing anything with spatial extent; i.e. size, shape or
+        position. In addition to describing things that are positioned relative to the Earth (also
+        see <a>geospatial data</a>), spatial data may also describe things using other coordinate systems
+        that are not related to position on the Earth, such as the size, shape and positions of
+        cellular and sub-cellular features described using the 2D or 3D Cartesian coordinate system
+        of a specific tissue sample.</p>
+      <p><dfn>Spatial database</dfn>: A spatial database, or geodatabase, is a database that is
+        optimized to store and query data that represents objects defined in a geometric space. Most
+        spatial databases allow representation of simple geometric objects such as points, lines and
+        polygons and provide functions to determine spatial relationships (overlaps, touches
+        etc.).</p>
+      <p><dfn data-lt="SDI|SDIs|Spatial Data Infrastructure|Spatial Data Infrastructures">Spatial Data Infrastructure (SDI)</dfn>:
+        An ecosystem of geographic data, metadata, tools, applications, policies and users that are
+        necessary to acquire, process, distribute, use, maintain, and preserve spatial data. Due to
+        its nature (size, cost, number of interactors) an SDI is often government-related.</p>
+      <p><dfn data-lt="SensorThings">SensorThings API</dfn>: An open, geospatial-enabled and unified 
+        way to interconnect the Internet of Things (IoT) devices, data, and applications over the Web. 
+        [[SensorThings]].</p>
+      <p><dfn data-lt="SOS|Sensor Observation Service">Sensor Observation Service (SOS)</dfn>: A 
+        standardized HTTP interface allowing requests for observations across the web using
+        platform-independent calls. Sensor Observation Service [[SOS]].</p>
+      <p><dfn data-lt="Spatial Thing|Spatial Things|SpatialThing|SpatialThings">Spatial thing</dfn>:
+        Anything with spatial extent, i.e. size, shape, or position. e.g. people, places, bowling
+        balls, as well as abstract regions like cubes. <span style="background-color:yellow">Compare
+          with the <a href="http://registry.it.csiro.au/sandbox/iso-tc211/terms/419">ISO definition
+            for Spatial Object</a>.</span>
+        [[W3C-BASIC-GEO]]</p>
+      <p><dfn data-lt="Temporal Thing|TemporalThing|TemporalThings">Temporal thing</dfn>: Anything
+        with temporal extent, i.e. duration. e.g. the taking of a photograph, a scheduled meeting, a
+        GPS time-stamped track-point [[W3C-BASIC-GEO]]</p>
+      <p><dfn data-lt="triple-store|triple store|triple stores|quad-store|quadstore">Triple-store
+          (or quadstore)</dfn>: A triple-store or <a>RDF</a> store is a purpose-built database for
+        the storage and retrieval of RDF subject-predicate-object “triples” through semantic
+        queries. Many implementations are actually “quad-stores” as they also hold the name of the
+        graph within which a triple is stored.</p>
+      <p><dfn>Universe of discourse</dfn>: View of the real or hypothetical world that includes
+        everything of interest. <span style="background-color:yellow">Compare with the <a
+            href="http://registry.it.csiro.au/sandbox/iso-tc211/terms/486">ISO
+          definition</a>.</span>
+        [[ISO-19101]] §4.29</p>
+      <p><dfn data-lt="WCS|Web Coverage Service">Web Coverage Service (WCS)</dfn>: A service
+        offering multi-dimensional coverage data for access over the Internet [[WCS]]</p>
+      <p><dfn data-lt="WFS|Web Feature Service">Web Feature Service (WFS)</dfn>: A standardized HTTP
+        interface allowing requests for geographical features across the web using
+        platform-independent calls. Web Feature Service [[WFS]].</p>
+      <p><dfn data-lt="WMS|Web Map Service">Web Map Service (WMS)</dfn>: A standardized HTTP
+        interface for requesting geo-registered map images from one or more distributed spatial
+        databases [[WMS]].</p>
+      <p><dfn data-lt="WMTS|Web Map Tile Service">Web Map Tile Service (WMTS)</dfn>: A standardized HTTP
+        interface for requesting tiled, geo-referenced map images from one or more distributed spatial
+        databases [[WMTS]].</p>
+      <p><dfn data-lt="well known text|well-known-text|wkt">Well Known Text (WKT)</dfn>: A text
+        markup language for representing vector geometry objects on a map, spatial reference systems
+        of spatial objects and transformations between spatial reference systems. <span
+          style="background-color:yellow"><a href="https://en.wikipedia.org/wiki/Well-known_text"
+            >wikipedia</a></span>)</p>
+      <p><dfn data-lt="WPS|Web Processing Service">Web Processing Service (WPS)</dfn>: An interface
+        standard which provides rules for standardizing inputs and outputs (requests and responses)
+        for invoking spatial processing services, such as polygon overlay, as a Web service [[WPS]].</p>
+      <p><dfn data-lt="Extensible Markup Language|XML">Extensible Markup Language (XML)</dfn>: A
+        simple, very flexible text-based markup language derived from SGML (ISO 8879). It defines a
+        set of rules for encoding documents in a format that is both human-readable and
+        machine-readable. [[XML11]]</p>
+    </section>
+    <section class="appendix" id="acknowledgments">
+      <h2>Acknowledgments</h2>
+      <p>The editors gratefully acknowledge the contributions made to this document by <a href="https://www.w3.org/2000/09/dbwg/details?group=75471&amp;public=1">all members
+        of the working group</a> and the chairs: Kerry Taylor and Ed Parsons.</p>
+    </section>
+    <section class="appendix" id="changes">
+      <h2>Changes since previous versions</h2>
+      <p>A full change-log is available on <a href="https://github.com/w3c/sdw/commits/gh-pages/bp">GitHub</a></p>
+      <section id="changes-since-20160119">
+        <h2>Changes since the first public working draft of 19 January 2016</h2>
+        <p>The document has undergone substantial changes since the <a href="https://www.w3.org/TR/2016/WD-sdw-bp-20160119/">first public working draft</a>. Below are some of the changes made:</p>
+
+        <ul>
+          <li>Focusing the document to suit the needs of practitioners: those either publishing spatial data themselves, or developing software tools to support the publication of spatial data (see sections <a href="#audience"></a> and <a href="#scope"></a>)</li>
+          <li>Addition of new introductory material to explain the fundamentals of spatial data to readers (see sections <a href="#spatial-things-features-and-geometry"></a>, <a href="#coverages"></a>, <a href="#spatial-relations"></a>, <a href="#linked-data"></a> and <a href="#why-are-traditional-sdi-not-enough"></a>)</li>
+          <li>Consolidation of the best practices from 30 down to 17 - based on merging duplicate or closely related best practices and focusing our scope only on spatial data concerns so that, for example, best practices relating to handling sensor data are removed (we expect these subjects to be included in future iterations of the Sensor Network deliverables of the <a href="http://www.opengeospatial.org/projects/groups/sdwwg">working group</a>)</li>
+          <li>Alignment of the remaining best practices with those from [[DWBP]] - including organizing them according to the same sub-section headings</li>
+          <li>As a consequence of the consolidation and [[DWBP]] alignment, the best practices are renumbered (although the fragment-identifiers remain unchanged from those used in the <a href="https://www.w3.org/TR/2016/WD-sdw-bp-20160119/">first public working draft</a>) and the cross-reference to the Requirements from [[SDW-UCR]] (section <a href="#requirements"></a>) has been updated</li>
+          <li>Addition of a new, partially complete section (see <a href="#how-to-use"></a>) that is intended to help readers understand the steps they should take and the questions they should consider when publishing spatial data on the Web; referencing both the general [[DWBP]] best practices and those specific to spatial data described in this document</li>
+          <li>Improvements to the <a href="#glossary"></a></li>
+        </ul>
+      </section>
+      <section id="changes-since-20161025">
+        <h2>Changes since working draft of 25 October 2016</h2>
+        <p>Significant updates to:</p>
+        <ul>
+          <li><a href="#indexable-by-search-engines" class="sectionRef">Best Practice 4: Make your spatial data indexable by search engines</a></li>
+          <li><a href="#desc-changing-properties" class="sectionRef">Best Practice 6: How to describe properties that change over time</a></li>
+          <li><a href="#globally-unique-ids" class="sectionRef">Best Practice 7: Use globally unique persistent HTTP URIs for spatial things</a></li>
+          <li><a href="#convenience-apis" class="sectionRef">Best Practice 11: Expose spatial data through 'convenience APIs'</a></li>
+        </ul>
+        <p><em>(further updates to these best practices are expected in the next WD release, circa end January 2017)</em></p>
+        <p>Plus minor changes that include adding a list of most important best practices for data publishers that start from an existing <a>SDI</a> to <a href="#why-are-traditional-sdi-not-enough" class="sectionRef">section 9</a>, and changing of a few best practice titles to include the word <em>spatial</em>.</p>
+
+      </section>
+      <section id="changes-since-20170105">
+        <h2>Changes since working draft of 5 January 2017</h2>
+        <p>Significant updates to:</p>
+        <ul>
+          <li>Section <a href="#CRS-background">8. Coordinate Reference Systems (CRS)</a></li>
+          <li><a href="#indexable-by-search-engines">Best Practice 4: Make your spatial data indexable by search engines</a></li>
+          <li><a href="#desc-changing-properties">Best Practice 6: How to describe properties that change over time</a></li>
+          <li><a href="#globally-unique-ids">Best Practice 7: Use globally unique persistent HTTP URIs for spatial things</a></li>
+          <li><a href="#entity-level-links">Best Practice 14: Publish links between spatial things and related resources</a></li>
+        </ul>
+        <p>Also:</p>
+        <ul>
+          <li>The <a href="#bp-summary">BP summary</a> has been moved and is now section 4 of the document;</li>
+          <li>Best Practice 17, "How to work with crowd-sourced observations" was removed; and</li>
+          <li>the Best Practices Template section, explaining the template used to describe Best Practices, was removed.</li>
+        </ul>
+      </section>
+      <section id="changes-since-20170216">
+        <h2>Changes since working draft of 16 February 2017</h2>
+        <p>Significant updates to the following best practices:</p>
+        <ul>
+          <li><a href="#spatial-info-dataset-metadata" class="sectionRef">Best Practice 1: Include spatial metadata in dataset metadata</a></li>
+          <li><a href="#bp-crs-choice" class="sectionRef">Best Practice 3: Choose the coordinate reference system to suit your user's applications</a></li>
+          <li><a href="#describe-geometry" class="sectionRef">Best Practice 8: Provide geometries on the Web in a usable way</a></li>
+          <li><a href="#relative-position" class="sectionRef">Best Practice 9: Describe relative positioning</a></li>
+          <li><a href="#semantic-thing" class="sectionRef">Best Practice 10: Encoding spatial data</a></li>
+          <li><a href="#convenience-apis" class="sectionRef">Best Practice 11: Expose spatial data through 'convenience APIs'</a></li>
+          <li><a href="#entity-level-links" class="sectionRef">Best Practice 14: Publish links between spatial things and related resources</a></li>
+          <li><a href="#bp-crs" class="sectionRef">Best Practice 17: State how coordinate values are encoded</a></li>
+        </ul>
+        <p>The following best practices have been removed or merged into other best practices:</p>
+        <ul>
+          <li><a href="#provide-context" class="sectionRef">Best Practice 2: Provide context required to interpret data values</a> (considered to be non-actionable guidance)</li>
+          <li><a href="#include-search-api" class="sectionRef">Best Practice 12: Include search capability in your data access API</a> (merged into <a href="#convenience-apis" class="sectionRef">Best Practice 11: Expose spatial data through 'convenience APIs'</a>)</li>
+          <li><a href="#ids-for-chunks" class="sectionRef">Best Practice 13: Provide subsets for large spatial datasets</a> (covered sufficiently in [[DWBP]], referenced from <a href="#bp-exposing-via-api" class="sectionRef"></a></li>
+          <li><a href="#find-related-data" class="sectionRef">Best Practice 15: Use links in spatial datasets to find related data</a> (data consumer guidance is, unfortunately, out of scope; the remaining guidance has been incorporated into <a href="#entity-level-links" class="sectionRef">Best Practice 14: Publish links between spatial things and related resources</a>)</li>
+          <li><a href="#minimum" class="sectionRef">Best Practice 16: Provide a minimum set of information about spatial things for your intended application</a> (merged into <a href="#semantic-thing" class="sectionRef">Best Practice 10: Encoding spatial data</a>)</li>
+        </ul>
+        <p><a href="https://www.w3.org/TR/2017/NOTE-sdw-bp-20170216/#narrative" class="sectionRef">Section 14. Narrative - the Nieuwhaven flooding</a> (link to previous WD version) has been removed.</p>
+        <p><a href="#auth-id-sources" class="sectionRef">Appendix B: Authoritative sources of geographic identifiers</a> has been merged into <a href="#entity-level-links" class="sectionRef">Best Practice 14: Publish links between spatial things and related resources</a>.</p>
+      </section>
+    </section>
+  </body>
 </html>


### PR DESCRIPTION
As actioned at the Delft meeting, I have attempted to express more about positional accuracy. As this is my first direct contribution, I'm not sure I've got the tone or format right. That said, do also comment on the actual content too!

Summary:

- Drop encouragement to specify the precision of the data (as the note says, that's misleading anyway)
- Re-draft intended outcome in terms of user fitness-for-purpose (included summary of alternative statements here)
- Added quite a large section in "how" on the various approaches.
- Amended the short list of 'example(s) to be added'
- 'spatialResolutionAsDistance' only really applies to coverages - although it is sometimes (ab)used as a short hand for some statement about the source imagery used in the production of a vector dataset!
- The INSPIRE regulation says nothing about positional accuracy, so conforming to it cannot be an example of a positional accuracy metadata statement; moved it to the more general section - but this makes it an example of a dwbp best practice. But are we OK with an example outside of the 'best practices'? There are other EC Directives that set positional accuracy requirements (e.g. for farm payments, https://marswiki.jrc.ec.europa.eu/wikicap/index.php/Positional_Accuracy - so it would be possible to create an example citing one); a better example might be IHO's S-44 which sets out accuracy requirements for hydropgrahic surveys - so survey datasets could state that they conform to S-44 (at one of four spec levels) - I've tried to create this one (although it doesn't have a URI - I've used the document URL & made up a fragment identifier)
- Added a few points on on 'how to test'
- 

Note: I found this page rather long for collaborative editing; could it be broken up into sections on separate GitHub pages?