### PR TITLE
harmonized URIs for alignment modules

### DIFF
--- a/ssn/index.html
+++ b/ssn/index.html
@@ -369,7 +369,7 @@ their usage are given.</p>
     <ul>
     <li>The new SSN streamlines the relations (and need for) the old Device, Platform, and Systems classes.</li>
     <li>The old SSN was perceived as too heavyweight (on its axiomatization) and too dependent on OWL reasoning by some users. To strike a balance, DL expressivity of the new lightweight SOSA ontology is ALI(D) which is efficiently supported by modern triple stores, while the new SSN is ALRIN(D). In contrast, the old SSN is SRIQ.</li>
-    <li>The SSN previously imported the Dolce-UltraLite ontology (DUL) and many SSN terms inherited from DUL terms. Due to frequent user requests, this has been redesigned so that SSN (and SOSA) can be used entirely independently of DUL if desired. Some of the alignments with DUL have been reconsidered. Those parts of SSN that use DUL terms have been separated into the <a href="http://www.w3.org/ns/ssn/dul/">SSN Alignment with DUL ontology.</a> This alignment and therefore the role of DUL in SSN have been declared non-normative.</li>
+    <li>The SSN previously imported the Dolce-UltraLite ontology (DUL) and many SSN terms inherited from DUL terms. Due to frequent user requests, this has been redesigned so that SSN (and SOSA) can be used entirely independently of DUL if desired. Some of the alignments with DUL have been reconsidered. Those parts of SSN that use DUL terms have been separated into the <a href="http://www.w3.org/ns/ssn/dul">SSN Alignment with DUL ontology.</a> This alignment and therefore the role of DUL in SSN have been declared non-normative.</li>
     <li>The definitions for many classes and properties have changed slightly to improve explanation or to correct minor errors. Examples have been separated from the main definitions.</li>
     <li>The initial SSN has been criticized for its partially inconsistent handling of virtual sensors (including software and simulations) and related classes and properties. The new SSN and SOSA address this issue by allowing all major classes to be virtual, and to better support humans and other animals as agents.</li>
     <li>The notion of Procedure (formerly Plan) has been clarified to describe a workflow, protocol, plan, algorithm, or computational method specifying how to make an Observation, create a Sample, or make a change to the state of the world via an Actuator.</li>
@@ -3840,7 +3840,7 @@ their usage are given.</p>
         SSN users wishing to interoperate with other DUL-aligned ontologies. It also 
         will be imported to the alignment module of the previous SSN to the current one. Note that it can be used independent to the previous version
         of SSN to align with more generic concepts/properties of DUL alone.</p>
-      The Dolce-Ultralite alignment, known as "ssn-dul" is available at <a href="http://www.w3.org/ns/ssn/dul/">http://www.w3.org/ns/ssn/dul/</a>.
+      The Dolce-Ultralite alignment, known as "ssn-dul" is available at <a href="http://www.w3.org/ns/ssn/dul">http://www.w3.org/ns/ssn/dul</a>.
       <p></p>
       <section id="DULAlignment" class="informative">
         <h3>Namespaces</h3>

--- a/ssn/integrated/catalog-v001.xml
+++ b/ssn/integrated/catalog-v001.xml
@@ -4,6 +4,6 @@
         <uri id="sosa" name="http://www.w3.org/ns/sosa/" uri="sosa.ttl"/>
         <uri id="ssn" name="http://www.w3.org/ns/ssn/" uri="ssn.ttl"/>
         <uri id="ssnx" name="http://purl.oclc.org/NET/ssnx/ssn" uri="ssnx.ttl"/>
-        <uri id="ssn-dul" name="https://www.w3.org/ns/ssn-dul/" uri="ssn-dul.ttl"/>
+        <uri id="ssn-dul" name="http://www.w3.org/ns/ssn/dul" uri="ssn-dul.ttl"/>
     </group>
 </catalog>

--- a/ssn/integrated/proposed-server-specification.md
+++ b/ssn/integrated/proposed-server-specification.md
@@ -258,7 +258,7 @@ Basic hash-based content-negotiation.
 
 ## SSN-DUL
 
-*URI:* https://www.w3.org/ns/ssn/dul/
+*URI:* http://www.w3.org/ns/ssn/dul
 
 *Version to use for publication:* http://w3c.github.io/sdw/ssn/integrated/ssn-dul.ttl
 
@@ -268,20 +268,20 @@ Basic hash-based content-negotiation.
 
 *HTML representation:* 
 
-When operating a GET at https://www.w3.org/ns/ssn/dul/ with a Accept header that is compatible with `text/html`, 303 redirect to https://www.w3.org/TR/vocab-ssn/#DUL_Alignment
+When operating a GET at http://www.w3.org/ns/ssn/dul with a Accept header that is compatible with `text/html`, 303 redirect to https://www.w3.org/TR/vocab-ssn/#DUL_Alignment
 
 
 *RDF/XML representation:* 
 
-When operating a GET at https://www.w3.org/ns/ssn/dul/ with a Accept header that is compatible with `application/rdf+xml`, serve ssn-dul.rdf, with headers:
+When operating a GET at http://www.w3.org/ns/ssn/dul with a Accept header that is compatible with `application/rdf+xml`, serve ssn-dul.rdf, with headers:
 
 ```
 Content-Type: application/rdf+xml
-Content-Location: https://www.w3.org/ns/ssn/dul/ssn-dul.rdf
+Content-Location: http://www.w3.org/ns/ssn/dul/ssn-dul.rdf
 Content-Disposition: filename= ssn-dul.rdf;
 ```
 
-When operating a GET at https://www.w3.org/ns/ssn/dul/ssn-dul.rdf with a Accept header that is compatible with `application/rdf+xml`, serve ssn-dul.rdf, with headers:
+When operating a GET at http://www.w3.org/ns/ssn/dul/ssn-dul.rdf with a Accept header that is compatible with `application/rdf+xml`, serve ssn-dul.rdf, with headers:
 
 ```
 Content-Type: application/rdf+xml
@@ -290,15 +290,15 @@ Content-Disposition: filename= ssn-dul.rdf;
 
 *Turtle representation:* 
 
-When operating a GET at https://www.w3.org/ns/ssn/dul/ with a Accept header that is compatible with `text/turtle`, serve ssn-dul.ttl, with headers:
+When operating a GET at http://www.w3.org/ns/ssn/dul with a Accept header that is compatible with `text/turtle`, serve ssn-dul.ttl, with headers:
 
 ```
 Content-Type: text/turtle
-Content-Location: https://www.w3.org/ns/ssn/dul/ssn-dul.ttl
+Content-Location: http://www.w3.org/ns/ssn/dul/ssn-dul.ttl
 Content-Disposition: filename= ssn-dul.ttl;
 ```
 
-When operating a GET at https://www.w3.org/ns/ssn/dul/ssn-dul.ttl with a Accept header that is compatible with `text/turtle`, serve ssn.ttl, with headers:
+When operating a GET at http://www.w3.org/ns/ssn/dul/ssn-dul.ttl with a Accept header that is compatible with `text/turtle`, serve ssn.ttl, with headers:
 
 ```
 Content-Type: text/turtle
@@ -320,20 +320,20 @@ Content-Disposition: filename= ssn-dul.ttl;
 
 *HTML representation:* 
 
-When operating a GET at https://www.w3.org/ns/sosa/om with a Accept header that is compatible with `text/html`, 303 redirect to https://www.w3.org/TR/vocab-ssn/#OM_Alignment
+When operating a GET at http://www.w3.org/ns/sosa/om with a Accept header that is compatible with `text/html`, 303 redirect to https://www.w3.org/TR/vocab-ssn/#OM_Alignment
 
 
 *RDF/XML representation:* 
 
-When operating a GET at https://www.w3.org/ns/sosa/om with a Accept header that is compatible with `application/rdf+xml`, serve sosa-om-mapping.rdf, with headers:
+When operating a GET at http://www.w3.org/ns/sosa/om with a Accept header that is compatible with `application/rdf+xml`, serve sosa-om-mapping.rdf, with headers:
 
 ```
 Content-Type: application/rdf+xml
-Content-Location: https://www.w3.org/ns/sosa/om.rdf
+Content-Location: http://www.w3.org/ns/sosa/om.rdf
 Content-Disposition: filename= sosa-om.rdf;
 ```
 
-When operating a GET at https://www.w3.org/ns/sosa/om.rdf with a Accept header that is compatible with `application/rdf+xml`, serve sosa-om-mapping.rdf, with headers:
+When operating a GET at http://www.w3.org/ns/sosa/om.rdf with a Accept header that is compatible with `application/rdf+xml`, serve sosa-om-mapping.rdf, with headers:
 
 ```
 Content-Type: application/rdf+xml
@@ -342,15 +342,15 @@ Content-Disposition: filename= sosa-om.rdf;
 
 *Turtle representation:* 
 
-When operating a GET at https://www.w3.org/ns/sosa/om with a Accept header that is compatible with `text/turtle`, serve sosa-om-mapping.ttl, with headers:
+When operating a GET at http://www.w3.org/ns/sosa/om with a Accept header that is compatible with `text/turtle`, serve sosa-om-mapping.ttl, with headers:
 
 ```
 Content-Type: text/turtle
-Content-Location: https://www.w3.org/ns/sosa/om.ttl
+Content-Location: http://www.w3.org/ns/sosa/om.ttl
 Content-Disposition: filename= sosa-om.ttl;
 ```
 
-When operating a GET at https://www.w3.org/ns/sosa/om.ttl with a Accept header that is compatible with `text/turtle`, serve sosa-om-mapping.ttl, with headers:
+When operating a GET at http://www.w3.org/ns/sosa/om.ttl with a Accept header that is compatible with `text/turtle`, serve sosa-om-mapping.ttl, with headers:
 
 ```
 Content-Type: text/turtle
@@ -370,20 +370,20 @@ Content-Disposition: filename= sosa-om.ttl;
 
 *HTML representation:* 
 
-When operating a GET at https://www.w3.org/ns/sosa/oboe with a Accept header that is compatible with `text/html`, 303 redirect to https://www.w3.org/TR/vocab-ssn/#OBOE_Alignment
+When operating a GET at http://www.w3.org/ns/sosa/oboe with a Accept header that is compatible with `text/html`, 303 redirect to https://www.w3.org/TR/vocab-ssn/#OBOE_Alignment
 
 
 *RDF/XML representation:* 
 
-When operating a GET at https://www.w3.org/ns/sosa/oboe with a Accept header that is compatible with `application/rdf+xml`, serve sosa-oboe-mapping.rdf, with headers:
+When operating a GET at http://www.w3.org/ns/sosa/oboe with a Accept header that is compatible with `application/rdf+xml`, serve sosa-oboe-mapping.rdf, with headers:
 
 ```
 Content-Type: application/rdf+xml
-Content-Location: https://www.w3.org/ns/sosa/oboe.rdf
+Content-Location: http://www.w3.org/ns/sosa/oboe.rdf
 Content-Disposition: filename= sosa-oboe.rdf;
 ```
 
-When operating a GET at https://www.w3.org/ns/sosa/oboe.rdf with a Accept header that is compatible with `application/rdf+xml`, serve sosa-oboe-mapping.rdf, with headers:
+When operating a GET at http://www.w3.org/ns/sosa/oboe.rdf with a Accept header that is compatible with `application/rdf+xml`, serve sosa-oboe-mapping.rdf, with headers:
 
 ```
 Content-Type: application/rdf+xml
@@ -392,15 +392,15 @@ Content-Disposition: filename= sosa-oboe.rdf;
 
 *Turtle representation:* 
 
-When operating a GET at https://www.w3.org/ns/sosa/oboe with a Accept header that is compatible with `text/turtle`, serve sosa-oboe-mapping.ttl, with headers:
+When operating a GET at http://www.w3.org/ns/sosa/oboe with a Accept header that is compatible with `text/turtle`, serve sosa-oboe-mapping.ttl, with headers:
 
 ```
 Content-Type: text/turtle
-Content-Location: https://www.w3.org/ns/sosa/oboe.ttl
+Content-Location: http://www.w3.org/ns/sosa/oboe.ttl
 Content-Disposition: filename= sosa-oboe.ttl;
 ```
 
-When operating a GET at https://www.w3.org/ns/sosa/oboe.ttl with a Accept header that is compatible with `text/turtle`, serve sosa-oboe-mapping.ttl, with headers:
+When operating a GET at http://www.w3.org/ns/sosa/oboe.ttl with a Accept header that is compatible with `text/turtle`, serve sosa-oboe-mapping.ttl, with headers:
 
 ```
 Content-Type: text/turtle
@@ -410,7 +410,7 @@ Content-Disposition: filename= sosa-oboe.ttl;
 
 ## SOSA-PROV
 
-*URI:* https://www.w3.org/ns/sosa-prov
+*URI:* http://www.w3.org/ns/sosa/prov
 
 *Version to use for publication:* http://w3c.github.io/sdw/ssn/rdf/sosa-prov-mapping.ttl
 
@@ -420,20 +420,20 @@ Content-Disposition: filename= sosa-oboe.ttl;
 
 *HTML representation:* 
 
-When operating a GET at https://www.w3.org/ns/sosa-prov with a Accept header that is compatible with `text/html`, 303 redirect to https://www.w3.org/TR/vocab-ssn/#PROV_Alignment
+When operating a GET at http://www.w3.org/ns/sosa/prov with a Accept header that is compatible with `text/html`, 303 redirect to https://www.w3.org/TR/vocab-ssn/#PROV_Alignment
 
 
 *RDF/XML representation:* 
 
-When operating a GET at https://www.w3.org/ns/sosa-prov with a Accept header that is compatible with `application/rdf+xml`, serve sosa-prov-mapping.rdf, with headers:
+When operating a GET at http://www.w3.org/ns/sosa/prov with a Accept header that is compatible with `application/rdf+xml`, serve sosa-prov-mapping.rdf, with headers:
 
 ```
 Content-Type: application/rdf+xml
-Content-Location: https://www.w3.org/ns/sosa-prov.rdf
+Content-Location: http://www.w3.org/ns/sosa/prov.rdf
 Content-Disposition: filename= sosa-prov.rdf;
 ```
 
-When operating a GET at https://www.w3.org/ns/sosa-prov.rdf with a Accept header that is compatible with `application/rdf+xml`, serve sosa-prov-mapping.rdf, with headers:
+When operating a GET at http://www.w3.org/ns/sosa/prov.rdf with a Accept header that is compatible with `application/rdf+xml`, serve sosa-prov-mapping.rdf, with headers:
 
 ```
 Content-Type: application/rdf+xml
@@ -442,15 +442,15 @@ Content-Disposition: filename= sosa-prov.rdf;
 
 *Turtle representation:* 
 
-When operating a GET at https://www.w3.org/ns/sosa-prov with a Accept header that is compatible with `text/turtle`, serve sosa-prov-mapping.ttl, with headers:
+When operating a GET at http://www.w3.org/ns/sosa/prov with a Accept header that is compatible with `text/turtle`, serve sosa-prov-mapping.ttl, with headers:
 
 ```
 Content-Type: text/turtle
-Content-Location: https://www.w3.org/ns/sosa-prov.ttl
+Content-Location: http://www.w3.org/ns/sosa/prov.ttl
 Content-Disposition: filename= sosa-prov.ttl;
 ```
 
-When operating a GET at https://www.w3.org/ns/sosa-prov.ttl with a Accept header that is compatible with `text/turtle`, serve sosa-prov-mapping.ttl, with headers:
+When operating a GET at http://www.w3.org/ns/sosa/prov.ttl with a Accept header that is compatible with `text/turtle`, serve sosa-prov-mapping.ttl, with headers:
 
 ```
 Content-Type: text/turtle

--- a/ssn/integrated/ssn-dul.ttl
+++ b/ssn/integrated/ssn-dul.ttl
@@ -11,7 +11,7 @@
 @prefix sosa: <http://www.w3.org/ns/sosa/> .
 @prefix ssn: <http://www.w3.org/ns/ssn/> .
 
-<https://www.w3.org/ns/ssn/dul/> rdf:type owl:Ontology ;
+<http://www.w3.org/ns/ssn/dul> rdf:type owl:Ontology ;
   owl:imports <http://www.ontologydesignpatterns.org/ont/dul/DUL.owl> ;
   owl:imports ssn: .
 

--- a/ssn/integrated/ssnx.ttl
+++ b/ssn/integrated/ssnx.ttl
@@ -48,7 +48,7 @@ time:TemporalEntity a owl:Class .
   rdfs:seeAlso <http://www.w3.org/2005/Incubator/ssn/> ;
   owl:imports ssn: ;
   owl:imports <http://www.ontologydesignpatterns.org/ont/dul/DUL.owl> ;
-  owl:imports <https://www.w3.org/ns/ssn-dul/> .
+  owl:imports <http://www.w3.org/ns/ssn/dul> .
 
 
 ## Features of interest and observable property

--- a/ssn/rdf/documentation_examples/sosa-core_examples.ttl
+++ b/ssn/rdf/documentation_examples/sosa-core_examples.ttl
@@ -1,18 +1,18 @@
-# baseURI: https://www.w3.org/ns/sosa/examples
-# imports: https://www.w3.org/ns/sosa
+# baseURI: http://www.w3.org/ns/sosa/examples
+# imports: http://www.w3.org/ns/sosa
 
-@prefix examples: <https://www.w3.org/ns/sosa/examples#> .
+@prefix examples: <http://www.w3.org/ns/sosa/examples#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix sosa-core: <https://www.w3.org/ns/sosa#> .
+@prefix sosa-core: <http://www.w3.org/ns/sosa#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://www.w3.org/ns/sosa/examples>
+<http://www.w3.org/ns/sosa/examples>
   rdf:type owl:Ontology ;
-  owl:imports <https://www.w3.org/ns/sosa> ;
+  owl:imports <http://www.w3.org/ns/sosa> ;
 .
-<https://www.w3.org/ns/sosa/examples#4830EH_UCSB>
+<http://www.w3.org/ns/sosa/examples#4830EH_UCSB>
   rdf:type sosa-core:Sample ;
   rdfs:comment "Instead of measuring temperature at every single office, we select room 4830 Ellison Hall, UCSB as a sample and thereby assume that the temperature observed there is a good proxy for the temperatures in other offices."^^xsd:string ;
   rdfs:label "4830 Ellison Hall"^^xsd:string ;
@@ -35,7 +35,7 @@ examples:TempObservation1
   rdfs:comment "Not yet linked through to the platform or sensor. ---> (kj). Yes, this will be 'linked' via SPARQL queries and possible via future axioms outside of SOSA-core. There is no need to habve explicit relations between anything and everything. Also, keep in mind that this is all under the OWA."^^xsd:string ;
   rdfs:label "Temperature observation 1."^^xsd:string ;
   sosa-core:madeBySensor examples:TempSensorS4_23;
-  sosa-core:hasFeatureOfInterest <https://www.w3.org/ns/sosa/examples#4830EH_UCSB> ;
+  sosa-core:hasFeatureOfInterest <http://www.w3.org/ns/sosa/examples#4830EH_UCSB> ;
   sosa-core:hasResult examples:TempObservationResult1 ;
   sosa-core:resultTime "2016-08-10T08:30:00"^^xsd:dateTime ;
   sosa-core:usedProcedure examples:RoomTemperature ;
@@ -56,7 +56,7 @@ examples:TempObservation2
   rdfs:comment "A temperature observation created using the SamsungGalaxyS4_23."^^xsd:string ;
   rdfs:label "Temperature observation 2. We usue this here to demonstrate that all room temperature observations use the same procedure."^^xsd:string ;
   sosa-core:madeBySensor examples:TempSensorS4_23;
-  sosa-core:hasFeatureOfInterest <https://www.w3.org/ns/sosa/examples#4830EH_UCSB> ;
+  sosa-core:hasFeatureOfInterest <http://www.w3.org/ns/sosa/examples#4830EH_UCSB> ;
   sosa-core:hasResult examples:TempObservationResult2 ;
   sosa-core:resultTime "2016-08-10T09:33:00"^^xsd:dateTime ;
   sosa-core:usedProcedure examples:RoomTemperature ;

--- a/ssn/rdf/sosa-bfo-mapping.ttl
+++ b/ssn/rdf/sosa-bfo-mapping.ttl
@@ -1,8 +1,8 @@
-# baseURI: https://www.w3.org/ns/sosa-bfo
+# baseURI: http://www.w3.org/ns/sosa/bfo
 # imports: http://purl.obolibrary.org/obo/bfo.owl
-# imports: https://www.w3.org/ns/sosa-om
-# imports: https://www.w3.org/ns/sosa-sam
-# imports: https://www.w3.org/ns/sosa-sn
+# imports: http://www.w3.org/ns/sosa/om
+# imports: http://www.w3.org/ns/sosa/sam
+# imports: http://www.w3.org/ns/sosa/sn
 
 @prefix bfo: <http://purl.obolibrary.org/obo/bfo.owl#> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
@@ -10,10 +10,10 @@
 @prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix sosa-core: <https://www.w3.org/ns/sosa#> .
-@prefix sosa-om: <https://www.w3.org/ns/sosa-om#> .
-@prefix sosa-sam: <https://www.w3.org/ns/sosa-sam#> .
-@prefix sosa-sn: <https://www.w3.org/ns/sosa-sn#> .
+@prefix sosa-core: <http://www.w3.org/ns/sosa#> .
+@prefix sosa-om: <http://www.w3.org/ns/sosa/om#> .
+@prefix sosa-sam: <http://www.w3.org/ns/sosa/sam#> .
+@prefix sosa-sn: <http://www.w3.org/ns/sosa/sn#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 sosa-core:ObservableProperty
@@ -22,12 +22,12 @@ sosa-core:ObservableProperty
 sosa-core:Observation
   rdfs:subClassOf obo:BFO_0000003 ;
 .
-<https://www.w3.org/ns/sosa-bfo>
+<http://www.w3.org/ns/sosa/bfo>
   rdf:type owl:Ontology ;
   owl:imports <http://purl.obolibrary.org/obo/bfo.owl> ;
-  owl:imports <https://www.w3.org/ns/sosa-om> ;
-  owl:imports <https://www.w3.org/ns/sosa-sam> ;
-  owl:imports <https://www.w3.org/ns/sosa-sn> ;
+  owl:imports <http://www.w3.org/ns/sosa/om> ;
+  owl:imports <http://www.w3.org/ns/sosa/sam> ;
+  owl:imports <http://www.w3.org/ns/sosa/sn> ;
 .
 sosa-sam:GeometryObject
   rdfs:subClassOf obo:BFO_0000006 ;

--- a/ssn/rdf/sosa-oboe-mapping.ttl
+++ b/ssn/rdf/sosa-oboe-mapping.ttl
@@ -1,4 +1,4 @@
-# baseURI: http://www.w3.org/ns/sosa/sosa-oboe/
+# baseURI: http://www.w3.org/ns/sosa/oboe#
 # imports: http://ecoinformatics.org/oboe/oboe.1.0/oboe-core.owl
 # imports: http://www.w3.org/ns/sosa/
 
@@ -9,7 +9,6 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sosa: <http://www.w3.org/ns/sosa/> .
-@prefix sosa-oboe: <http://www.w3.org/ns/sosa/sosa-oboe#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 oboe-core:Characteristic
@@ -54,7 +53,7 @@ sosa:hasFeatureOfInterest
       oboe-core:ofEntity
     ) ;
 .
-<http://www.w3.org/ns/sosa/sosa-oboe/>
+<http://www.w3.org/ns/sosa/oboe>
   rdf:type owl:Ontology ;
   dc:creator "Simon J D COX" ;
   dct:created "2017-03-05"^^xsd:date ;

--- a/ssn/rdf/sosa-prov-mapping.ttl
+++ b/ssn/rdf/sosa-prov-mapping.ttl
@@ -1,4 +1,4 @@
-# baseURI: https://www.w3.org/ns/sosa/prov
+# baseURI: http://www.w3.org/ns/sosa/prov
 # imports: http://www.w3.org/ns/prov-o#
 # imports: http://www.w3.org/ns/sosa/
 
@@ -9,7 +9,7 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sosa: <http://www.w3.org/ns/sosa/> .
-@prefix sp: <https://www.w3.org/ns/sosa/prov/> .
+@prefix sosa-prov: <http://www.w3.org/ns/sosa/prov#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 sosa:Actuation
@@ -77,11 +77,11 @@ sosa:resultTime
 .
 sosa:usedProcedure
   owl:propertyChainAxiom (
-      sp:eventAssociation
-      sp:hadProcedure
+      sosa-prov:eventAssociation
+      sosa-prov:hadProcedure
     ) ;
 .
-<https://www.w3.org/ns/sosa-prov>
+<http://www.w3.org/ns/sosa/prov>
   rdf:type owl:Ontology ;
   dc:creator "Simon J D Cox" ;
   dcterms:created "2016-12-14"^^xsd:date ;
@@ -91,7 +91,7 @@ sosa:usedProcedure
   owl:imports <http://www.w3.org/ns/prov-o#> ;
   owl:imports sosa: ;
 .
-sp:eventAssociation
+sosa-prov:eventAssociation
   rdf:type owl:ObjectProperty ;
   rdfs:domain [
       rdf:type owl:Class ;
@@ -103,7 +103,7 @@ sp:eventAssociation
     ] ;
   rdfs:subPropertyOf prov:qualifiedAssociation ;
 .
-sp:hadProcedure
+sosa-prov:hadProcedure
   rdf:type owl:ObjectProperty ;
   rdfs:range sosa:Procedure ;
   rdfs:subPropertyOf prov:hadPlan ;

--- a/ssn/ssn_separated/dul-alignment.ttl
+++ b/ssn/ssn_separated/dul-alignment.ttl
@@ -1,4 +1,4 @@
-@prefix : <https://www.w3.org/ns/ssn/dul#> .
+@prefix : <http://www.w3.org/ns/ssn/dul#> .
 @prefix dul: <http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -6,9 +6,9 @@
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@base <https://www.w3.org/ns/ssn/dul> .
+@base <http://www.w3.org/ns/ssn/dul> .
 
-<https://www.w3.org/ns/ssn/dul> rdf:type owl:Ontology ;
+<http://www.w3.org/ns/ssn/dul> rdf:type owl:Ontology ;
                                  owl:imports <http://www.ontologydesignpatterns.org/ont/dul/DUL.owl> .
 
 #################################################################


### PR DESCRIPTION
all alignment module URIs:

- now end in sosa/<name of the aligned ont> or ssn/<name of the aligned ont>
- are http instead of https

the corresponding namespaces are hash-based

