### PR TITLE
Link docs for OGC Pending

### DIFF
--- a/qb4st/OGCDocsLinkToW3C-CovJSON.txt
+++ b/qb4st/OGCDocsLinkToW3C-CovJSON.txt
@@ -1,0 +1,5 @@
+Please see the W3C Git Pages at
+http://w3c.github.io/sdw/coverage-json/
+
+and the repository at 
+https://github.com/w3c/sdw/tree/gh-pages/coverage-json

--- a/qb4st/OGCDocsLinkToW3C-QB4ST.txt
+++ b/qb4st/OGCDocsLinkToW3C-QB4ST.txt
@@ -1,0 +1,5 @@
+Please see the W3C Git Pages at
+http://w3c.github.io/sdw/qb4st/
+
+and the repository at 
+https://github.com/w3c/sdw/tree/gh-pages/qb4st


### PR DESCRIPTION
Text files to link OGC Pending docs to QB4ST and Cov-JSON.  (possibly best to move the cov-JSON - or put these all in some more sensible place so they can be found and standardised)