### PR TITLE
BP: Revised tables in Appendix A + ed changes

### DIFF
--- a/bp/index.html
+++ b/bp/index.html
@@ -434,8 +434,18 @@ function init() {
         border-collapse: collapse;
         caption-side:bottom;
       }
+      
+      table#table-formats-matrix,
+      table#table-vocabs-matrix
+      {
+          font-size: .8em;
+      }
+      
       table#x-ref_formatVbp,
-      table#detailed-format-matrix{
+      table#detailed-format-matrix,
+      table#table-formats-matrix,
+      table#table-vocabs-matrix
+      {
           border-collapse: collapse;
           caption-side: bottom;
       }
@@ -445,14 +455,22 @@ function init() {
       table#x-ref_formatVbp th,
       table#x-ref_formatVbp td,
       table#detailed-format-matrix th,
-      table#detailed-format-matrix td{
+      table#detailed-format-matrix td,
+      table#table-formats-matrix th,
+      table#table-formats-matrix td,
+      table#table-vocabs-matrix th,
+      table#table-vocabs-matrix td
+      {
           border: 1px solid black;
           padding: 0.3em;
       }
 
       table.bptable,
       table#x-ref_formatVbp caption,
-      table#detailed-format-matrix caption{
+      table#detailed-format-matrix caption,
+      table#table-formats-matrix caption,
+      table#table-vocabs-matrix caption
+      {
           margin: 0.5em;
           font-style: italic;
       }
@@ -1427,7 +1445,15 @@ function init() {
           </div>
           <div class="note">
             <p>The current list of RDF vocabularies / OWL ontologies for spatial data being considered
-              by the SDW WG are provided below. Some of these will be used in examples. Full details,
+              by the SDW WG are provided below. Some of these will be used in examples.
+
+<!-- @andrea-perego -->
+A high-level comparison is provided in <a href="#applicability-formatVbp" class="sectionRef"></a>.</p>
+<div style="background-color:yellow;">
+<p>
+<!-- @andrea-perego -->              
+              
+               Full details,
               including mapping between vocabularies, pointers about inconsistencies in vocabularies
               (if any are evident), and recommendations avoiding their use as these may lead to
               confusion, will be published in a complementary <strong>NOTE: Comparison of geospatial
@@ -1436,6 +1462,11 @@ function init() {
               spatial data format or vocabulary. It provides a methodology for
               making that choice. We do this rather than recommending one vocabulary because this
               recommendation would not be durable as vocabularies are released or amended. </p>
+
+<!-- @andrea-perego -->
+</div>
+<!-- @andrea-perego -->             
+              
             <p>Vocabularies can discovered from <a href="http://lov.okfn.org/dataset/lov/">Linked Open
               Vocabularies (LOV)</a>; using search terms like 'location' or Tags <a
                 href="http://lov.okfn.org/dataset/lov/terms?q=place">place</a>, <a
@@ -1444,12 +1475,23 @@ function init() {
                       href="http://lov.okfn.org/dataset/lov/vocabs?tag=Time">Time</a>.</p>
 		  
 <dl>
+<dt>Dublin Core [[DCTERMS]]</dt>
+<dd>[[DCTERMS]] includes term for describing location and temporal information, as classes <a href="http://purl.org/dc/terms/Location">dct:Location</a>, <a href="http://purl.org/dc/terms/PeriodOfTime">dct:PeriodOfTime</a>, and properties <a href="http://purl.org/dc/terms/spatial">dct:spatial</a>, <a href="http://purl.org/dc/terms/temporal">dct:temporal</a>, and <a href="http://purl.org/dc/terms/coverage">dct:coverage</a>.</dd>
 <dt>W3C Basic Geo [[W3C-BASIC-GEO]]</dt>
 <dd>A widely used vocabulary, although not an official standard, for specifying point coordinates in the WGS84 datum.</dd>
+<dt>vCard Ontology [[VCARD-RDF]]</dt>
+<dd>[[VCARD-RDF]] includes terms for describing <a href="https://www.w3.org/TR/vcard-rdf/#Delivery_Addressing_Properties">postal addresses</a> and <a href="https://www.w3.org/TR/vcard-rdf/#Geographical_Properties">0D geometries</a> (points).</dd>
+<dt>GeoRSS [[GeoRSS]]</dt>
+<dd>
+<p>Vocabulary defined by the W3C Geospatial Incubator Group (GeoXG) for the representation of geospatial properties of Web resources.</p>
+<p style="background-color:yellow;">On 28 March 2017, [[GeoRSS]] has been proposed as a <a href="http://www.opengeospatial.org/pressroom/pressreleases/2570">candidate OGC Community Standard</a>.</p>
+</dd>
 <dt>Schema.org [[SCHEMA-ORG]]</dt>
 <dd>Designed for annotating Web pages with machine-readable metadata, it supports a number of classes and properties for specifying location information, including geometries. See <a href="#indexable-by-search-engines"></a> for more information.</dd>
 <dt>GeoSPARQL [[GeoSPARQL]]</dt>
 <dd>Official OGC standard, defining a set of terms and functions for modeling and querying spatial information. Coordinates are encoded by using <a>WKT</a> or [[GML]].</dd>
+<dt>ISA Programme Location Core Vocabulary [[LOCN]]</dt>
+<dd>[[LOCN]] has been designed to define a set of terms for describing location information, common across domains and sectors, thus providing a core vocabulary that can be extended based on domain-specific requirements. The defined terms cover geographical names, geometries, and postal addresses.</dd>
 <!--
 <dt>NeoGeo [[NeoGeo]]<dt>
 <dd>TBD</dd>
@@ -1462,25 +1504,14 @@ function init() {
 <dt><a href="http://rdf-vocabulary.ddialliance.org/xkos.html">XKOS</a></dt>
 <dd>(used for geographical hierarchies in some examples)</dd>
 -->
-<dt>Dublin Core [[DCTERMS]]</dt>
-<dd>[[DCTERMS]] includes term for describing location and temporal information, as classes <a href="http://purl.org/dc/terms/Location">dct:Location</a>, <a href="http://purl.org/dc/terms/PeriodOfTime">dct:PeriodOfTime</a>, and properties <a href="http://purl.org/dc/terms/spatial">dct:spatial</a>, <a href="http://purl.org/dc/terms/temporal">dct:temporal</a>, and <a href="http://purl.org/dc/terms/coverage">dct:coverage</a>.</dd>
 <!--
 <dt>BBC's ontology</dt>
 <dd>It includes the notion of <a href="http://www.bbc.co.uk/ontologies/coreconcepts#terms_Place">Place</a></dd>
 -->
-<dt>ISA Programme Location Core Vocabulary [[LOCN]]</dt>
-<dd>[[LOCN]] has been designed to define a set of terms for describing location information, common across domains and sectors, thus providing a core vocabulary that can be extended based on domain-specific requirements. The defined terms cover geographical names, geometries, and postal addresses.</dd>
 <!--
 <dt><a href="http://sw-portal.deri.org/ontologies/swportal#">SWPortal ontology</a></dt>
 <dd>TBD includes definition of location</dd>
 -->
-<dt><a href="http://www.w3.org/TR/2014/NOTE-vcard-rdf-20140522/">vCard Ontology</a></dt>
-<dd>The vCard ontology includes terms for describing <a href="https://www.w3.org/TR/vcard-rdf/#Delivery_Addressing_Properties">postal addresses</a> and <a href="https://www.w3.org/TR/vcard-rdf/#Geographical_Properties">simple geometries</a>.</dd>
-<dt><a href="https://www.w3.org/2005/Incubator/geo/XGR-geo-20071023/">GeoRSS</a></dt>
-<dd>
-<p>Vocabulary defined by the W3C Geospatial Incubator Group (GeoXG) for the representation of geospatial properties of Web resources.</p>
-<p style="background-color:yellow;">On 28 March 2017, GeoRSS has been proposed as a <a href="http://www.opengeospatial.org/pressroom/pressreleases/2570">candidate OGC Community Standard</a>.</p>
-</dd>
 <!--
 <dt>stRDF &amp; stSPARQL</dt>
 <dd>stRDF and stSPARQL, used in the <a href="http://strabon.di.uoa.gr/">Strabon</a> system, extend RDF and SPARQL with spatial and temporal semantics (see publications <a href="http://www.strabon.di.uoa.gr/files/iswc-strabon.pdf">iswc-strabon.pdf</a> and <a href="http://www.strabon.di.uoa.gr/files/eswc2013.pdf">eswc2013.pdf</a>).</dd>
@@ -1552,7 +1583,7 @@ function init() {
               
               <h5>1. Web pages for people to read about spatial things</h5>
               <p>In <a href="#globally-unique-ids" class="sectionRef">Best Practice 1</a> we recommend use of HTTP URIs as a way of assigning identifiers to spatial things. The data publisher should offer the ability to look up ('dereference') such a URI to find out useful information about that spatial thing in human readable form (as well as machine readable formats - see the discussion below on data integration).  Each spatial thing therefore gets its own web page - in addition it might be useful to have web pages about groups of spatial things, but the 'page per thing' approach enables fine-grained linking of information.</p>
-              <p>To promote discovery of such web pages in search engines, each page should contain a clear text description of what it is, ideally in a way that distinguishes it from pages about other similar spatial things. Including metadata using the [[SCHEMA-ORG]] vocabulary, embedded as microdata, RDFa or as JSON-LD in the <em>&lt;head&gt;</em> section of the page can provide additional information to search engines to support more precise indexing.  See <a href="#indexable-by-search-engines" class="sectionRef">Best Practice 2: Making data indexable by search engines</a> for a more detailed discussion.</p>
+              <p>To promote discovery of such web pages in search engines, each page should contain a clear text description of what it is, ideally in a way that distinguishes it from pages about other similar spatial things. Including metadata using the [[SCHEMA-ORG]] vocabulary, embedded as [[MICRODATA]], [[HTML-RDFa] or as [[JSON-LD]] in the <em>&lt;head&gt;</em> section of the page can provide additional information to search engines to support more precise indexing.  See <a href="#indexable-by-search-engines" class="sectionRef">Best Practice 2: Making data indexable by search engines</a> for a more detailed discussion.</p>
               <p>It is also very useful in such web pages to include links to descriptions of the spatial thing in other formats (typically machine-readable formats) as well as linking to related spatial things.</p>
               <aside class="example">
                 <p>TO DO: Web pages about spatial thing example...</p>
@@ -1571,7 +1602,7 @@ function init() {
               <p>A common approach to encoding data to enable data integration is Linked Data #linked-data and RDF. The spatial aspects of the data can either be included in the RDF data model, or the entity in question can link to an external web resource containing the geometry in one of the standard spatial data formats. Although RDF is well-suited to important aspects of best practice, including use of URIs as identifiers and re-use of vocabularies, other data formats are also consistent with this approach. Most spatial data formats enable associating attributes of an entity alongside its geometry.</p>	
               <p>The publisher's choice of data model to represent the data will depend on what data is available and which audiences and purposes it seems most important to support. However, a reasonable general rule is that it is always useful to provide a label and a type for each entity in the data collection. (See [[DWBP]] <a href="https://www.w3.org/TR/dwbp/#ChooseRightFormalizationLevel">Best Practice 16: Choose the right formalization level</a>)</p>  
               <p>A common way of specifying the location of a building is to use its postal address. Most spatial applications require an address to be turned into spatial coordinates, so that its location can be marked on a map, or compared with locations of other things, a process known as 'geocoding'.  Although a publisher could leave this process of geocoding to the data user, ideally the publisher should take responsibility for this as they are in a better position to check the accuracy of the results.  Different ways of specifying addresses can sometimes lead to errors in the geocoding process.</p>
-              <p>Common vocabularies for describing the address of a Spatial Thing include: <a href="https://schema.org/">schema.org</a>, <a href="https://www.w3.org/TR/vcard-rdf/">vCard</a> and <a href="https://www.w3.org/ns/locn">ISA Core Location (LOCN)</a>.</p>
+              <p>Common vocabularies for describing the address of a Spatial Thing include: [[SCHEMA-ORG]], [[VCARD-RDF]] and [[LOCN]].</p>
               <p><a href="https://what3words.com/">what3words</a> is an example of a service that assigns an alternative kind of address to a location - in this case a sequence of three common words associated with a 3m by 3m square on the ground.  It allows every location to be given such an address and what3words also provides a means to relate the address to latitude and longitude coordinates.  Like conventional addresses, converting to coordinates is necessary for many spatial data applications (e.g. to calculate the distance between points or whether a point is inside a region), but the process of conversion is more reliable and precise.</p>
               <aside class="example">
                 <p>TO DO. data integration example. <a href="http://statistics.gov.scot">Scottish Government Statistics</a></p>
@@ -3694,6 +3725,380 @@ a:Dataset a dcat:Dataset ;
         reworked in other ways. </p>
       <p>The first table is a matrix of the common formats, showing in general terms how well these
         formats help achieve goals such as discoverability, granularity etc. </p>
+        
+<!-- @andrea-perego -->
+
+<p>Please note that the formats listed in the table are all open and textual formats.</p>
+
+<table id="table-formats-matrix">
+<caption>Common formats for spatial data and what you can or can't achieve with them.</caption>
+<thead>
+<tr>
+<th></th>
+<th>WKT</th>
+<th>GML</th>
+<th>KML</th>
+<th>GeoJSON</th>
+<th>HTML</th>
+</tr>
+</thead>
+
+<tbody>
+<tr>
+<th>Based on</th>
+<td>WKT</td>
+<td>XML</td>
+<td>XML</td>
+<td>JSON</td>
+<td>HTML</td>
+</tr>
+<tr>
+<th>Media type</th>
+<td><a href="https://www.iana.org/assignments/media-types/text/plain"><code>text/plain</code></a></td>
+<td><a href="https://www.iana.org/assignments/media-types/application/gml+xml"><code>application/gml+xml</code></a></td>
+<td><a href="https://www.iana.org/assignments/media-types/application/vnd.google-earth.kml+xml"><code>application/vnd.google-earth.kml+xml</code></a>, <a href="https://www.iana.org/assignments/media-types/application/vnd.google-earth.kmz"><code>application/vnd.google-earth.kmz</code></a></td>
+<td><a href="https://www.iana.org/assignments/media-types/application/geo+json"><code>application/geo+json</code></a></td>
+<td><a href="https://www.iana.org/assignments/media-types/text/html"><code>text/html</code></a></td>
+</tr>
+<!--
+<tr>
+<th>Openness</th>
+<td>Open</td>
+<td>Open</td>
+<td>Open</td>
+<td>Open</td>
+<td>Open</td>
+</tr>
+<tr>
+<th>Binary/text</th>
+<td>Text</td>
+<td>Text</td>
+<td>Text</td>
+<td>Text</td>
+<td>Text</td>
+</tr>
+-->
+<tr>
+<th>Usage</th>
+<td>Representation of 0D-2D geometries, CRS and CRS transformation</td>
+<td>Representation of spatial things and 0D-3D geometries. Comprehensive and supporting many use cases.</td>
+<td>Representation of spatial things and 0D-3D geometries. Main focus on spatial data visualization and interaction</td>
+<td>Representation of spatial things and 0D-2D geometries</td>
+<td>Description of spatial things and geometries can be embedded by using mechanisms as [[HTML-RDFa]], [[MICRODATA]], [[JSON-LD]], using vocabularies as [[SCHEMA-ORG]]</td>
+</tr>
+<tr>
+<th>Tool support</th>
+<td>
+<p>Widely supported in <a>GIS</a> tools</p>
+<p>Supported by some Web libraries, usually converted in GeoJSON</p>
+<p>Supported by most triple stores</p>
+</td>
+<td>
+<p>Widely supported in <a>GIS</a> tools</p>
+<p>Supported by some Web libraries, usually converted in GeoJSON, but not when the geometry is 3-dimensional (volumes)</p>
+<p>Supported only by triple stores supporting [[GeoSPARQL]]</p>
+</td>
+<td>
+<p>Mainly supported by Earth browsers, as Google Earth</p>
+</td>
+<td>
+<p>Supported in some <a>GIS</a> tools</p>
+<p>Widely supported in Web libraries and mapping APIs</p>
+</td>
+<td>
+<p>Optimal for Web publication and discovery</p>
+</td>
+</tr>
+<tr>
+<th>Web discoverability</th>
+<td>Low</td>
+<td>Low</td>
+<td>Low</td>
+<td>Low</td>
+<td>Good</td>
+</tr>
+<!--
+<tr>
+<th>Granular links ??</th>
+<td>In Theory ?</td>
+<td>In Theory ?</td>
+<td>No</td>
+<td>In Theory?</td>
+<td>Yes</td>
+</tr>
+-->
+<tr>
+<th>Link support</th>
+<td>No</td>
+<td>Via [[XLINK11]]</td>
+<td>Via [[XLINK11]]</td>
+<td>No</td>
+<td>Yes</td>
+</tr>
+<!--
+<tr>
+<th>Verbosity</th>
+<td>Lightweight</td>
+<td>Verbose</td>
+<td>Medium</td>
+<td>Medium</td>
+<td>Depends on the vocabulary used</td>
+</tr>
+-->
+<!--
+<tr>
+<th>Semantics vocab?</th>
+<td>No</td>
+<td>No</td>
+<td>No</td>
+<td>No</td>
+<td>No</td>
+</tr>
+-->
+<!--
+<tr>
+<th>Streamable</th>
+<td>No</td>
+<td>Yes?</td>
+<td>No</td>
+<td>No</td>
+<td>No</td>
+</tr>
+-->
+<!--
+<tr>
+<th>Remarks</th>
+<td>Format widely supported in GIS tools, as well as in most Linked Data tools (even in triple stores not supporting [[GeoSPARQL]])</td>
+<td>Format widely supported in GIS tools, and in some Linked Data tools (i.e., only in triple stores supporting [[GeoSPARQL]]). Comprehensive and supporting many use cases, but requires strong XML skills.</td>
+<td>Focussed on visualization of and interaction with spatial data, typically in Earth browsers, like Google Earth</td>
+<td>Supported by many mapping APIs and Web libraries</td>
+<td>Optimal for Web publication and discovery</td>
+</tr>
+-->
+<tr>
+<th colspan="6">Geometry specification</th>
+</tr>
+<!--
+<tr>
+<th>Default CRS</th>
+<td>Depends on the flavor - e.g., [[GeoSPARQL]]'s WKT defaults to WGS84 long/lat (CRS84)</td>
+<td>Yes</td>
+<td>No</td>
+<td>WGS84 long/lat (CRS84)</td>
+<td>Depends on the vocabulary used</td>
+</tr>
+-->
+<tr>
+<th>CRS support</th>
+<td>Depends on the flavor - e.g., EWKT and [[GeoSPARQL]]'s WKT support arbitrary CRSs, and the latter defaults to WGS84 long/lat (CRS84)</td>
+<td>Any, and it can be explicitly specified (via attribute <code>@srsName</code>)</td>
+<td>WGS84 long/lat (CRS84) only</td>
+<td>WGS84 long/lat (CRS84) only</td>
+<td>Depends on the vocabulary used - e.g., [[SCHEMA-ORG]] supports WGS84 only</td>
+</tr>
+<!--
+<tr>
+<th>Default axis order</th>
+<td>Any, but it cannot be explicitly specified - e.g., in EWKT it defaults to longitude/latitude, whereas in [[GeoSPARQL]]'s WKT it is determined by the CRS used</td>
+<td>Yes</td>
+<td>No</td>
+<td>Long/lat</td>
+<td>Depends on the vocabulary used</td>
+</tr>
+-->
+<tr>
+<th>Axis order support</th>
+<td>Any, but it cannot be explicitly specified - e.g., in EWKT it defaults to longitude/latitude, whereas in [[GeoSPARQL]]'s WKT it is determined by the CRS used</td>
+<td>Determined by the CRS used</td>
+<td>Longitude / latitude only, with optional altitude</td>
+<td>Longitude / latitude only, with optional altitude</td>
+<td>Depends on the vocabulary used - e.g., [[SCHEMA-ORG]] supports lat/long only</td>
+</tr>
+<tr>
+<th>3D support</th>
+<td>No</td>
+<td>Yes</td>
+<td>Yes</td>
+<td>No</td>
+<td>Depends on the vocabulary used - e.g., [[SCHEMA-ORG]] does not support 3D geometries</td>
+</tr>
+</tbody>
+</table>
+
+<p>The following table compares the spatial data vocabularies listed in <a href="#bp-expressing-spatial" class="sectionRef"></a>, and what you can do with them.</p>
+	
+<table id="table-vocabs-matrix">
+
+<caption>Common spatial vocabularies, and what you can and can't do with them.</caption>
+
+<thead>
+<tr>
+<th></th>
+<th>[[DCTERMS]]</th>
+<th>[[W3C-BASIC-GEO]]</th>
+<th>[[VCARD-RDF]]</th>
+<th>[[GeoRSS]]</th>
+<th>[[SCHEMA-ORG]]</th>
+<th>[[GeoSPARQL]]</th>
+<th>[[LOCN]]</th>
+</tr>
+</thead>
+<!--
+<tfoot>
+<tr>
+<th></th>
+<th>[[DCTERMS]]</th>
+<th>[[W3C-BASIC-GEO]]</th>
+<th>[[VCARD-RDF]]</th>
+<th>[[GeoRSS]]</th>
+<th>[[SCHEMA-ORG]]</th>
+<th>[[GeoSPARQL]]</th>
+<th>[[LOCN]]</th>
+</tr>
+</tfoot>
+-->
+<tbody>
+<tr>
+<th>Spatial things</th>
+<td><a href="http://purl.org/dc/terms/Location"><code>dct:Location</code></a></td>
+<td><code>w3cgeo:SpatialThing</code></td>
+<td><a href="https://www.w3.org/TR/vcard-rdf/#d4e1819"><code>vcard:Kind</code></a>, and its subclasses; <a href="https://www.w3.org/TR/vcard-rdf/#d4e1292"><code>vcard:Address</code></a></td>
+<td>No specific class defined to model <a>spatial things</a></td>
+<td><a href="http://schema.org/Place"><code>schema:Place</code></a>, and its subclasses; <a href="http://schema.org/PostalAddress"><code>schema:PostalAddress</code></a></td>
+<td><code>geosparql:Feature</code></td>
+<td><a href="http://www.w3.org/ns/locn#dcterms:Location"><code>dct:Location</code></a>, <a href="http://www.w3.org/ns/locn#locn:Address"><code>locn:Address</code></a></td>
+
+</tr>
+<tr>
+<th>Properties to associate spatial things with geometries</th>
+<td>-</td>
+<td><code>w3cgeo:location</code>, <code>w3cgeo:lat_long</code>, <code>w3cgeo:lat</code>, <code>w3cgeo:long</code>, <code>w3cgeo:alt</code></td>
+<td><a href="https://www.w3.org/TR/vcard-rdf/#d4e239"><code>vcard:hasGeo</code></a></td>
+<td><a href="https://www.w3.org/2005/Incubator/geo/XGR-geo-20071023/#where"><code>georss:where</code></a>, <a href="https://www.w3.org/2005/Incubator/geo/XGR-geo-20071023/#point"><code>georss:point</code></a>, <a href="https://www.w3.org/2005/Incubator/geo/XGR-geo-20071023/#line"><code>georss:line</code></a>, <a href="https://www.w3.org/2005/Incubator/geo/XGR-geo-20071023/#polygon"><code>georss:polygon</code></a>, <a href="https://www.w3.org/2005/Incubator/geo/XGR-geo-20071023/#box"><code>georss:box</code></a></td>
+<td><a href="http://schema.org/geo"><code>schema:geo</code></a></td>
+<td><code>geosparql:hasGeometry</code>, <code>geosparql:defaultGeometry</code></td>
+<td><a href="http://www.w3.org/ns/locn#locn:geometry"><code>locn:geometry</code></a></td>
+</tr>
+<tr>
+<th>Geometries</th>
+<td>-</td>
+<td><code>w3cgeo:Point</code> (subclass of <code>w3cgeo:SpatialThing</code>)</td>
+<td>Geometries are represented with the <code>geo:</code> URI scheme</td>
+<td>Geometries are represented with a literal encoding of point coordinates</td>
+<td>
+<ul>
+<li><a href="http://schema.org/GeoCoordinates"><code>schema:GeoCoordinates</code></a></li>
+<li><a href="http://schema.org/GeoShape"><code>schema:GeoShape</code></a></li>
+<li><a href="http://schema.org/GeoCircle"><code>schema:GeoCircle</code></a></li>
+</ul>
+</td>
+<td><code>geosparql:Geometry</code>, and its subclasses (<code>sf:Point</code>, <code>sf:Polygon</code>, etc.)</td>
+<td><a href="http://www.w3.org/ns/locn#locn:Geometry"><code>locn:Geometry</code></a> (it denotes either a structured object or a literal)</td>
+</tr>
+<!--
+<tr>
+<th>Properties to specify coordinates</th>
+<td>-</td>
+<td><code>w3cgeo:lat_long</code>, <code>w3cgeo:lat</code>, <code>w3cgeo:long</code>, <code>w3cgeo:alt</code></td>
+<td><a href="https://www.w3.org/TR/vcard-rdf/#d4e239"><code>vcard:hasGeo</code></a></td>
+<td><a href="https://www.w3.org/2005/Incubator/geo/XGR-geo-20071023/#where"><code>georss:where</code></a>, <a href="https://www.w3.org/2005/Incubator/geo/XGR-geo-20071023/#point"><code>georss:point</code></a>, <a href="https://www.w3.org/2005/Incubator/geo/XGR-geo-20071023/#line"><code>georss:line</code></a>, <a href="https://www.w3.org/2005/Incubator/geo/XGR-geo-20071023/#polygon"><code>georss:polygon</code></a>, <a href="https://www.w3.org/2005/Incubator/geo/XGR-geo-20071023/#box"><code>georss:box</code></a></td>
+<td>
+<ul>
+<li><a href="http://schema.org/latitude"><code>schema:latitude</code></a>, <a href="http://schema.org/longitude"><code>schema:longitude</code></a>, <a href="http://schema.org/elevation"><code>schema:elevation</code></a></li>
+<li><a href="http://schema.org/box"><code>schema:box</code></a>, <a href="http://schema.org/elevation"><code>schema:elevation</code></a>, <a href="http://schema.org/line"><code>schema:line</code></a>, <a href="http://schema.org/polygon"><code>schema:polygon</code></a>, <a href="http://schema.org/circle"><code>schema:circle</code></a></li>
+<li><a href="http://schema.org/geoMidpoint"><code>schema:geoMidpoint</code></a>, <a href="http://schema.org/geoRadius"><code>schema:geoRadius</code></a></li>
+</ul>
+</td>
+<td><code>geosparql:hasSerialization</code>, <code>geosparql:asGML</code>, <code>geosparql:asWKT</code></td>
+<td><a href="http://www.w3.org/ns/locn#locn:geometry"><code>locn:geometry</code></a></td>
+</tr>
+-->
+<tr>
+<th colspan="8">Geometry specification</th>
+</tr>
+<!--
+<tr>
+<th rowspan="7">Coordinate specification</th>
+</tr>
+-->
+<tr>
+<th>CRS support</th>
+<td>-</td>
+<td>WGS84 only</td>
+<td>WGS84 only</td>
+<td>WGS84 only</td>
+<td>WGS84 only</td>
+<td>Any</td>
+<td>Any (depends on how the geometry is represented)</td>
+</tr>
+<tr>
+<th>Axis order support</th>
+<td>-</td>
+<td>lat/long only</td>
+<td>lat/long only</td>
+<td>lat/long only</td>
+<td>lat/long only</td>
+<td>Determined by the CRS used</td>
+<td>Any (depends on how the geometry is represented)</td>
+</tr>
+<tr>
+<th>0D support</th>
+<td>-</td>
+<td>lat/long coordinate pair (<code>w3cgeo:lat_long</code>), decimal degrees (<code>w3cgeo:lat</code>, <code>w3cgeo:long</code>), decimal metres (<code>w3cgeo:alt</code>)</td>
+<td><code>geo:</code> URI scheme</td>
+<td>lat/long coordinate pair</td>
+<td>lat/long coordinate pair</td>
+<td>[[GML]], <a>WKT</a></td>
+<td>[[GML]], <a>WKT</a>, GeoJSON, <code>geo:</code> URI scheme, <a>GeoHash</a></td>
+</tr>
+<!--
+<tr>
+<th>1D (lines)</th>
+<td>-</td>
+<td>-</td>
+<td>-</td>
+<td>lat/long coordinate pairs, separated by a comma</td>
+<td>lat/long coordinate pairs, separated by a comma or a space</td>
+<td>[[GML]], <a>WKT</a></td>
+<td>[[GML]], <a>WKT</a>, GeoJSON</td>
+</tr>
+<tr>
+<td>2D (surfaces)</td>
+<td>-</td>
+<td>-</td>
+<td>-</td>
+<td>lat/long coordinate pairs, separated by a comma</td>
+<td>lat/long coordinate pairs, separated by a comma or a space</td>
+<td>[[GML]], <a>WKT</a></td>
+<td>[[GML]], <a>WKT</a>, GeoJSON</td>
+</tr>
+-->
+<tr>
+<th>1D and 2D support</th>
+<td>-</td>
+<td>-</td>
+<td>-</td>
+<td>lat/long coordinate pairs, separated by a comma</td>
+<td>lat/long coordinate pairs, separated by a comma or a space</td>
+<td>[[GML]], <a>WKT</a></td>
+<td>[[GML]], <a>WKT</a>, GeoJSON</td>
+</tr>
+<tr>
+<th>3D support</th>
+<td>-</td>
+<td>-</td>
+<td>-</td>
+<td>-</td>
+<td>-</td>
+<td>[[GML]]</td>
+<td>[[GML]]</td>
+</tr>
+</tbody>
+</table>
+
+<!-- @andrea-perego -->        
+        
+<!--        
       <table id="x-ref_formatVbp">
         <caption>An attempt at matrix of the common formats (GeoJSON, [[GML]], RDF, JSON-LD) and what
           you can or can't achieve with it. (<span style="background-color:yellow">source:
@@ -4027,6 +4432,9 @@ a:Dataset a dcat:Dataset ;
           <td> used for sharing spatial data in tiles, mainly for display in maps </td>
         </tr>
       </table>
+      
+-->      
+      
     </section>    
     <section class="appendix" id="BP_Benefits" class="informative">
       <h2>Best Practices Benefits</h2>
@@ -4326,4 +4734,4 @@ a:Dataset a dcat:Dataset ;
       </section>
     </section>
   </body>
-</html>
+</html> 


### PR DESCRIPTION
- Replaced the two format tables in Appendix A with a table for formats and a table for the spatial data vocabularies listed in [section 12.2.1](https://andrea-perego.github.io/sdw/bp/#bp-expressing-spatial)
- Minor changes to CSS statements, to style the two new tables
- Re-ordered vocabularies in [section 12.2.1](https://andrea-perego.github.io/sdw/bp/#bp-expressing-spatial) to reflect the order in the new table for spatial data vocabularies in Appendix A
- Editorial changes to [section 12.2.1](https://andrea-perego.github.io/sdw/bp/#bp-expressing-spatial)
- Replaced links and inline citations of RDFa, vCard, GeoRSS specs with the corresponding bib refs