### PR TITLE
Update ssn.ttl

### DIFF
--- a/ssn/ssn_separated/ssn.ttl
+++ b/ssn/ssn_separated/ssn.ttl
@@ -147,7 +147,8 @@ ssn:endTime rdf:type owl:ObjectProperty ;
 			rdfs:comment "The end point of a time interval." ;
             rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
             rdfs:label "end time" ;
-            rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Base#Time" .
+            rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Base#Time" ;
+	    rdf:type owl:DeprecatedProperty.
 
 
 ###  http://www.w3.org/ns/ssn/featureOfInterest
@@ -440,7 +441,8 @@ ssn:startTime rdf:type owl:ObjectProperty ;
               rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
 			  rdfs:comment "The start point of a time interval." ;
               rdfs:label "start time" ;
-              rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Base#Time" .
+              rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Base#Time";
+	      rdf:type owl:DeprecatedProperty.
 
 
 ### http://www.w3.org/ns/ssn/wasOriginatedBy


### PR DESCRIPTION
Set x rdf:type owl:DeprecatedProperty. For x being startTime and endTime; see https://www.w3.org/2015/spatial/wiki/Time_in_SOSA_and_SSN#Properties_that_are_only_in_SSN