### PR TITLE
Add BP3 in chapter 11

### DIFF
--- a/bp/index.html
+++ b/bp/index.html
@@ -1124,6 +1124,7 @@ function init() {
       <ul>
         <li><a href="#globally-unique-ids">Best Practice 1: Use globally unique persistent HTTP URIs for spatial things</a></li>
         <li><a href="#indexable-by-search-engines">Best Practice 2: Make your <a>spatial data</a> indexable by search engines</a></li>
+        <li><a href="#linking">Best Practice 3: Link resources together to create the Web of data</a></li>
         <li><a href="#convenience-apis">Best Practice 12: Expose spatial data through 'convenience APIs'</a></li>
       </ul>
       <p>The rest of the best practices provide more detail on specific aspects of publishing <a>spatial data</a> on the Web, such as metadata, <a>geometries</a>, <a>CRS</a> information, versioned data, and so on.</p>


### PR DESCRIPTION
In 12.1.3 we say that "the widespread use of links within data is
regarded as one of the most significant departures from contemporary
practices used within SDIs."

To be consistent, we should include BP3 in the list of key BPs in the
"Why are traditional Spatial Data Infrastructures not enough?" section.