### PR TITLE
[OWL-Time] Fix subsection headings

### DIFF
--- a/time/index.html
+++ b/time/index.html
@@ -252,7 +252,7 @@ given using multiple duration descriptions or individual durations (e.g., 2 days
 <code><a href="#time:Duration">:Duration</a></code> has properties to describe the duration using a scaled number (i.e. a temporal quantity). 
 <code><a href="#time:GeneralDurationDescription">:GeneralDurationDescription</a></code> has a set of properties to specify a duration using calendar and clock elements, the definitions of which are given in the associated TRS description. 
 Its subclass <code><a href="#time:DurationDescription">:DurationDescription</a></code> fixes the temporal reference system to the Gregorian calendar, so the <code><a href="#time:hasTRS">:hasTRS</a></code> property may be omitted on individuals from this class. </p>
-<p><code><a href="#time:TemporalUnit">:TemporalUnit</a></code> is a standard duration which is used to scale a length of time, and to captures its granularity or precision. </p>
+<p><code><a href="#time:TemporalUnit">:TemporalUnit</a></code> is a standard duration which is used to scale a length of time, and to capture its granularity or precision. </p>
 
 <figure> <img title="Temporal Duration" alt="UML representation of Temporal Duration and sub-classes"
 src="./images/TemporalDuration.png"> 
@@ -297,6 +297,7 @@ so that you can say "duration of 2.5 years".</p>
 <code><a href="#time:TRS">:TRS</a></code> 
 </p>
 
+<section>
 <h4 id="time:DateTimeDescription">Date-time description</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -334,7 +335,9 @@ xsd:gDay, respectively. </td>
 </tbody>
 </table>
 <p>Other datetime concepts can be defined by specialization of <code><a href="#time:DateTimeDescription">:DateTimeDescription</a></code> - see <a href="#specialization">examples below</a>.</p>
+</section>
 
+<section>
 <h4 id="time:DateTimeInterval">Date-time interval</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -362,7 +365,9 @@ Two properties <code><a href="#time:hasDateTimeDescription">:hasDateTimeDescript
 <p>Any <code><a href="#time:TemporalEntity">:TemporalEntity</a></code> has a duration, but only <code><a href="#time:DateTimeInterval">:DateTimeInterval</a></code> can have <code><a href="#time:DateTimeDescription">:DateTimeDescription</a></code>.
 For example, May 8 can be expressed as a <code><a href="#time:DateTimeDescription">:DateTimeDescription</a></code>, but the interval from 1:30pm, May 8, to 1:30pm,
 May 9, cannot. Both have a duration of a day.</p>
+</section>
 
+<section>
 <h4 id="time:DayOfWeek">Day of week</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -384,7 +389,9 @@ May 9, cannot. Both have a duration of a day.</p>
 days used in the Gregorian calendar, and using the English names <code><a href="#time:Sunday">:Sunday</a></code>, <code><a href="#time:Monday">:Monday</a></code>, <code><a href="#time:Tuesday">:Tuesday</a></code>,
 <code><a href="#time:Wednesday">:Wednesday</a></code>, <code><a href="#time:Thursday">:Thursday</a></code>, <code><a href="#time:Friday">:Friday</a></code>, <code><a href="#time:Saturday">:Saturday</a></code>.</p>
 <p class="note">Membership of the class <code><a href="#time:DayOfWeek">:DayOfWeek</a></code> is open, to allow for alternative week lengths and different day names. </p>
+</section>
 
+<section>
 <h4 id="time:Duration">Duration</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -410,7 +417,9 @@ days used in the Gregorian calendar, and using the English names <code><a href="
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:DurationDescription">Duration description</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -463,7 +472,9 @@ each of the numeric properties is restricted to <a href="https://www.w3.org/TR/x
 </tbody>
 </table>
 <p>Other duration concepts can be straightforwardly defined - see <a href="#specialization">examples below</a>.</p>
+</section>
 
+<section>
 <h4 id="time:GeneralDateTimeDescription">Generalized date-time description</h4>
 <table class="definition" style="border-collapse: collapse; width: 812px; ">
 <tbody>
@@ -539,7 +550,9 @@ Datatypes [<a href="#XSD-D">XSD-D</a>], except that the calendar is not specifie
 through the value of the <code><a href="#time:hasTRS">:hasTRS</a></code> property (defined above). </p>
 <p>Two additional properties <code><a href="#time:week">:week</a></code> and <code><a href="#time:dayOfYear">:dayOfYear</a></code> allow for the the numeric value of the week or day relative to the year. </p>
 <p>The property <code><a href="#time:dayOfWeek">:dayOfWeek</a></code> provides the name of the day, and the property <code><a href="#time:monthOfYear">:monthOfYear</a></code> provides the name of the month. </p>
+</section>
 
+<section>
 <h4 id="time:GeneralDurationDescription">Generalized duration description</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -592,7 +605,9 @@ calendar-clock system. </td>
 </table>
 <p>Seven datatype properties <code><a href="#time:years">:years</a></code>, <code><a href="#time:months">:months</a></code>, <code><a href="#time:weeks">:weeks</a></code>, <code><a href="#time:days">:days</a></code>, <code><a href="#time:hours">:hours</a></code>, <code><a href="#time:minutes">:minutes</a></code>, and <code><a href="#time:seconds">:seconds</a></code> support the description of components of a temporal extent in a calendar-clock system. </p>
 <p>The property <code><a href="#time:hasTRS">time:hasTRS</a></code> indicates the temporal reference system applicable for the duration components. </p>
+</section>
 
+<section>
 <h4 id="time:Instant">Time instant</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -612,7 +627,9 @@ calendar-clock system. </td>
 </table>
 <p>Seven properties, <code><a href="#time:inXSDDate">:inXSDDate</a></code>, <code><a href="#time:inXSDDateTime">:inXSDDateTime</a></code> (deprecated), <code><a href="#time:inXSDDateTimeStamp">:inXSDDateTimeStamp</a></code>, <code><a href="#time:inXSDgYear">:inXSDgYear</a></code>, <code><a href="#time:inXSDgYearMonth">:inXSDgYearMonth</a></code>, <code><a href="#time:inTimePosition">:inTimePosition</a></code>, and <code><a href="#time:inDateTime">:inDateTime</a></code>
 provide alternative ways to describe the temporal position of an <code><a href="#time:Instant">:Instant</a></code>. </p>
+</section>
 
+<section>
 <h4 id="time:Interval">Time interval</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -631,7 +648,9 @@ provide alternative ways to describe the temporal position of an <code><a href="
 </tbody>
 </table>
 <p>One property <code><a href="#time:inside">:inside</a></code> links to an <code><a href="#time:Instant">:Instant</a></code> that falls inside the <code><a href="#time:Interval">:Interval</a></code>.</p>
+</section>
 
+<section>
 <h4 id="time:MonthOfYear">Month of year</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -696,8 +715,9 @@ provide alternative ways to describe the temporal position of an <code><a href="
 <code><a href="#greg:December">greg:December</a></code>. 
 Each month is defined by setting the value of <code><a href="#time:month">time:month</a></code> to the corresponding value.</p>
 <p class="note">Membership of the class <code><a href="#time:MonthOfYear">:MonthOfYear</a></code> is open, to allow for alternative annual calendars and different month names. </p>
+</section>
 
-
+<section>
 <h4 id="time:ProperInterval">Proper interval</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -731,7 +751,9 @@ are different</td>
 <code><a href="#time:intervalDisjoint">:intervalDisjoint</a></code> 
 <code><a href="#time:intervalIn">:intervalIn</a></code> 
 support the set of interval relations defined by Allen [<a href="#AL-84">AL-84</a>] and Allen and Ferguson [<a href="#AF-97">AF-97</a>].</p>
+</section>
 
+<section>
 <h4 id="time:TemporalDuration">Temporal duration</h4>
 <table class="definition" style="width: 812px;">
 <thead>
@@ -751,7 +773,9 @@ support the set of interval relations defined by Allen [<a href="#AL-84">AL-84</
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:TemporalEntity">Temporal entity</h4>
 <table class="definition" style="width: 812px;">
 <thead>
@@ -777,7 +801,9 @@ support the set of interval relations defined by Allen [<a href="#AL-84">AL-84</
 </table>
 <p>Two properties, <code><a href="#time:before">:before</a></code>, <code><a href="#time:after">:after</a></code>, support ordering relationships between two <code><a href="#time:TemporalEntity">:TemporalEntity</a></code>s.</p>
 <p>The properties <code><a href="#time:hasBeginning">:hasBeginning</a></code>, <code><a href="#time:hasEnd">:hasEnd</a></code> and <code><a href="#time:hasTemporalDuration">:hasTemporalDuration</a></code> (or its sub-properties), support the description of the bounds and extent of a <code><a href="#time:TemporalEntity">:TemporalEntity</a></code>.</p>
+</section>
 
+<section>
 <h4 id="time:TemporalPosition">Temporal position</h4>
 <table class="definition" style="width: 812px;">
 <thead>
@@ -802,7 +828,9 @@ support the set of interval relations defined by Allen [<a href="#AL-84">AL-84</
 </tbody>
 </table>
 <p>The property <code><a href="#time:hasTRS">time:hasTRS</a></code> indicates the temporal reference system. </p>
+</section>
 
+<section>
 <h4 id="time:TemporalUnit">Temporal unit</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -825,7 +853,9 @@ elements of the standard calendar-clock: <code><a href="#time:unitYear">:unitYea
 <code><a href="#time:unitDay">:unitDay</a></code>, <code><a href="#time:unitHour">:unitHour</a></code>, <code><a href="#time:unitMinute">:unitMinute</a></code> and <code><a href="#time:unitSecond">:unitSecond</a></code>. </p>
 <p class="note">Membership of the class TemporalUnit is open, to allow for
 other temporal units used in some technical applications (e.g. millions of years, Baha'i month). </p>
+</section>
 
+<section>
 <h4 id="time:TimePosition">Time position</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -852,7 +882,9 @@ other temporal units used in some technical applications (e.g. millions of years
 descriptions of position or extent. One of these is expected to be present. </p>
 <p>The temporal ordinal reference system should be provided as the value of the <code><a href="#time:hasTRS">:hasTRS</a></code> property</p>
 <p>The temporal coordinate system should be provided as the value of the <code><a href="#time:hasTRS">:hasTRS</a></code> property</p>
+</section>
 
+<section>
 <h4 id="time:TimeZone">Time-zone</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -879,7 +911,9 @@ However, that ontology was incomplete in scope, and the example datasets were se
 <p><a href="https://www.ietf.org/timezones/data/">IETF</a> and <a href="http://www.iana.org/time-zones">IANA</a> also provide databases. These are well maintained, but individual iems are not available at individual URIs, i.e. not as "Linked Data".</p>
 <p>The World Clock service provides a <a href="https://www.timeanddate.com/time/zones/">list of time zones</a>, with the description of each available as an individual webpage with a convenient individual URI (e.g. <a href="https://www.timeanddate.com/time/zones/acwst">https://www.timeanddate.com/time/zones/acwst</a>. Currently this appears to offer best practice. </p>
 </div>
+</section>
 
+<section>
 <h4 id="time:TRS">Temporal reference system</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -909,6 +943,7 @@ Timescale</a>. </p>
 including (a) calendar + clock systems; (b) temporal coordinate systems (i.e. numeric offset from an epoch); 
 (c) temporal ordinal reference systems (i.e. ordered sequence of named intervals, not necessarily of equal duration). </p>
 </div>
+</section>
 
 </section>
 
@@ -977,6 +1012,7 @@ including (a) calendar + clock systems; (b) temporal coordinate systems (i.e. nu
 <code><a href="#time:years">:years</a></code>
 </p>
 
+<section>
 <h4 id="time:after">after</h4>
 <table class="definition" style="width: 812px;">
 <thead>
@@ -1001,7 +1037,9 @@ entity T<sub>2</sub>, then the beginning of T<sub>1</sub> is after the end of T<
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:before">before</h4>
 <table class="definition" style="width: 812px;">
 <thead>
@@ -1031,8 +1069,9 @@ Thus, <em>before</em> can be considered to be basic to instants and derived for 
 </tr>
 </tbody>
 </table>
+</section>
 
-
+<section>
 <h4 id="time:day">day</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -1056,7 +1095,9 @@ The range of this property is not specified, so can be replaced by any specific 
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:dayOfWeek">day of week</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -1082,7 +1123,9 @@ The range of this property is not specified, so can be replaced by any specific 
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:dayOfYear">day of year</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -1108,7 +1151,9 @@ The range of this property is not specified, so can be replaced by any specific 
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:days">days duration</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -1134,7 +1179,9 @@ The range of this property is not specified, so can be replaced by any specific 
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:hasBeginning">has beginning</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -1156,7 +1203,9 @@ The range of this property is not specified, so can be replaced by any specific 
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:hasDateTimeDescription">has date-time description</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -1182,7 +1231,9 @@ The range of this property is not specified, so can be replaced by any specific 
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:hasDuration">has duration</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -1208,7 +1259,9 @@ The range of this property is not specified, so can be replaced by any specific 
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:hasDurationDescription">has duration description</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -1234,7 +1287,9 @@ The range of this property is not specified, so can be replaced by any specific 
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:hasEnd">has end</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -1256,7 +1311,9 @@ The range of this property is not specified, so can be replaced by any specific 
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:hasTemporalDuration">has temporal duration</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -1278,7 +1335,9 @@ The range of this property is not specified, so can be replaced by any specific 
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:hasTime">has time</h4>
 <table class="definition" style="width: 812px;">
 <thead>
@@ -1302,7 +1361,9 @@ The range of this property is not specified, so can be replaced by any specific 
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:hasTRS">temporal reference system used</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -1328,7 +1389,9 @@ The range of this property is not specified, so can be replaced by any specific 
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:hour">hour</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -1354,7 +1417,9 @@ The range of this property is not specified, so can be replaced by any specific 
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:hours">hours duration</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -1380,7 +1445,9 @@ The range of this property is not specified, so can be replaced by any specific 
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:inDateTime">in date-time description</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -1410,7 +1477,9 @@ The range of this property is not specified, so can be replaced by any specific 
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:inside">has time instant inside</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -1437,7 +1506,9 @@ intervals. </td>
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:inTemporalPosition">temporal position</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -1463,7 +1534,9 @@ intervals. </td>
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:intervalAfter">interval after</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -1502,7 +1575,9 @@ then the beginning of T<sub>1</sub> is after the end of T<sub>2</sub>. </td>
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:intervalBefore">interval before</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -1541,7 +1616,9 @@ then the end of T<sub>1</sub> is before the beginning of T<sub>2</sub>. </td>
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:intervalContains">interval contains</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -1573,7 +1650,9 @@ is after the end of T<sub>2</sub>. </td>
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:intervalDisjoint">interval disjoint</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -1601,7 +1680,9 @@ is before the beginning of T<sub>2</sub>, i.e. the intervals do not overlap in a
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:intervalDuring">interval during</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -1633,7 +1714,9 @@ is before the end of T<sub>2</sub>. </td>
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:intervalEquals">interval equals</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -1665,7 +1748,9 @@ the end of T<sub>2</sub>. </td>
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:intervalFinishedBy">interval finished by</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -1697,7 +1782,9 @@ is coincident with the end of T<sub>2</sub>. </td>
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:intervalFinishes">interval finishes</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -1733,7 +1820,9 @@ is coincident with the end of T<sub>2</sub>. </td>
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:intervalIn">interval in</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -1763,7 +1852,9 @@ is coincident with the end of T<sub>2</sub>. </td>
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:intervalMeets">interval meets</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -1794,7 +1885,9 @@ then the end of T<sub>1</sub> is coincident with the beginning of T<sub>2</sub>.
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:intervalMetBy">interval met by</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -1825,7 +1918,9 @@ then the beginning of T<sub>1</sub> is coincident with the end of T<sub>2</sub>.
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:intervalOverlappedBy">interval overlapped by</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -1857,7 +1952,9 @@ is before the end of T<sub>2</sub>, and the end of T<sub>1</sub> is after the en
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:intervalOverlaps">interval overlaps</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -1889,7 +1986,9 @@ is after the beginning of T<sub>2</sub>, and the end of T<sub>1</sub> is before 
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:intervalStartedBy">interval started by</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -1921,7 +2020,9 @@ after the end of T<sub>2</sub>. </td>
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:intervalStarts">interval starts</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -1957,7 +2058,9 @@ before the end of T<sub>2</sub>. </td>
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:inTimePosition">time position</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -1987,7 +2090,9 @@ before the end of T<sub>2</sub>. </td>
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:inXSDDate">in XSD date</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -2013,7 +2118,9 @@ before the end of T<sub>2</sub>. </td>
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:inXSDDateTime">in XSD date-time</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -2046,7 +2153,9 @@ before the end of T<sub>2</sub>. </td>
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:inXSDDateTimeStamp">in XSD date-time-stamp</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -2072,7 +2181,9 @@ before the end of T<sub>2</sub>. </td>
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:inXSDgYear">in XSD gYear</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -2098,7 +2209,9 @@ before the end of T<sub>2</sub>. </td>
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:inXSDgYearMonth">in XSD gYearMonth</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -2124,7 +2237,9 @@ before the end of T<sub>2</sub>. </td>
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:minute">minute</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -2150,7 +2265,9 @@ before the end of T<sub>2</sub>. </td>
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:minutes">minutes duration</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -2176,7 +2293,9 @@ before the end of T<sub>2</sub>. </td>
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:month">month</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -2200,7 +2319,9 @@ The range of this property is not specified, so can be replaced by any specific 
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:monthOfYear">month of year</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -2226,7 +2347,9 @@ The range of this property is not specified, so can be replaced by any specific 
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:months">months duration</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -2252,7 +2375,9 @@ The range of this property is not specified, so can be replaced by any specific 
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:nominalPosition">name of temporal position</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -2278,7 +2403,9 @@ The range of this property is not specified, so can be replaced by any specific 
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:numericDuration">numeric value of temporal duration</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -2304,7 +2431,9 @@ The range of this property is not specified, so can be replaced by any specific 
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:numericPosition">numeric value of temporal position</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -2330,7 +2459,9 @@ The range of this property is not specified, so can be replaced by any specific 
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:second">second</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -2356,7 +2487,9 @@ The range of this property is not specified, so can be replaced by any specific 
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:seconds">seconds duration</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -2382,7 +2515,9 @@ The range of this property is not specified, so can be replaced by any specific 
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:timeZone">in time zone</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -2413,7 +2548,9 @@ The range of this property is not specified, so can be replaced by any specific 
 is not ideal. We propose adding a stub class <code><a href="#time:TimeZone">:TimeZone</a></code> into the the main namespace (i.e. no
 properties) which can then be a super-class or equivalent class to any time zone formalization.(Compare with <a href="#time:">
 time:TRS</a> which is handled this way.) </p> -->
+</section>
 
+<section>
 <h4 id="time:unitType">temporal unit type</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -2439,7 +2576,9 @@ time:TRS</a> which is handled this way.) </p> -->
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:week">week</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -2465,7 +2604,9 @@ time:TRS</a> which is handled this way.) </p> -->
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:weeks">weeks duration</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -2491,7 +2632,9 @@ time:TRS</a> which is handled this way.) </p> -->
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:xsdDateTime">has XSD date-time</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -2525,7 +2668,9 @@ time:TRS</a> which is handled this way.) </p> -->
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:year">year</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -2549,7 +2694,9 @@ The range of this property is not specified, so can be replaced by any specific 
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:years">years duration</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -2575,6 +2722,7 @@ The range of this property is not specified, so can be replaced by any specific 
 </tr>
 </tbody>
 </table>
+</section>
 
 </section>
 
@@ -2588,6 +2736,7 @@ The range of this property is not specified, so can be replaced by any specific 
 <code><a href="#time:Number">:Number</a></code>
 </p>
 
+<section>
 <h4 id="time:generalDay">generalDay</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -2617,7 +2766,9 @@ processor cannot compute ordering relationships of values of this type. </td>
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:generalMonth">generalMonth</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -2647,7 +2798,9 @@ generic OWL2 processor cannot compute ordering relationships of values of this t
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:generalYear">generalYear</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -2676,7 +2829,9 @@ processor cannot compute ordering relationships of values of this type. </td>
 </tr>
 </tbody>
 </table>
+</section>
 
+<section>
 <h4 id="time:Number">Number</h4>
 <table class="definition" style="width: 812px;">
 <tbody>
@@ -2701,6 +2856,7 @@ processor cannot compute ordering relationships of values of this type. </td>
 <p>The datatype <code><a href="#time:Number">:Number</a></code> provides for numbers expressed using any of the XSD types <code><a href="https://www.w3.org/TR/xmlschema11-2/#decimal">xsd:decimal</a></code> (of
 which <code>xsd:integer</code> is a sub-type), <code><a href="https://www.w3.org/TR/xmlschema11-2/#float">xsd:float</a></code>, or <code><a href="https://www.w3.org/TR/xmlschema11-2/#double">xsd:double</a></code> (which allows
 exponential or scientific notation). </p>
+</section>
 
 </section>
 


### PR DESCRIPTION
ReSpec expects all headings to be within `<section>` tags and get confused when that's not the case.

Now, wrapping has two consequences: headings are now numbered, and they appear in the table of contents. Numbering seems a good feature to me. Now, if you prefer to keep a smaller Table of Contents, we can always add `maxTocLevel: 2` to ReSpec config to avoid listing these headings in the ToC.

See: https://tidoust.github.io/sdw/time/index.html to see the result of these changes.

The pull request also fixes a typo in the text.