### PR TITLE
BP: Editorial changes

### DIFF
--- a/bp/index.html
+++ b/bp/index.html
@@ -1136,7 +1136,7 @@ function init() {
 
       <p>It is worth noting that the precision with which coordinate positions are reported often do not reflect the accuracy of the measurement. For example, <a>latitude</a> and <a>longitude</a> reported to six decimal places corresponds to a precision of around 1cm on the ground. Such accuracy can only be achieved with professional equipment, yet a lot of software defaults to use of six, seven or even more decimal places when expressing coordinate positions which may mislead users to thinking that the data is more accurate than it actually is!</p>
       
-      <p>As with everything to do with <a>spatial data</a>, things can get more complicated. One of the most common problems occurs because not all <a>Coordinate Reference Systems</a> (CRS) agree how to express <a>latitude</a> and <a>longitude</a> coordinates. Some CRS order the coordinates <em>Lat/Long</em> while others use <em>Long/Lat</em>; some use <em>decimal degrees</em> while others use <em>degrees, minutes and seconds</em> (<em>dms</em>). <a>axis order</a> mistakes can mean the difference between, say, a position in the Netherlands or somewhere in Somalia, while encoding coordinates in <em>decimal degrees</em> when <em>dms</em> is expected can lead to positional errors on the kilometer scale.  </p>
+      <p>As with everything to do with <a>spatial data</a>, things can get more complicated. One of the most common problems occurs because not all <a>Coordinate Reference Systems</a> (CRS) agree how to express <a>latitude</a> and <a>longitude</a> coordinates. Some CRS order the coordinates <em>Lat/Long</em> while others use <em>Long/Lat</em>; some use <em>decimal degrees</em> while others use <em>degrees, minutes and seconds</em> (<em>dms</em>). <a>Axis order</a> mistakes can mean the difference between, say, a position in the Netherlands or somewhere in Somalia, while encoding coordinates in <em>decimal degrees</em> when <em>dms</em> is expected can lead to positional errors on the kilometer scale.  </p>
       
       <p>Therefore, it is very important to provide explicit information to your users about how coordinates are encoded. For example, this snippet of results from the <a href="https://developers.google.com/maps/documentation/geocoding/intro">Google Geocoding API</a> makes explicit which is the <a>latitude</a> and which is the <a>longitude</a> coordinate. </p>
 
@@ -1848,7 +1848,7 @@ Connection: close
         </section>
         <section id="geometry-and-crs">
           <h4>Geometries and coordinate reference systems</h4>
-          <p>Location information is often a common thread running through <a>spatial data</a> and can be an important 'hook' for finding information and for integrating different datasets. There are different ways of describing the location of <a>spatial things</a>. You can use and/or refer to the name of a well-known named place, provide the location's coordinates as a <a>geometry</a> or describe it in relation to another location. Providing multiple representations i.e. several <a>geometries</a> for one Spatial Thing can also be helpful, allowing data users to choose the one that fits their use case. When providing coordinates, it is important choose the <a>coordinate reference system</a> with care and communicate which one it is.</p>
+          <p>Location information is often a common thread running through <a>spatial data</a> and can be an important 'hook' for finding information and for integrating different datasets. There are different ways of describing the location of <a>spatial things</a>. You can use and/or refer to the name of a well-known named place, provide the location's coordinates as a <a>geometry</a> or describe it in relation to another location. Providing multiple representations i.e. several <a>geometries</a> for one <a>spatial thing</a> can also be helpful, allowing data users to choose the one that fits their use case. When providing coordinates, it is important choose the <a>coordinate reference system</a> with care and communicate which one it is.</p>
 		
         <div class="practice">
           <p><span id="describe-geometry" class="practicelab">Provide geometries on the Web in a usable way</span></p>
@@ -1857,7 +1857,7 @@ Connection: close
             <h4 class="subhead">Why</h4>
             <p>The geospatial, Linked Data, and Web communities use different <a>geometry</a> formats and tools, which reflect different requirements with respect to data complexity and manipulation.</p>
             <p>When deciding how a <a>geometry</a> should be described, it is therefore necessary to consider the intended uses and the related user communities. Which may imply providing alternative geometry descriptions.</p>
-            <p>This best practice helps with choosing the right format for describing <a>geometries</a>, based on aspects like intended use(s), performance, and tool support. It also helps deciding on when using literals rather than structured objects for geometric representations is a good idea.</p>
+            <p>This best practice helps with choosing the right format for describing <a>geometries</a>, based on aspects like intended use(s), performance, and tool support. It also helps with deciding on when using literals rather than structured objects for geometric representations is a good idea.</p>
             <div class="note">
               <p>This best practice is strictly correlated to <a href="#multiplegeometries" class="sectionRef"></a>, <a href="#bp-crs-choice" class="sectionRef"></a>, and <a href="#bp-crs" class="sectionRef"></a>, to which we refer the reader for more information.</p>
 <!--
@@ -2232,10 +2232,12 @@ Connection: close
   bag:geometriePand     &lt;http://bag.basisregistraties.overheid.nl/bag/id/geometry/5C1F8F11324717378B437B2CD12871FF&gt; ;
   
 # Centroid
+
   w3cgeo:lat  "52.37509"^^xsd:float ;
   w3cgeo:long "4.88412"^^xsd:float ;
   
 # Bounding box
+
   georss:box "52.3749,4.8838 52.3753,4.8845"^^xsd:string .
 .
 </pre>
@@ -2564,7 +2566,7 @@ Content-type: application/geo+json
   }
 }
                 </pre>
-                <p>The media type <code>application/geo+json</code> is used to designate that content is provided in GeoJSON [[RFC7946]] format, as specified in [[RFC7946]].</p>
+                <p>The media type <code>application/geo+json</code> is used to designate that content is provided in GeoJSON format, as specified in [[RFC7946]].</p>
                 <p>[[RFC7946]] <a href="https://tools.ietf.org/html/rfc7946#section-4">Section 4. Coordinate Reference System</a> provides all the necessary information to interpret the coordindates, stating that:</p>
                 <p style="margin-left: 40px"><em>The <a>coordinate reference system</a> for all GeoJSON [[RFC7946]] coordinates is a geographic coordinate reference system, using the World Geodetic System 1984 (WGS 84) [WGS84] <a>datum</a>, with <a>longitude</a> and <a>latitude</a> units of decimal degrees.  This is equivalent to the coordinate reference system identified by the Open Geospatial Consortium (OGC) URN urn:ogc:def:crs:OGC::CRS84.  An OPTIONAL third-position element SHALL be the height in meters above or below the WGS 84 reference <a>ellipsoid</a>.  In the absence of elevation values, applications sensitive to height or depth SHOULD interpret positions as being at local ground or sea level.</em></p>
 
@@ -2957,7 +2959,7 @@ Content-type: application/geo+json
   &lt;/script&gt;
                   </pre>
   
-                  <p>This example snippet, adapted to use [[RFC7946]] GeoJSON [[RFC7946]] format, shows a list of <a>spatial things</a> (e.g. Westerkerk, Homomonument and Westertoren) that are deemed '<a href="http://sws.geonames.org/6618987/nearby.rdf">nearby</a>' Anne Frank's House according to <a href="http://www.geonames.org">GeoNames</a>.</p>
+                  <p>This example snippet, adapted to use the GeoJSON [[RFC7946]] format, shows a list of <a>spatial things</a> (e.g. Westerkerk, Homomonument and Westertoren) that are deemed '<a href="http://sws.geonames.org/6618987/nearby.rdf">nearby</a>' Anne Frank's House according to <a href="http://www.geonames.org">GeoNames</a>.</p>
   
                   <div class="note">
                     <p>The [[RFC7159]] <a>JSON</a> format provides only simple primitive types; string, number, boolean etc. The lack of a datatype for URIs means that they must be encoded as strings. As such, conventions (such as those defined in <a href="http://stateless.co/hal_specification.html">HAL</a>) are required to tell applications that a given string value is a URI. However, [[RFC7946]] GeoJSON [[RFC7946]] does not define any conventions for describing URIs and forbids any extension of the data format specification.</p>
@@ -3862,15 +3864,15 @@ another:Dataset a dcat:Dataset ;
                 <li>a <a>coverage</a> dataset may have a ground sampling distance of 1000 meters</li>
               </ul>
             </aside>
-            <p>The following example shows how DQV can express conformance to a specified positional accuracy</p>
+            <p>The following example shows how [[VOCAB-DQV]] can express conformance to a specified positional accuracy</p>
             <pre class="example" id="ex-geodcat-ap-dataset-conformance-with-specification2" title="GeoDCAT-AP specification of a dataset conformance with IHO's S44">a:Dataset a dcat:Dataset ;
   dct:conformsTo &lt;<a href="https://www.iho.int/iho_pubs/standard/S-44_5E.pdf">https://www.iho.int/iho_pubs/standard/S-44_5E.pdf#Special</a>&gt; .
 
 &lt;<a href="https://www.iho.int/iho_pubs/standard/S-44_5E.pdf">https://www.iho.int/iho_pubs/standard/S-44_5E.pdf</a>&gt; a dct:Standard , foaf:Document ;
   dct:title "IHO Standards for Hydrographic Surveys"@en ;
   dct:issued "2008-02-01"^^xsd:date.</pre>
-            <p>The following example shows how DQV can express the amount of detail in a <a>coverage</a> dataset: </p>
-            <pre class="example" id="ex-dqv-dataset-quality" title="DQV specification of data quality">
+            <p>The following example shows how [[VOCAB-DQV]] can express the amount of detail in a <a>coverage</a> dataset: </p>
+            <pre class="example" id="ex-dqv-dataset-quality" title="[VOCAB-DQV] specification of data quality">
 :myDataset a dcat:Dataset ;
    dqv:hasQualityMeasurement :myDatasetPrecision, :myDatasetAccuracy .
 
@@ -3887,7 +3889,7 @@ another:Dataset a dcat:Dataset ;
     .
             </pre>
             <p>This example was taken from [[VOCAB-DQV]]. For more examples of expressing <a>spatial data</a>
-              precision and accuracy see DQV, <a
+              precision and accuracy see [[VOCAB-DQV]], <a
                 href="https://www.w3.org/TR/vocab-dqv/#h-expressdatasetaccuracyprecision">Express
                 dataset precision and accuracy</a>. 
             </p>
@@ -4195,7 +4197,7 @@ another:Dataset a dcat:Dataset ;
 </tr>
 -->
 <tr>
-<th><a>axis order</a> support</th>
+<th><a>Axis order</a> support</th>
 <td>Any, but it cannot be explicitly specified - e.g., in [[SIMPLE-FEATURES]]'s <a>WKT</a> and <a href="http://www.postgis.net/docs/ST_AsEWKT.html">EWKT</a> it defaults to longitude/latitude, whereas in [[GeoSPARQL]]'s WKT it is determined by the CRS used</td>
 <td>Determined by the CRS used</td>
 <td>Longitude / latitude only, with optional altitude</td>
@@ -4339,7 +4341,7 @@ another:Dataset a dcat:Dataset ;
 <td>Any (depends on how the geometry is represented)</td>
 </tr>
 <tr>
-<th><a>axis order</a> support</th>
+<th><a>Axis order</a> support</th>
 <td>-</td>
 <td>lat/long only</td>
 <td>lat/long only</td>


### PR DESCRIPTION
- Small editorial fixes to BP5 & BP6
- Replaced "DQV" inline citation with corresponding bib ref
- In three places, "axis order" should have been capitalised ("Axis order"). Fixed.
- Fixed 2 redundant repetitions of GeoJSON bib ref. The relevant text:
  > This example snippet, adapted to use [[RFC7946]] GeoJSON [[RFC7946]] format [...]

  > The media type application/geo+json is used to designate that content is provided in GeoJSON [[RFC7946]] format, as specified in [[RFC7946]].