### PR TITLE
Mimic Result to define Command

### DIFF
--- a/ssn/integrated/sosa.ttl
+++ b/ssn/integrated/sosa.ttl
@@ -414,3 +414,52 @@ sosa:phenomenonTime a owl:ObjectProperty ;
   schema:domainIncludes sosa:Sampling ;
   schema:rangeIncludes time:TemporalEntity ;
   rdfs:isDefinedBy sosa: .
+
+
+## Command - feature at risk
+
+sosa:Command a rdfs:Class , owl:Class ;
+  rdfs:label "Command"@en ;
+  skos:definition "The Command of an Actuation, or act of Sampling. To store a simple command value one can use the hasSimpleCommand property."@en ;
+  rdfs:comment "The Command of an Actuation, or act of Sampling. To store a simple command value one can use the hasSimpleCommand property."@en ;
+  skos:example "The value 20 as the commanded temperature for a radiator together with the unit, e.g., Degree Celsius."@en ;
+  rdfs:isDefinedBy sosa: .
+
+  sosa:hasCommand a owl:ObjectProperty ;
+    rdfs:label "has command"@en ;
+    skos:definition "Relation linking an Actuation, or Sampling and a Command."@en ;
+    rdfs:comment "Relation linking an Actuation, or Sampling and a Command."@en ;
+    schema:domainIncludes sosa:Actuation ;
+    schema:domainIncludes sosa:Sampling ;
+    schema:rangeIncludes sosa:Command  ;
+    owl:inverseOf sosa:isCommandOf ;
+    rdfs:isDefinedBy sosa: .
+
+  sosa:isCommandOf a owl:ObjectProperty ;
+    rdfs:label "is command of"@en ;
+    skos:definition "Relation linking a Command to the Actuation, or Sampling, that used it as input."@en ;
+    rdfs:coment "Relation linking a Command to the Actuation, or Sampling, that used it as input."@en ;
+    schema:domainIncludes sosa:Result ;
+    schema:rangeIncludes sosa:Actuation ;
+    schema:rangeIncludes sosa:Sampling ;
+    owl:inverseOf sosa:hasCommand ;
+    rdfs:isDefinedBy sosa: .
+
+  sosa:hasSimpleCommand a owl:DatatypeProperty ;
+    rdfs:label "has simple command"@en ;
+    skos:definition "Relation linking an Actuation, or Sampling and a simple Command."@en ;
+    rdfs:comment "Relation linking an Actuation, or Sampling and a simple Command."@en ;
+    skos:example "For instance, the values 23 or true."@en ;
+    schema:domainIncludes sosa:Actuation ;
+    schema:domainIncludes sosa:Sampling ;
+    rdfs:isDefinedBy sosa: .
+
+sosa:commandTime a owl:DatatypeProperty ;
+  rdfs:label "command time"@en ;
+  skos:definition "The command time is the time when the Actuation or act of Sampling was started."@en ;
+  rdfs:comment "The command time is the time when the Actuation or act of Sampling was started."@en ;
+  schema:domainIncludes sosa:Actuation ;
+  schema:domainIncludes sosa:Observation ;
+  schema:domainIncludes sosa:Sampling ;
+  rdfs:range xsd:dateTime ;
+  rdfs:isDefinedBy sosa: .

--- a/ssn/integrated/ssn.ttl
+++ b/ssn/integrated/ssn.ttl
@@ -250,11 +250,13 @@ sosa:Actuation a owl:Class ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:actsOnProperty ; owl:minCardinality "1"^^xsd:nonNegativeInteger ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasResult ; owl:minCardinality "1"^^xsd:nonNegativeInteger ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:resultTime ; owl:cardinality "1"^^xsd:nonNegativeInteger ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:commandTime ; owl:cardinality "1"^^xsd:nonNegativeInteger ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:usedProcedure ; owl:allValuesFrom sosa:Procedure ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasFeatureOfInterest ; owl:allValuesFrom sosa:FeatureOfInterest ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:actuationMadeBy ; owl:allValuesFrom sosa:Actuator ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:actsOnProperty ; owl:allValuesFrom sosa:ActuatableProperty ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasResult ; owl:allValuesFrom sosa:Result ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasCommand ; owl:allValuesFrom sosa:Command ] ;
   rdfs:isDefinedBy sosa: .
 
   sosa:madeActuation
@@ -275,9 +277,11 @@ sosa:Sampling a owl:Class ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasFeatureOfInterest ; owl:cardinality "1"^^xsd:nonNegativeInteger ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasResultingSample ; owl:minCardinality "1"^^xsd:nonNegativeInteger ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:resultTime ; owl:cardinality "1"^^xsd:nonNegativeInteger ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:commandTime ; owl:cardinality "1"^^xsd:nonNegativeInteger ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:usedProcedure ; owl:allValuesFrom sosa:Procedure ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasFeatureOfInterest ; owl:allValuesFrom sosa:FeatureOfInterest ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:madeBySampler ; owl:allValuesFrom sosa:Sampler ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasCommand ; owl:allValuesFrom sosa:Command ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasResult ; owl:allValuesFrom sosa:Result ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasResultingSample ; owl:allValuesFrom sosa:Sample ] ;
   rdfs:isDefinedBy sosa: .
@@ -355,6 +359,24 @@ sosa:Result
     rdfs:comment "Relation linking an Observation to the adjudged quality of the Result. This is complimentary to the MeasurementCapability information recorded for the Sensor that made the Observation."@en ;
     rdfs:subPropertyOf ssn:hasProperty ;
     rdfs:isDefinedBy ssn: .
+
+## Command - Feature at risk
+
+sosa:Command
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty [ owl:inverseOf sosa:isCommandOf ] ; owl:minCardinality "1"^^xsd:nonNegativeInteger ] ;
+  rdfs:isDefinedBy sosa: .
+
+  sosa:hasCommand 
+    rdfs:isDefinedBy sosa: .
+
+  sosa:isCommandOf
+    rdfs:isDefinedBy sosa: .
+
+  sosa:hasSimpleCommand 
+    rdfs:isDefinedBy sosa: .
+
+  sosa:commandTime
+    rdfs:isDefinedBy sosa: .
 
 
 ## Systems
@@ -502,8 +524,8 @@ ssn:hasSystemCapability a owl:ObjectProperty ;
 
     ssn:Accuracy a owl:Class ;
       rdfs:label "Accuracy"@en ;
-      skos:definition "The closeness of agreement between the Result of an Observation (resp. the command of an Actuation) and the true value of the observed ObservableProperty (resp. of the acted on ActuatableProperty) under the defined Conditions."@en ;
-      rdfs:comment "The closeness of agreement between the Result of an Observation (resp. the command of an Actuation) and the true value of the observed ObservableProperty (resp. of the acted on ActuatableProperty) under the defined Conditions."@en ;
+      skos:definition "The closeness of agreement between the Result of an Observation (resp. the Command of an Actuation) and the true value of the observed ObservableProperty (resp. of the acted on ActuatableProperty) under the defined Conditions."@en ;
+      rdfs:comment "The closeness of agreement between the Result of an Observation (resp. the Command of an Actuation) and the true value of the observed ObservableProperty (resp. of the acted on ActuatableProperty) under the defined Conditions."@en ;
       rdfs:subClassOf ssn:SystemProperty ;
       rdfs:isDefinedBy ssn: .
 
@@ -535,8 +557,8 @@ ssn:hasSystemCapability a owl:ObjectProperty ;
 
     ssn:Latency a owl:Class ;
       rdfs:label "Latency"@en ;
-      skos:definition "The time between a command for an Observation (resp. Actuation) and the Sensor providing a Result (resp. the Actuator operating the Actuation), under the defined Conditions."@en ;
-      rdfs:comment "The time between a command for an Observation (resp. Actuation) and the Sensor providing a Result (resp. the Actuator operating the Actuation), under the defined Conditions."@en ;
+      skos:definition "The time between a Command for an Observation (resp. Actuation) and the Sensor providing a Result (resp. the Actuator operating the Command), under the defined Conditions."@en ;
+      rdfs:comment "The time between a Command for an Observation (resp. Actuation) and the Sensor providing a Result (resp. the Actuator operating the Command), under the defined Conditions."@en ;
       rdfs:subClassOf ssn:SystemProperty ;
       rdfs:isDefinedBy ssn: .
 
@@ -552,10 +574,10 @@ ssn:hasSystemCapability a owl:ObjectProperty ;
       rdfs:label "Resolution"@en ;
       skos:definition """As a Sensor Property: the smallest difference in the value of a Property being observed that would result in perceptably different values of Observation Results, under the defined Conditions.
 
-      As an Actuator Property: the smallest difference in the value of an Actuation command that would result in a value change of the ActuatableProperty being acted on, under the defined Conditions."""@en ;
+      As an Actuator Property: the smallest difference in the value of an Command that would result in a value change of the ActuatableProperty being acted on, under the defined Conditions."""@en ;
       rdfs:comment """As a Sensor Property: the smallest difference in the value of a Property being observed that would result in perceptably different values of Observation Results, under the defined Conditions. 
 
-      As an Actuator Property: the smallest difference in the value of an Actuation command that would result in a value change of the ActuatableProperty being acted on, under the defined Conditions."""@en ;
+      As an Actuator Property: the smallest difference in the value of an Command that would result in a value change of the ActuatableProperty being acted on, under the defined Conditions."""@en ;
       rdfs:subClassOf ssn:SystemProperty ;
       rdfs:isDefinedBy ssn: .
 


### PR DESCRIPTION
See also https://lists.w3.org/Archives/Public/public-sdw-wg/2017Apr/0188.html 

-> sosa:Command, sosa:hasCommand, sosa:isCommandOf, sosa:hasSimpleCommand, sosa:commandTime

I marked all these terms as "Features at Risk", meaning they may be removed in case implementation evidence is not sufficient.