### PR TITLE
added clarification to use WGS84 for spatial metadata

### DIFF
--- a/bp/index.html
+++ b/bp/index.html
@@ -3507,7 +3507,7 @@ GID,On Street,Long,Lat,Species,Trim Cycle,Diameter at Breast Ht,Inventory Date,C
             <ul>
               <li>number of dimensions (1D, 2D, 3D, 4D)</li>
               <li>spatial representation type (e.g. grid, vector, text table)</li>
-              <li>geometric property (e.g. boundary, region, centerline, centroid, field</li>
+              <li>geometric property (e.g. boundary, bounding box, region, centerline, centroid, field) - expressed in the WGS 84 coordinate reference system to make the metadata consumable by as broad an audience as possible (see <a href="#bp-crs-choice" class="sectionRef">Best Practice 7: Choose coordinate reference systems to suit your user's applications</a> for more information).</li>
               <li>Coordinate Reference System(s) - refer to <a href="#CRS-background" class="sectionRef"></a> for an introduction to that topic</li>
               <li>spatial resolution - <a href="#desc-accuracy" class="sectionRef">Best Practice 14: Describe the positional accuracy of spatial data</a></li>
               <li>spatial significance of non-spatial properties (e.g. point value, interpolation, unit average, sum)</li>


### PR DESCRIPTION
… such as bounding boxes etc.

See @ByronCinNZ ’s [email](https://lists.w3.org/Archives/Public/public-sdw-wg/2017Apr/0009.html) with this suggestion.