### PR TITLE
Fixes in the SSN document and in the ontologies

### DIFF
--- a/ssn/index.html
+++ b/ssn/index.html
@@ -1795,7 +1795,7 @@ their usage are given.</p>
       </section>
 
       <section>
-        <h3>Feature of Interest and Properties</h3>
+        <h3>Features of Interest and Properties</h3>
         <p>This section introduces the following classes and properties:</p>
         <div class="azlist">
           <p>
@@ -2541,7 +2541,7 @@ their usage are given.</p>
               <p class="crossreference"><strong>IRI:</strong> http://www.w3.org/ns/sosa/Platform</p>
 
               <em property="rdfs:label">Platform</em> -
-              <span property="rdfs:comment skos:definition">A <a href="#SOSAPlatform"><code>Platform</code></a> is an entity that <a href="#SOSAhosts"><code>hosts</code></a> other entities, particularly <a href="#SOSASensor"><code>Sensors</code></a>, <a href="#SOSAActuator"><code>Actuators</code></a> and other <a href="#SOSAPlatform"><code>Platforms</code></a>.</span> <br>
+              <span property="rdfs:comment skos:definition">A <a href="#SOSAPlatform"><code>Platform</code></a> is an entity that <a href="#SOSAhosts"><code>hosts</code></a> other entities, particularly <a href="#SOSASensor"><code>Sensors</code></a>, <a href="#SOSAActuator"><code>Actuators</code></a>, <a href="#SOSASampler"><code>Samplers</code></a>, and other <a href="#SOSAPlatform"><code>Platforms</code></a>.</span> <br>
               <table style="th { float: top; }">
                 <tbody>
                   <tr>
@@ -2642,7 +2642,7 @@ their usage are given.</p>
               <p class="crossreference"><strong>IRI:</strong> http://www.w3.org/ns/ssn/System</p>
 
             <em property="rdfs:label">System</em> -
-            <span property="rdfs:comment skos:definition">System is a unit of abstraction for pieces of infrastructure that implements <a href="#SOSAProcedure"><code>Procedures</code></a>. A System may have components, its subsystems, which are other Systems.</span>
+            <span property="rdfs:comment skos:definition">System is a unit of abstraction for pieces of infrastructure that implement <a href="#SOSAProcedure"><code>Procedures</code></a>. A System may have components, its subsystems, which are other Systems.</span>
             <table style="th { float: top; }">
               <tbody>
                 <tr>

--- a/ssn/index.html
+++ b/ssn/index.html
@@ -2594,7 +2594,7 @@ their usage are given.</p>
                     <th>Sub property of Chain</th>
                     <td>
                      <span rel="owl:propertyChainAxiom" resource="[_:SOSAhosts1]"></span>
-                     <span about="[_:SOSAhosts1]" rel="rdf:first" resource="ssn:hasDeployment"><a href="#SSNhasDeployment">ssn:hasDeployment</a></span> o
+                     <span about="[_:SOSAhosts1]" rel="rdf:first" resource="ssn:inDeployment"><a href="#SSNinDeployment">ssn:inDeployment</a></span> o
                      <span about="[_:SOSAhosts1]" rel="rdf:rest" resource="[_:SOSAhosts2]"></span>
                      <span about="[_:SOSAhosts2]" rel="rdf:first" resource="ssn:deployedSystem"><a href="#SSNdeployedSystem">ssn:deployedSystem</a></span>
                      <span about="[_:SOSAhosts2]" rel="rdf:rest" resource="rdf:nil"></span>

--- a/ssn/index.html
+++ b/ssn/index.html
@@ -2200,8 +2200,8 @@ their usage are given.</p>
                     <td><span rel="schema:domainIncludes" resource="sosa:Actuation"><a href="#SOSAActuation">sosa:Actuation</a></span>, <span rel="schema:domainIncludes" resource="sosa:Observation"><a href="#SOSAObservation">sosa:Observation</a></span>, <span rel="schema:domainIncludes" resource="sosa:Sampling"><a href="#SOSASampling">sosa:Sampling</a></span></td>
                   </tr>
                   <tr>
-                    <th>Range Includes</th>
-                    <td><span rel="schema:rangeIncludes" resource="xsd:dateTime"><a href="https://www.w3.org/TR/xmlschema-2/#dateTime">xsd:dateTime</a></span></td>
+                    <th>Range</th>
+                    <td><span rel="rdfs:range" resource="xsd:dateTime"><a href="https://www.w3.org/TR/xmlschema-2/#dateTime">xsd:dateTime</a></span></td>
                   </tr>
                 </tbody>
               </table>

--- a/ssn/index.html
+++ b/ssn/index.html
@@ -2654,8 +2654,8 @@ their usage are given.</p>
                     <span about="[_:System1]" property="owl:allValuesFrom" resource="sosa:Platform"><em><b>must be</b></em> <a href="#SOSAPlatform">sosa:Platform</a></span>
                     <br>
                     <span about="ssn:System" rel="rdfs:subClassOf" resource="[_:System2]"></span>
-                    <span about="[_:System2]" typeof="owl:Restriction" rel="owl:onProperty" resource="[_:System3]"></span>
-                    <span about="[_:System3]" rel="owl:inverseOf" resource="ssn:implements"><em><b>inverse Of</b></em> <a href="#SSNimplements">ssn:implements</a></span>
+                    <span about="[_:System2]" typeof="owl:Restriction"></span>
+                    <span about="[_:System2]" rel="owl:onProperty" resource="ssn:implements"><a href="#SSNimplements">ssn:implements</a></span>
                     <span about="[_:System2]" property="owl:allValuesFrom" resource="sosa:Procedure"><em><b>must be</b></em> <a href="#SOSAProcedure">sosa:Procedure</a></span>
                     <br>
                     <span about="ssn:System" rel="rdfs:subClassOf" resource="[_:System4]"></span>

--- a/ssn/index.html
+++ b/ssn/index.html
@@ -2090,8 +2090,8 @@ their usage are given.</p>
                   <th>Restriction</th>
                   <td>
                     <span about="sosa:Result" rel="rdfs:subClassOf" resource="[_:SOSAResult1]"></span>
-                    <span about="[_:SOSAResult1]" typeof="owl:Restriction" rel="owl:onProperty" resource="[_:SOSAResult2]"></span>
-                    <span about="[_:SOSAResult2]" rel="owl:inverseOf" resource="sosa:isResultOf"><em><b>inverse Of</b></em> <a href="#SOSAisResultOf">sosa:isResultOf</a></span>
+                    <span about="[_:SOSAResult1]" typeof="owl:Restriction"></span>
+                    <span about="[_:SOSAResult1]" rel="owl:onProperty" resource="sosa:isResultOf"><a href="#SOSAisResultOf">sosa:isResultOf</a></span>
                     <span about="[_:SOSAResult1]" property="owl:minCardinality" content="1" datatype="xsd:nonNegativeInteger"><em><b>must be at least 1</b></em></span>
                   </td>
                 </tr>

--- a/ssn/integrated/sosa.ttl
+++ b/ssn/integrated/sosa.ttl
@@ -48,8 +48,8 @@ sosa: a owl:Ontology , voaf:Vocabulary ;
 
 sosa:FeatureOfInterest a rdfs:Class ; a owl:Class ;
   rdfs:label "Feature Of Interest"@en ;
-  skos:definition """The thing whose property is being estimated or calculated in the course of an Observation to arrive at a Result or whose property is being manipulated by an Actuator, or which is being sampled or transformed in an act of Sampling."""@en ;
-  rdfs:comment """The thing whose property is being estimated or calculated in the course of an Observation to arrive at a Result or whose property is being manipulated by an Actuator, or which is being sampled or transformed in an act of Sampling."""@en ;
+  skos:definition "The thing whose property is being estimated or calculated in the course of an Observation to arrive at a Result or whose property is being manipulated by an Actuator, or which is being sampled or transformed in an act of Sampling."@en ;
+  rdfs:comment "The thing whose property is being estimated or calculated in the course of an Observation to arrive at a Result or whose property is being manipulated by an Actuator, or which is being sampled or transformed in an act of Sampling."@en ;
   skos:example "When measuring the height of a tree, the height is the observed ObservableProperty, 20m may be the Result of the Observation, and the tree is the FeatureOfInterest. A window is a FeatureOfInterest for an automatic window control Actuator."@en ;
   rdfs:isDefinedBy sosa: .
 

--- a/ssn/integrated/ssn.ttl
+++ b/ssn/integrated/ssn.ttl
@@ -58,22 +58,22 @@ sosa:FeatureOfInterest
 
 ssn:Property a owl:Class ;
   rdfs:label "Property"@en ;
-  skos:definition """A quality of a FeatureOfInterest. An aspect of an entity that is intrinsic to and cannot exist without the entity."""@en ;
-  rdfs:comment """A quality of a FeatureOfInterest. An aspect of an entity that is intrinsic to and cannot exist without the entity."""@en ;
+  skos:definition "A quality of a FeatureOfInterest. An aspect of an entity that is intrinsic to and cannot exist without the entity."@en ;
+  rdfs:comment "A quality of a FeatureOfInterest. An aspect of an entity that is intrinsic to and cannot exist without the entity."@en ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:isPropertyOf ; owl:allValuesFrom sosa:FeatureOfInterest ]  ;
   rdfs:isDefinedBy ssn: .
 
   ssn:hasProperty a owl:ObjectProperty , owl:InverseFunctionalProperty ; 
     rdfs:label "has property"@en ;
-    skos:definition """Relation between a FeatureOfInterest and a Property of that feature."""@en ;
-    rdfs:comment """Relation between a FeatureOfInterest and a Property of that feature."""@en ;
+    skos:definition "Relation between a FeatureOfInterest and a Property of that feature."@en ;
+    rdfs:comment "Relation between a FeatureOfInterest and a Property of that feature."@en ;
     owl:inverseOf ssn:isPropertyOf ;
     rdfs:isDefinedBy ssn: .
 
   ssn:isPropertyOf a owl:ObjectProperty , owl:FunctionalProperty ;
     rdfs:label "is property of"@en ;
-    skos:definition """Relation between a Property and the FeatureOfInterest it belongs to."""@en ;
-    rdfs:comment """Relation between a Property and the FeatureOfInterest it belongs to."""@en ;
+    skos:definition "Relation between a Property and the FeatureOfInterest it belongs to."@en ;
+    rdfs:comment "Relation between a Property and the FeatureOfInterest it belongs to."@en ;
     owl:inverseOf ssn:hasProperty ; 
     rdfs:isDefinedBy ssn: .
 
@@ -362,7 +362,7 @@ sosa:Result
 
 ssn:System a owl:Class ;
   rdfs:label "System"@en ;
-  skos:definition "System is a unit of abstraction for pieces of infrastructure that implements Procedures. A System may have components, its subsystems, which are other systems."@en ; 
+  skos:definition "System is a unit of abstraction for pieces of infrastructure that implement Procedures. A System may have components, its subsystems, which are other systems."@en ; 
   rdfs:comment "System is a unit of abstraction for pieces of infrastructure that implements Procedures. A System may have components, its subsystems, which are other systems."@en ; 
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:isHostedBy ; owl:allValuesFrom sosa:Platform ]  ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:implements ; owl:allValuesFrom sosa:Procedure ] ;
@@ -376,8 +376,8 @@ ssn:System a owl:Class ;
 
   ssn:hasSubSystem a owl:ObjectProperty ;
     rdfs:label "has subsystem"@en ;
-    skos:definition """Relation between a System and its component parts."""@en ;
-    rdfs:comment """Relation between a System and its component parts."""@en ;
+    skos:definition "Relation between a System and its component parts."@en ;
+    rdfs:comment "Relation between a System and its component parts."@en ;
     rdfs:isDefinedBy ssn: .
 
 

--- a/ssn/integrated/ssn.ttl
+++ b/ssn/integrated/ssn.ttl
@@ -365,7 +365,7 @@ ssn:System a owl:Class ;
   skos:definition "System is a unit of abstraction for pieces of infrastructure that implements Procedures. A System may have components, its subsystems, which are other systems."@en ; 
   rdfs:comment "System is a unit of abstraction for pieces of infrastructure that implements Procedures. A System may have components, its subsystems, which are other systems."@en ; 
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:isHostedBy ; owl:allValuesFrom sosa:Platform ]  ;
-  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty [ owl:inverseOf ssn:implements ] ; owl:allValuesFrom sosa:Procedure ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:implements ; owl:allValuesFrom sosa:Procedure ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:hasSubSystem ; owl:allValuesFrom ssn:System ]  ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty [ owl:inverseOf ssn:hasSubSystem ] ; owl:allValuesFrom ssn:System ]  ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:hasDeployment ; owl:allValuesFrom ssn:Deployment ]  ;

--- a/ssn/integrated/ssn.ttl
+++ b/ssn/integrated/ssn.ttl
@@ -115,7 +115,7 @@ sosa:Platform
   rdfs:isDefinedBy sosa: .
 
   sosa:hosts
-    owl:propertyChainAxiom ( ssn:hasDeployment ssn:deployedSystem ) ;
+    owl:propertyChainAxiom ( ssn:inDeployment ssn:deployedSystem ) ;
     rdfs:isDefinedBy sosa: .
  
   sosa:isHostedBy

--- a/ssn/integrated/ssn.ttl
+++ b/ssn/integrated/ssn.ttl
@@ -324,7 +324,7 @@ ssn:Stimulus a owl:Class ;
 ## Result
 
 sosa:Result
-  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty [ owl:inverseOf sosa:isResultOf ] ; owl:minCardinality "1"^^xsd:nonNegativeInteger ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:isResultOf ; owl:minCardinality "1"^^xsd:nonNegativeInteger ] ;
   rdfs:isDefinedBy sosa: .
 
   sosa:hasResult 


### PR DESCRIPTION
The pull request includes the following fixes:

# sosa:isResultOf restriction in sosa:Result

sosa:Result is restricted in ssn with the following restriction: inverse Of sosa:isResultOf must be at least 1.
The restriction should be without the inverse part: sosa:isResultOf must be at least 1.

# sosa:resultTime

The documentation of sosa:resultTime states: Range Includes xsd:dateTime.
However, it is defined with rdfs:range xsd:dateTime in sosa, not with schema:rangeIncludes.

# sosa:hosts

sosa:hosts includes in its ssn definition: "Sub property of Chain ssn:hasDeployment o ssn:deployedSystem" while it should be "Sub property of Chain ssn:inDeployment o ssn:deployedSystem".

# ssn:System

ssn:System includes the restriction: "inverse Of ssn:implements must be sosa:Procedure", when it should be: "ssn:implements must be sosa:Procedure" (without the inverse of).

# Writing corrections (document + ontologies)

4.3.4 Feature of Interest and Properties
->
4.3.4 Features of Interest and Properties

A Platform is an entity that hosts other entities, particularly Sensors, Actuators and other Platforms.
->
A Platform is an entity that hosts other entities, particularly Sensors, Actuators, Samplers, and other Platforms.

System is a unit of abstraction for pieces of infrastructure that implements Procedures.
->
System is a unit of abstraction for pieces of infrastructure that implement Procedures.

Replaced in the ontologies all the unneeded multiline literals (""") to single line ones (").
