### PR TITLE
Fixed syntax bug in namespace table

### DIFF
--- a/bp/index.html
+++ b/bp/index.html
@@ -980,12 +980,12 @@ function init() {
             <td><a href="http://statistics.gov.scot/">STATISTICS.GOV.SCOT</a> Geography Linked Data</td>
           </tr>
           <tr>
-          <tr>
             <td><code>sf</code></td>
             <td>http://www.opengis.net/ont/sf#</td>
             <td><a href="#bib-GeoSPARQL">GeoSPARQL - A Geographic Query Language for RDF Data</a></td>
           </tr>            
-          <td><code>skos</code></td>
+	  <tr>
+            <td><code>skos</code></td>
             <td>http://www.w3.org/2004/02/skos/core#</td>
             <td><a href="#bib-SKOS-PRIMER">Simple Knowledge Organization System (SKOS)</a></td>
           </tr>


### PR DESCRIPTION
There was an unclosed &lt;tr&gt; tag in the wrong place, and a missing &lt;tr&gt; tag in another place.