### PR TITLE
SSN samplingresult

### DIFF
--- a/ssn/integrated/sosa.ttl
+++ b/ssn/integrated/sosa.ttl
@@ -75,6 +75,7 @@ sosa:Sample a rdfs:Class , owl:Class ;
   skos:definition "Feature which is intended to be representative of a FeatureOfInterest on which Observations may be made."@en ;
   rdfs:comment "Feature which is intended to be representative of a FeatureOfInterest on which Observations may be made."@en ;
   rdfs:comment "Physical samples are sometimes known as 'specimens'."@en ;
+  rdfs:comment "A Sample is the result from an act of Sampling."@en ;
   rdfs:comment """Samples are artifacts of an observational strategy, and have no significant function outside of their role in the observation process. The characteristics of the samples themselves are of little interest, except perhaps to the manager of a sampling campaign.
 
 A Sample is intended to sample some FatureOfInterest, so there is an expectation of at least one isSampleOf property. However, in some cases the identity, and even the exact type, of the sampled feature may not be known when observations are made using the sampling features."""@en ;
@@ -349,52 +350,57 @@ sosa:Result a rdfs:Class , owl:Class ;
 
   sosa:hasResult a owl:ObjectProperty ;
     rdfs:label "has result"@en ;
-    skos:definition "Relation linking an Observation and a Sensor or Actuator and a Result, which contains a value representing the value associated with the observed Property."@en ;
-    rdfs:comment "Relation linking an Observation and a Sensor or Actuator and a Result, which contains a value representing the value associated with the observed Property."@en ;
+    skos:definition "Relation linking an Observation or Actuation or act of Sampling and a Result or Sample."@en ;
+    rdfs:comment "Relation linking an Observation or Actuation or act of Sampling and a Result or Sample."@en ;
     schema:domainIncludes sosa:Actuation ;
     schema:domainIncludes sosa:Observation ;
+    schema:domainIncludes sosa:Sampling ;
     schema:rangeIncludes sosa:Result ;
+    schema:rangeIncludes sosa:Sample ;
     owl:inverseOf sosa:isResultOf ;
     rdfs:isDefinedBy sosa: .
 
   sosa:isResultOf a owl:ObjectProperty ;
     rdfs:label "is result of"@en ;
-    skos:definition "Relation linking a Result to the Observation or Actuation that created or caused it."@en ;
-    rdfs:comment "Relation linking a Result to the Observation or Actuation that created or caused it."@en ;
+    skos:definition "Relation linking a Result to the Observation or Actuation or act of Sampling that created or caused it."@en ;
+    rdfs:comment "Relation linking a Result to the Observation or Actuation or act of Sampling that created or caused it."@en ;
     schema:domainIncludes sosa:Result ;
+    schema:domainIncludes sosa:Sample ;
     schema:rangeIncludes sosa:Actuation ;
     schema:rangeIncludes sosa:Observation ;
+    schema:rangeIncludes sosa:Sampling ;
     owl:inverseOf sosa:hasResult ;
     rdfs:isDefinedBy sosa: .
 
   sosa:hasSimpleResult a owl:DatatypeProperty ;
     rdfs:label "has simple result"@en ;
-    skos:definition "The simple value of an Observation or Actuation."@en ;
-    rdfs:comment "The simple value of an Observation or Actuation."@en ;
+    skos:definition "The simple value of an Observation or Actuation or act of Sampling."@en ;
+    rdfs:comment "The simple value of an Observation or Actuation or act of Sampling."@en ;
     skos:example "For instance, the values 23 or true."@en ;
-    schema:domainIncludes sosa:Observation ;
     schema:domainIncludes sosa:Actuation ;
+    schema:domainIncludes sosa:Observation ;
+    schema:domainIncludes sosa:Sampling ;
     rdfs:isDefinedBy sosa: .
 
   # for sampling
 
-  sosa:hasResultingSample a owl:ObjectProperty ;
-    rdfs:label "has resulting sample"@en ;
-    skos:definition "Relation linking an act of Sampling and the new Sample created as a result."@en ;
-    rdfs:comment "Relation linking an act of Sampling and the new Sample created as a result."@en ;
-    schema:domainIncludes sosa:Sampling ;
-    schema:rangeIncludes sosa:Sample ;
-    owl:inverseOf sosa:isSamplingResultOf ;
-    rdfs:isDefinedBy sosa: .
+#  sosa:hasResultingSample a owl:ObjectProperty ;
+#    rdfs:label "has resulting sample"@en ;
+#    skos:definition "Relation linking an act of Sampling and the new Sample created as a result."@en ;
+#    rdfs:comment "Relation linking an act of Sampling and the new Sample created as a result."@en ;
+#    schema:domainIncludes sosa:Sampling ;
+#    schema:rangeIncludes sosa:Sample ;
+#    owl:inverseOf sosa:isSamplingResultOf ;
+#    rdfs:isDefinedBy sosa: .
 
-  sosa:isSamplingResultOf a owl:ObjectProperty ;
-    rdfs:label "is sampling result of"@en ;
-    skos:definition "Relation linking a Sample to the act of Sampling that created or caused it."@en ;
-    rdfs:comment "Relation linking a Sample to the act of Sampling that created or caused it."@en ;
-    schema:domainIncludes sosa:Sample ;
-    schema:rangeIncludes sosa:Sampling ;
-    owl:inverseOf sosa:hasResultingSample ;
-    rdfs:isDefinedBy sosa: .
+#  sosa:isSamplingResultOf a owl:ObjectProperty ;
+#    rdfs:label "is sampling result of"@en ;
+#    skos:definition "Relation linking a Sample to the act of Sampling that created or caused it."@en ;
+#    rdfs:comment "Relation linking a Sample to the act of Sampling that created or caused it."@en ;
+#    schema:domainIncludes sosa:Sample ;
+#    schema:rangeIncludes sosa:Sampling ;
+#    owl:inverseOf sosa:hasResultingSample ;
+#    rdfs:isDefinedBy sosa: .
 
 
 sosa:resultTime a owl:DatatypeProperty ;

--- a/ssn/integrated/ssn.ttl
+++ b/ssn/integrated/ssn.ttl
@@ -94,10 +94,10 @@ ssn:Property a owl:Class ;
 sosa:Sample
   rdfs:subClassOf sosa:FeatureOfInterest ;
   rdfs:subClassOf sosa:Result ; 
-  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:isSamplingResultOf ; owl:minCardinality "1"^^xsd:nonNegativeInteger ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:isResultOf ; owl:minCardinality "1"^^xsd:nonNegativeInteger ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:isSampleOf ; owl:allValuesFrom sosa:FeatureOfInterest ]  ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:isSampleOf ; owl:minCardinality "1"^^xsd:nonNegativeInteger ] ;
-  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:isSamplingResultOf ; owl:allValuesFrom sosa:Sampling ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:isResultOf ; owl:allValuesFrom sosa:Sampling ] ;
   rdfs:isDefinedBy sosa: .
 
   sosa:hasSample a owl:InverseFunctionalProperty ;
@@ -278,8 +278,8 @@ sosa:Sampling a owl:Class ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:usedProcedure ; owl:allValuesFrom sosa:Procedure ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasFeatureOfInterest ; owl:cardinality "1"^^xsd:nonNegativeInteger ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasFeatureOfInterest ; owl:allValuesFrom sosa:FeatureOfInterest ] ;
-  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasResultingSample ; owl:minCardinality "1"^^xsd:nonNegativeInteger ] ;
-  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasResultingSample ; owl:allValuesFrom sosa:Sample ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasResult ; owl:minCardinality "1"^^xsd:nonNegativeInteger ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasResult ; owl:allValuesFrom sosa:Sample ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:resultTime ; owl:cardinality "1"^^xsd:nonNegativeInteger ] ;
   rdfs:isDefinedBy sosa: .
 
@@ -336,13 +336,13 @@ sosa:Result
   sosa:hasSimpleResult 
     rdfs:isDefinedBy sosa: .
 
-  sosa:hasResultingSample 
-    rdfs:subPropertyOf sosa:hasResult ;
-    rdfs:isDefinedBy sosa: .
+#  sosa:hasResultingSample 
+#    rdfs:subPropertyOf sosa:hasResult ;
+#    rdfs:isDefinedBy sosa: .
 
-  sosa:isSamplingResultOf
-    rdfs:subPropertyOf sosa:isResultOf ;
-    rdfs:isDefinedBy sosa: .
+#  sosa:isSamplingResultOf
+#    rdfs:subPropertyOf sosa:isResultOf ;
+#    rdfs:isDefinedBy sosa: .
 
   sosa:resultTime
     rdfs:isDefinedBy sosa: .

--- a/ssn/integrated/ssnx.rdf
+++ b/ssn/integrated/ssnx.rdf
@@ -351,7 +351,7 @@ O&amp;M allows sensors, methods, instruments, systems, algorithms and process ch
 
   <owl:ObjectProperty rdf:about="http://purl.oclc.org/NET/ssnx/ssn#featureOfInterest">
     <rdfs:label xml:lang="en">feature of interest</rdfs:label>
-    <dc:source>skos:exactMatch 'featureOfInterest' [O&amp;M - ISO/DIS 19156] 
+    <dc:source>skos:exactMatch 'featureOfInterest' [O&amp;M - ISO 19156:2011/OGC Abstract Specification Topic 20] 
                         http://portal.opengeospatial.org/files/?artifact_id=41579</dc:source>
     <rdfs:comment xml:lang="en">A relation between an Observation and the entity whose quality was observed.   For example, in an observation of the weight of a person, the feature of interest is the person and the quality is weight.</rdfs:comment>
     <rdfs:seeAlso rdf:resource="http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton"/>
@@ -387,7 +387,7 @@ Measurement result in VIM is the measured value plus any other relevant informat
           <owl:ObjectProperty rdf:about="http://purl.oclc.org/NET/ssnx/ssn#observationResult">
             <rdfs:label xml:lang="en">observation result</rdfs:label>
             <skos:definition xml:lang="en">Relation linking an Observation (i.e., a description of the context, the Situation, in which the observation was made) and a Result, which contains a value representing the value associated with the observed Property.</skos:definition>
-            <dc:source>skos:closeMatch 'result' [O&amp;M - ISO/DIS 19156] 
+            <dc:source>skos:closeMatch 'result' [O&amp;M - ISO 19156:2011/OGC Abstract Specification Topic 20] 
                           http://portal.opengeospatial.org/files/?artifact_id=41579</dc:source>
             <rdfs:seeAlso rdf:resource="http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton"/>
             <rdfs:subPropertyOf rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#isSettingFor"/>
@@ -468,7 +468,7 @@ Measurement result in VIM is the measured value plus any other relevant informat
           <owl:ObjectProperty rdf:about="http://purl.oclc.org/NET/ssnx/ssn#qualityOfObservation">
             <rdfs:label xml:lang="en">quality of observation</rdfs:label>
             <skos:definition xml:lang="en">Relation linking an Observation to the adjudged quality of the result.  This is of course complimentary to the MeasurementCapability information recorded for the Sensor that made the Observation.</skos:definition>
-            <dc:source>skos:exactMatch 'resultQuality' [O&amp;M - ISO/DIS 19156] 
+            <dc:source>skos:exactMatch 'resultQuality' [O&amp;M - ISO 19156:2011/OGC Abstract Specification Topic 20] 
                           http://portal.opengeospatial.org/files/?artifact_id=41579</dc:source>
             <rdfs:seeAlso rdf:resource="http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Observation#Observation"/>
             <owl:equivalentProperty rdf:resource="http://www.w3.org/ns/ssn/qualityOfObservation"/>
@@ -523,7 +523,7 @@ Measurement result in VIM is the measured value plus any other relevant informat
   <owl:ObjectProperty rdf:about="http://purl.oclc.org/NET/ssnx/ssn#observedProperty">
     <rdfs:label xml:lang="en">observed property</rdfs:label>
     <skos:definition xml:lang="en">Relation linking an Observation to the Property that was observed.  The observedProperty should be a Property (hasProperty) of the FeatureOfInterest (linked by featureOfInterest) of this observation.</skos:definition>
-    <dc:source>skos:exactMatch 'observedProperty' [O&amp;M - ISO/DIS 19156] 
+    <dc:source>skos:exactMatch 'observedProperty' [O&amp;M - ISO 19156:2011/OGC Abstract Specification Topic 20] 
       http://portal.opengeospatial.org/files/?artifact_id=41579</dc:source>
     <rdfs:seeAlso rdf:resource="http://www.w3.org/2005/Incubator/ssn/wiki/SSN_Skeleton#Skeleton"/>
     <rdfs:subPropertyOf rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#associatedWith"/>

--- a/ssn/rdf/sosa.ttl
+++ b/ssn/rdf/sosa.ttl
@@ -123,6 +123,7 @@ sosa:Sample
   rdf:type owl:Class ;
   rdfs:comment "Feature on which Observations may be made, which is intended to be representative of a FeatureOfInterest that is not fully accessible."@en ;
   rdfs:comment "Physical samples are sometimes known as 'specimens'."@en ;
+  rdfs:comment "A Sample is the result from an act of Sampling."@en ;
   rdfs:comment """Samples are artifacts of an observational strategy, and have no significant function outside of their role in the observation process. The characteristics of the samples themselves are of little interest, except perhaps to the manager of a sampling campaign.
 
 A Sample is intended to sample some FatureOfInterest in an application domain, so there is an expectation of at least one sampledFeature property. However, in some cases the identity, and even the exact type, of the sampled feature may not be known when observations are made using the sampling features."""@en ;
@@ -183,21 +184,23 @@ sosa:hasResult
   rdf:type owl:ObjectProperty ;
   schema:domainIncludes sosa:Actuation ;
   schema:domainIncludes sosa:Observation ;
+  schema:domainIncludes sosa:Sampling ;
   schema:rangeIncludes sosa:Result ;
-  rdfs:comment "Relation linking an Observation and a Sensor or Actuator and a Result, which contains a value representing the value associated with the observed Property."@en ;
+  schema:rangeIncludes sosa:Sample ;
+  rdfs:comment "Relation linking an Observation or Actuation or act of Sampling and a Result."@en ;
   rdfs:label "has result"@en ;
   owl:inverseOf sosa:isResultOf ;
-  skos:definition "Relation linking an Observation and a Sensor or Actuator and a Result, which contains a value representing the value associated with the observed Property."@en ;
+  skos:definition "Relation linking an Observation or Actuation or act of Sampling and a Result."@en ;
 .
-sosa:hasResultingSample
-  rdf:type owl:ObjectProperty ;
-  schema:domainIncludes sosa:Sampling ;
-  schema:rangeIncludes sosa:Sample ;
-  rdfs:label "has resulting sample"@en ;
-  owl:inverseOf sosa:isSamplingResultOf ;
-  skos:definition "Relation linking an act of Sampling and the new Sample created as a result."@en ;
-  rdfs:comment "Relation linking an act of Sampling and the new Sample created as a result."@en ;
-.
+#sosa:hasResultingSample
+#  rdf:type owl:ObjectProperty ;
+#  schema:domainIncludes sosa:Sampling ;
+#  schema:rangeIncludes sosa:Sample ;
+#  rdfs:label "has resulting sample"@en ;
+#  owl:inverseOf sosa:isSamplingResultOf ;
+#  skos:definition "Relation linking an act of Sampling and the new Sample created as a result."@en ;
+#  rdfs:comment "Relation linking an act of Sampling and the new Sample created as a result."@en ;
+#.
 sosa:hasSample
   rdf:type owl:ObjectProperty ;
   schema:domainIncludes sosa:FeatureOfInterest ;
@@ -278,22 +281,24 @@ sosa:isObservedBy
 sosa:isResultOf
   rdf:type owl:ObjectProperty ;
   schema:domainIncludes sosa:Result ;
+  schema:domainIncludes sosa:Sample ;
   schema:rangeIncludes sosa:Actuation ;
   schema:rangeIncludes sosa:Observation ;
+  schema:rangeIncludes sosa:Sampling ;
   rdfs:comment "Relation linking a Result to the Observation or Actuation that created or caused it."@en ;
   rdfs:label "is result of"@en ;
   owl:inverseOf sosa:hasResult ;
   skos:definition "Relation linking a Result to the Observation or Actuation that created or caused it."@en ;
 .
-sosa:isSamplingResultOf
-  rdf:type owl:ObjectProperty ;
-  schema:domainIncludes sosa:Sample ;
-  schema:rangeIncludes sosa:Sampling ;
-  rdfs:comment "Relation linking a Sample to the act of Sampling that created or caused it."@en ;
-  skos:definition "Relation linking a Sample to the act of Sampling that created or caused it."@en ;
-  rdfs:label "is sampling result of"@en ;
-  owl:inverseOf sosa:hasResultingSample ;
-.
+#sosa:isSamplingResultOf
+#  rdf:type owl:ObjectProperty ;
+#  schema:domainIncludes sosa:Sample ;
+#  schema:rangeIncludes sosa:Sampling ;
+#  rdfs:comment "Relation linking a Sample to the act of Sampling that created or caused it."@en ;
+#  skos:definition "Relation linking a Sample to the act of Sampling that created or caused it."@en ;
+#  rdfs:label "is sampling result of"@en ;
+#  owl:inverseOf sosa:hasResultingSample ;
+#.
 sosa:isSampleOf
   rdf:type owl:ObjectProperty ;
   schema:domainIncludes sosa:Sample ;


### PR DESCRIPTION
Removed isSamplingResultOf and hasResult

Added constraints to Sampling/Sample to require the Result to be a Sample
Adjusted domain/rangeIncludes where necessary

http://www.w3.org/2015/spatial/track/actions/341