### PR TITLE
updates to BP8 based on discussions in Delft F2F

### DIFF
--- a/bp/index.html
+++ b/bp/index.html
@@ -2074,6 +2074,28 @@ BP8b :: multiple geometries -->
             <p>There are four common ways that this information can be provided:</p>
             <ol>
               <li>
+                <p>Describe the coordinate reference system in the dataset metadata.</p>
+                <pre class="example" id="ex-crs-dataset-metadata" title="Coordinate reference system stated in [GeoDCAT-AP] (TTL encoding)">
+@prefix ex:      &lt;http://data.example.org/datasets/&gt; .
+@prefix dcat:    &lt;http://www.w3.org/ns/dcat#&gt; .
+@prefix dcterms: &lt;http://purl.org/dc/terms/&gt; .
+@prefix skos:    &lt;http://www.w3.org/2004/02/skos/core#&gt; .
+
+ex:ExampleDataset 
+  a dcat:Dataset ;
+  dcterms:conformsTo &lt;http://www.opengis.net/def/crs/EPSG/0/32630&gt; .
+
+&lt;http://www.opengis.net/def/crs/EPSG/0/32630&gt; 
+  a dcterms:Standard, skos:Concept ;
+  dcterms:type &lt;http://inspire.ec.europa.eu/glossary/SpatialReferenceSystem&gt; ;
+  dcterms:identifier "http://www.opengis.net/def/crs/EPSG/0/32630"^^xsd:anyURI ;
+  skos:prefLabel "WGS 84 / UTM zone 30N"@en ;
+  skos:inScheme &lt;http://www.opengis.net/def/crs/EPSG/0/&gt; .
+                </pre>
+                <p>The example above illustrates how to describe the coordinate reference system used for a dataset within [[GeoDCAT-AP]] metadata. The <code>conformsTo</code> property from [[DCTERMS]] is used to assert the relationship between dataset and CRS in the same way that conformance with a <em>standard</em> is expressed in [[VOCAB-DQV]].</p>
+                <p>Dataset metadata for spatial data should always provide details of the CRS used. For more information about dataset metadata, please refer to <a href="#spatial-info-dataset-metadata" class="sectionRef">Best Practice 13: Include spatial metadata in dataset metadata</a>.</p>
+              </li>
+              <li>
                 <p>Provide each coordinate value with explicit labels and provide metadata to indicate what each label means.</p>
                 <pre class="example" id="ex-crs-sepatate-axes-lables-w3c-basic-geo" title="Coordinate position provided using [W3C-BASIC-GEO]">
 @prefix w3cgeo: &lt;http://www.w3.org/2003/01/geo/wgs84_pos#&gt; .
@@ -2122,6 +2144,71 @@ BP8b :: multiple geometries -->
                 </div>
 
                 <p>The metadata for axis labels may also be provided in the documentation for an API from which the spatial data is accessed. For more information on documenting APIs, please refer to [[DWBP]] <a href="https://www.w3.org/TR/dwbp/#documentYourAPI">Best Practice 25: Provide complete documentation for your API</a>.</p>
+
+                <pre class="example" id="ex-crs-sepatate-axes-lables-tabular-data" title="Coordinate position provided using column in tabular data">
+GID,On Street,Long,Lat,Species,Trim Cycle,Diameter at Breast Ht,Inventory Date,Comments,Protected
+1,ADDISON AV,-122.15649,37.44096,Celtis australis,Large Tree Routine Prune,11,10/18/2010,,
+2,EMERSON ST,-122.15675,37.44096,Liquidambar styraciflua,Large Tree Routine Prune,11,6/2/2010,,
+6,ADDISON AV,-122.15630,37.44115,Robinia pseudoacacia,Large Tree Routine Prune,29,6/1/2010,cavity or decay; trunk decay; codominant leaders; included bark; large leader or limb decay; previous failure root damage; root decay;  beware of BEES,YES
+                </pre>
+                <p>In this example (adapted from the City of Palo Alto tree operations database and published as <a href="https://fusiontables.google.com/DataSource?docid=1XKUADil8qq1PT6xkJV3FF9bqLAZj2tBXwTTI_rc#rows:id=1">tabular data</a> and as an <a href="https://fusiontables.google.com/DataSource?docid=1XKUADil8qq1PT6xkJV3FF9bqLAZj2tBXwTTI_rc#map:id=3">interactive map</a>) the coordinate position of each tree is specified using separate columns (<code>Long</code> and <code>Lat</code>).</p>
+
+                <p>We see the definitions of those <code>Long</code> and <code>Lat</code> columns provided in the dataset metadata, in this case a tabular metadata document, as per approach (1) above. <code>Long</code> and <code>Lat</code> are mapped onto the definitions provided by [[W3C-BASIC-GEO]] to ensure that the meaning of the data values in those columns is clear:</p> 
+
+                <pre class="example" id="ex-crs-sepatate-axes-lables-tabular-metadata" title="Abridged tabular metadata providing column meanings">
+{
+  "@context": ["http://www.w3.org/ns/csvw", {"@language": "en"}],
+  "@id": "http://example.org/tree-ops-db",
+  "url": "tree-ops-db.csv",
+  "dc:title": "Tree Operations",
+  ...
+  "tableSchema": {
+    "columns": [{
+      "name": "GID",
+      "titles": [
+        "GID",
+        "Generic Identifier"
+      ],
+      "dc:description": "An identifier for the operation on a tree.",
+      "datatype": "string",
+      "required": true, 
+      "suppressOutput": true
+    }, {
+      "name": "on_street",
+      "titles": "On Street",
+      "dc:description": "The street that the tree is on.",
+      "datatype": "string"
+    }, {
+      "name": "Long",
+      "titles": "Longitude",
+      "dc:description": "The WGS84 longitude of the tree (decimal degrees).",
+      "propertyUrl": "http://www.w3.org/2003/01/geo/wgs84_pos#long"
+      "datatype": {
+        "base": "number",
+        "minimum": "-180",
+        "maximum": "180"
+      }
+    }, {
+      "name": "Lat",
+      "titles": "Latitude",
+      "propertyUrl": "http://www.w3.org/2003/01/geo/wgs84_pos#lat"
+      "dc:description": "The WGS84 latitude of the tree (decimal degrees).",
+      "datatype": {
+        "base": "number",
+        "minimum": "-90",
+        "maximum": "90"
+      }
+    },
+    ...
+    "primaryKey": "GID",
+    "aboutUrl": "http://example.org/tree-ops-ext#gid-{GID}"
+  }
+}
+                </pre>
+
+                <div class="note">
+                  <p>Please refer to [[TABULAR-DATA-PRIMER]] <a href="https://www.w3.org/TR/tabular-data-primer/#geospatial">section 6.2 How do you support geospatial data?</a> for more details on working with geospatial content in tabular data.</p>
+                </div>
               </li>
               <li>
                 <p>Use a data format that specifies axes, their order, datum and unit of measurement for coordinates.</p>
@@ -2249,94 +2336,6 @@ Content-type: application/geo+json
 <p>For this reason, whenever using <a>WKT</a> to encode geometries, it is important that the reference <a>WKT</a> specification can be unambiguously determined.</p>
 <!-- @andrea-perego -->
                 </div>
-              </li>
-              <li>
-                <p>Describe the coordinate reference system in the dataset metadata.</p>
-                <pre class="example" id="ex-crs-dataset-metadata" title="Coordinate reference system stated in [GeoDCAT-AP] (TTL encoding)">
-@prefix ex:      &lt;http://data.example.org/datasets/&gt; .
-@prefix dcat:    &lt;http://www.w3.org/ns/dcat#&gt; .
-@prefix dcterms: &lt;http://purl.org/dc/terms/&gt; .
-@prefix skos:    &lt;http://www.w3.org/2004/02/skos/core#&gt; .
-
-ex:ExampleDataset 
-  a dcat:Dataset ;
-  dcterms:conformsTo &lt;http://www.opengis.net/def/crs/EPSG/0/32630&gt; .
-
-&lt;http://www.opengis.net/def/crs/EPSG/0/32630&gt; 
-  a dcterms:Standard, skos:Concept ;
-  dcterms:type &lt;http://inspire.ec.europa.eu/glossary/SpatialReferenceSystem&gt; ;
-  dcterms:identifier "http://www.opengis.net/def/crs/EPSG/0/32630"^^xsd:anyURI ;
-  skos:prefLabel "WGS 84 / UTM zone 30N"@en ;
-  skos:inScheme &lt;http://www.opengis.net/def/crs/EPSG/0/&gt; .
-                </pre>
-                <p>The example above illustrates how to describe the coordinate reference system used for a dataset within [[GeoDCAT-AP]] metadata. The <code>conformsTo</code> property from [[DCTERMS]] is used to assert the relationship between dataset and CRS in the same way that conformance with a <em>standard</em> is expressed in [[VOCAB-DQV]].</p>
-                <p>For more information about dataset metadata, please refer to <a href="#spatial-info-dataset-metadata" class="sectionRef">Best Practice 13: Include spatial metadata in dataset metadata</a>.</p>
-
-                <pre class="example" id="ex-crs-sepatate-axes-lables-tabular-data" title="Coordinate position provided using column in tabular data">
-GID,On Street,Long,Lat,Species,Trim Cycle,Diameter at Breast Ht,Inventory Date,Comments,Protected
-1,ADDISON AV,-122.15649,37.44096,Celtis australis,Large Tree Routine Prune,11,10/18/2010,,
-2,EMERSON ST,-122.15675,37.44096,Liquidambar styraciflua,Large Tree Routine Prune,11,6/2/2010,,
-6,ADDISON AV,-122.15630,37.44115,Robinia pseudoacacia,Large Tree Routine Prune,29,6/1/2010,cavity or decay; trunk decay; codominant leaders; included bark; large leader or limb decay; previous failure root damage; root decay;  beware of BEES,YES
-                </pre>
-                <p>In this example (adapted from the City of Palo Alto tree operations database and published as <a href="https://fusiontables.google.com/DataSource?docid=1XKUADil8qq1PT6xkJV3FF9bqLAZj2tBXwTTI_rc#rows:id=1">tabular data</a> and as an <a href="https://fusiontables.google.com/DataSource?docid=1XKUADil8qq1PT6xkJV3FF9bqLAZj2tBXwTTI_rc#map:id=3">interactive map</a>) the coordinate position of each tree is specified using separate columns (<code>Long</code> and <code>Lat</code>) as recommended in approach (1) above.</p>
-
-                <p>As shown in the abridged tabular metadata document, the columns <code>Long</code> and <code>Lat</code> are mapped onto the definitions provided by [[W3C-BASIC-GEO]] to ensure that the meaning of the data values in those columns is clear:</p> 
-
-                <pre class="example" id="ex-crs-sepatate-axes-lables-tabular-metadata" title="Abridged tabular metadata providing column meanings">
-{
-  "@context": ["http://www.w3.org/ns/csvw", {"@language": "en"}],
-  "@id": "http://example.org/tree-ops-db",
-  "url": "tree-ops-db.csv",
-  "dc:title": "Tree Operations",
-  ...
-  "tableSchema": {
-    "columns": [{
-      "name": "GID",
-      "titles": [
-        "GID",
-        "Generic Identifier"
-      ],
-      "dc:description": "An identifier for the operation on a tree.",
-      "datatype": "string",
-      "required": true, 
-      "suppressOutput": true
-    }, {
-      "name": "on_street",
-      "titles": "On Street",
-      "dc:description": "The street that the tree is on.",
-      "datatype": "string"
-    }, {
-      "name": "Long",
-      "titles": "Longitude",
-      "dc:description": "The WGS84 longitude of the tree (decimal degrees).",
-      "propertyUrl": "http://www.w3.org/2003/01/geo/wgs84_pos#long"
-      "datatype": {
-        "base": "number",
-        "minimum": "-180",
-        "maximum": "180"
-      }
-    }, {
-      "name": "Lat",
-      "titles": "Latitude",
-      "propertyUrl": "http://www.w3.org/2003/01/geo/wgs84_pos#lat"
-      "dc:description": "The WGS84 latitude of the tree (decimal degrees).",
-      "datatype": {
-        "base": "number",
-        "minimum": "-90",
-        "maximum": "90"
-      }
-    },
-    ...
-    "primaryKey": "GID",
-    "aboutUrl": "http://example.org/tree-ops-ext#gid-{GID}"
-  }
-}
-                </pre>
-
-                <div class="note">
-                  <p>Please refer to [[TABULAR-DATA-PRIMER]] <a href="https://www.w3.org/TR/tabular-data-primer/#geospatial">section 6.2 How do you support geospatial data?</a> for more details on working with geospatial content in tabular data.</p>
-                </div>
-
               </li>
             </ol>
           </section>


### PR DESCRIPTION
At Delft, we said that you should _always_ specify the CRS of a spatial dataset in the metadata. BP8 is now amended to reflect this … and moved a couple of other bits around to improve the reading flow.