### PR TITLE
Update ssn.ttl

### DIFF
--- a/ssn/ssn_separated/ssn.ttl
+++ b/ssn/ssn_separated/ssn.ttl
@@ -142,18 +142,11 @@ The Stimulus itself will be serving as a proxy for (see isProxyOf) some observab
             rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" .
 
 
-###  http://www.w3.org/ns/ssn/endTime
-ssn:endTime rdf:type owl:ObjectProperty ;
-			rdfs:comment "The end point of a time interval." ;
-            rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-            rdfs:label "end time" ;
-            rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Base#Time" .
-
 
 ###  http://www.w3.org/ns/ssn/featureOfInterest
 ssn:featureOfInterest rdf:type owl:ObjectProperty ;
                       dc:source """skos:exactMatch 'featureOfInterest' [O&M - ISO/DIS 19156] 
-		                    http://portal.opengeospatial.org/files/?artifact_id=41579""" ;
+                        http://portal.opengeospatial.org/files/?artifact_id=41579""" ;
                       rdfs:comment "A relation between an Observation and the entity whose quality was observed.   For example, in an observation of the weight of a person, the feature of interest is the person and the quality is weight." ;
                       rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
                       rdfs:label "feature of interest" ;
@@ -179,7 +172,7 @@ ssn:hasDeployment rdf:type owl:ObjectProperty ;
 ###  http://www.w3.org/ns/ssn/hasInput
 ssn:hasInput rdf:type owl:ObjectProperty ;
              rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-			 rdfs:comment "Relation between a Procedure and an Input to it." ;
+       rdfs:comment "Relation between a Procedure and an Input to it." ;
              rdfs:label "has input" ;
              rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Model#Process" .
 
@@ -223,7 +216,7 @@ ssn:hasOperatingRange rdf:type owl:ObjectProperty ;
 ###  http://www.w3.org/ns/ssn/hasOutput
 ssn:hasOutput rdf:type owl:ObjectProperty ;
               rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-			  rdfs:comment "Relation between a Procedure and an Output of it." ;
+        rdfs:comment "Relation between a Procedure and an Output of it." ;
               rdfs:label "has output" ;
               rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Model#Process" .
 
@@ -266,7 +259,7 @@ ssn:hasSurvivalRange rdf:type owl:ObjectProperty ;
 ###  http://www.w3.org/ns/ssn/hasValue
 ssn:hasValue rdf:type owl:ObjectProperty ;
              rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-			 rdfs:comment "Relation between a Sensor Output and it's Observation Value." ;
+       rdfs:comment "Relation between a Sensor Output and it's Observation Value." ;
              rdfs:label "has value" ;
              rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Base#Data" .
 
@@ -346,7 +339,7 @@ sosa:madeBySensor rdf:type owl:ObjectProperty ;
 ###  http://www.w3.org/ns/ssn/observationResult
 ssn:observationResult rdf:type owl:ObjectProperty ;
                       dc:source """skos:closeMatch 'result' [O&M - ISO/DIS 19156] 
-		                    http://portal.opengeospatial.org/files/?artifact_id=41579""" ;
+                        http://portal.opengeospatial.org/files/?artifact_id=41579""" ;
                       rdfs:comment "Relation linking an Observation (i.e., a description of the context, the Situation, in which the observation was made) and a Result, which contains a value representing the value associated with the observed Property." ;
                       rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
                       rdfs:label "observation result" ;
@@ -376,15 +369,15 @@ ssn:observationSamplingTime rdf:type owl:ObjectProperty ;
 ###  http://www.w3.org/ns/sosa/isObservedBy
 sosa:isObservedBy rdf:type owl:ObjectProperty ;
                rdfs:isDefinedBy "http://www.w3.org/ns/sosa" ;
-			   rdfs:comment "Relation between an Observation and the Sensor that observed it. Inverse of madeObservation." ;
-    		   rdfs:label "observed by" ;
+         rdfs:comment "Relation between an Observation and the Sensor that observed it. Inverse of madeObservation." ;
+           rdfs:label "observed by" ;
                rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton" .
 
 
 ###  http://www.w3.org/ns/ssn/observedProperty
 ssn:observedProperty rdf:type owl:ObjectProperty ;
                      dc:source """skos:exactMatch 'observedProperty' [O&M - ISO/DIS 19156] 
-		                    http://portal.opengeospatial.org/files/?artifact_id=41579""" ;
+                        http://portal.opengeospatial.org/files/?artifact_id=41579""" ;
                      rdfs:comment "Relation linking an Observation to the Property that was observed.  The observedProperty should be a Property (hasProperty) of the FeatureOfInterest (linked by featureOfInterest) of this observation." ;
                      rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
                      rdfs:label "observed property" ;
@@ -427,20 +420,13 @@ ssn:onPlatform rdf:type owl:ObjectProperty ;
 ssn:qualityOfObservation rdf:type owl:ObjectProperty ;
                          rdfs:subPropertyOf ssn:hasProperty ;
                          dc:source """skos:exactMatch 'resultQuality' [O&M - ISO/DIS 19156] 
-		                    http://portal.opengeospatial.org/files/?artifact_id=41579""" ;
+                        http://portal.opengeospatial.org/files/?artifact_id=41579""" ;
                          rdfs:comment "Relation linking an Observation to the adjudged quality of the result.  This is of course complimentary to the MeasurementCapability information recorded for the Sensor that made the Observation." ;
                          rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
                          rdfs:label "quality of observation" ;
                          rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Observation#Observation" .
 
 
-
-###  http://www.w3.org/ns/ssn/startTime
-ssn:startTime rdf:type owl:ObjectProperty ;
-              rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
-			  rdfs:comment "The start point of a time interval." ;
-              rdfs:label "start time" ;
-              rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Base#Time" .
 
 
 ### http://www.w3.org/ns/ssn/wasOriginatedBy
@@ -458,7 +444,7 @@ ssn:wasOriginatedBy rdf:type owl:ObjectProperty ;
 ssn:Accuracy rdf:type owl:Class ;
              rdfs:subClassOf ssn:MeasurementProperty ;
              dc:source """skos:exactMatch 'measurement accuracy/accuracy' [VIM 2.13] 
-		                    http://www.bipm.org/utils/common/documents/jcgm/JCGM_200_2008.pdf""" ;
+                        http://www.bipm.org/utils/common/documents/jcgm/JCGM_200_2008.pdf""" ;
              rdfs:comment "The closeness of agreement between the value of an observation and the true value of the observed quality." ;
              rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
              rdfs:label "Accuracy" ;
@@ -698,7 +684,7 @@ ssn:Observation rdf:type owl:Class ;
                                   owl:onClass ssn:Sensing
                                 ] ;
                 dc:source """skos:closeMatch 'observation' [O&M] 
-		                    http://www.opengeospatial.org/standards/om 
+                        http://www.opengeospatial.org/standards/om 
 
 Observation in this ontology and O&M are described differently (O&M records an observation as an act/event), but they record the same thing and are essentially interchangeable.  The difference is in the ontological structure of the two, not the data or use.
 
@@ -908,7 +894,7 @@ sosa:Sensor rdf:type owl:Class ;
 #  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:hasMeasurementCapability ; owl:allValuesFrom ssn:MeasurementCapability ] ;
 #  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:observes ; owl:allValuesFrom ssn:Property ] .
            dc:source """skos:exactMatch 'sensor' [SensorML OGC-0700]
-		                    http://www.opengeospatial.org/standards/sensorml 
+                        http://www.opengeospatial.org/standards/sensorml 
 
                                 skos:closeMatch 'observation procedure' [O&M] 
                                 http://www.opengeospatial.org/standards/om 


### PR DESCRIPTION
Removed the following triples:

###  http://www.w3.org/ns/ssn/startTime
ssn:startTime rdf:type owl:ObjectProperty ;
              rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
        rdfs:comment "The start point of a time interval." ;
              rdfs:label "start time" ;
              rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Base#Time" .

              ###  http://www.w3.org/ns/ssn/endTime
ssn:endTime rdf:type owl:ObjectProperty ;
      rdfs:comment "The end point of a time interval." ;
            rdfs:isDefinedBy "http://www.w3.org/ns/ssn" ;
            rdfs:label "end time" ;
            rdfs:seeAlso "http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Base#Time" .