### PR TITLE
BP12: Example about the GeoDCAT-AP API

### DIFF
--- a/bp/index.html
+++ b/bp/index.html
@@ -3528,11 +3528,6 @@ Content-type: application/geo+json
                   of writing generalized SPARQL queries and understanding the underpinning 
                   data model.</p> 
               </aside>  
-              
-<aside class="example" id="ex-geodcat-ap-api">
-<p>As far as metadata are concerned, the experimental <a href="https://webgate.ec.europa.eu/CITnet/stash/projects/ODCKAN/repos/iso-19139-to-dcat-ap/browse/api">GeoDCAT-AP API</a> allows data publishers to serve [[ISO-19115]] records in different <a>RDF</a> serialization formats, [[HTML-RDFa]] included, on top of a geospatial catalog, by using the standard [[CSW]] query interface, and supporting HTTP content negotiation.</p>
-</aside>
-              
               </li>  
               
               <li>
@@ -3706,6 +3701,11 @@ Content-type: application/geo+json
               <a href="#applicability-formatVbp" class="sectionRef"></a>.</li>
               <li>Publish metadata in both machine- and human-readable format, following [[DWBP]] <a href="https://www.w3.org/TR/dwbp/#ProvideMetadata">Best Practice 1: Provide metadata</a>.</li>
             </ul>
+
+<aside class="example" id="ex-geodcat-ap-api">
+<p>The experimental <a href="https://webgate.ec.europa.eu/CITnet/stash/projects/ODCKAN/repos/iso-19139-to-dcat-ap/browse/api">GeoDCAT-AP API</a> allows data publishers to serve [[ISO-19115]] records in different <a>RDF</a> serialization formats, [[HTML-RDFa]] included, on top of a geospatial catalog, by using the standard [[CSW]] query interface, and supporting HTTP content negotiation.</p>
+</aside>
+
             <aside class="example" id="ex-geodcat-ap-dataset-spatial-representation-type" title="Specification of spatial representation type in [GeoDCAT-AP]">
               <p>[[GeoDCAT-AP]] models this information by using <code>adms:representationTechnique</code> [[VOCAB-ADMS]], with URIs
                 corresponding to the items in the appropriate <a

--- a/bp/index.html
+++ b/bp/index.html
@@ -3528,6 +3528,11 @@ Content-type: application/geo+json
                   of writing generalized SPARQL queries and understanding the underpinning 
                   data model.</p> 
               </aside>  
+              
+<aside class="example" id="ex-geodcat-ap-api">
+<p>As far as metadata are concerned, the experimental <a href="https://webgate.ec.europa.eu/CITnet/stash/projects/ODCKAN/repos/iso-19139-to-dcat-ap/browse/api">GeoDCAT-AP API</a> allows data publishers to serve [[ISO-19115]] records in different <a>RDF</a> serialization formats, [[HTML-RDFa]] included, on top of a geospatial catalog, by using the standard [[CSW]] query interface, and supporting HTTP content negotiation.</p>
+</aside>
+              
               </li>  
               
               <li>


### PR DESCRIPTION
The example about the GeoDCAT-API was originally included in the narrative (see last paragragh in [the relevant wiki page](https://www.w3.org/2015/spatial/wiki/BP_Narrative_2#.284.29_Publish_details_of_fixed_assets_.28e.g._dikes_.26_dams.2C_buildings.2C_roads.2C_critical_infrastructure_etc..29_and_topographical_features_.28e.g._water_bodies.29)).

The proposal is to add it to [BP12 ("Expose spatial data through 'convenience APIs'")](http://w3c.github.io/sdw/bp/#convenience-apis), under point (1) ("Reuse your existing spatial data infrastructure"), after Example 49.

The relevance for that section concerns the fact that the GeoDCAT-AP API allows geospatial catalogues and CSWs to serve geospatial metadata in HTML+RDFa and RDF, by using standard CSW query parameters - namely, `outputSchema` and `outputFormat`, and via HTTP content negotiation. (More details are available in [the API documentation page](https://webgate.ec.europa.eu/CITnet/stash/projects/ODCKAN/repos/iso-19139-to-dcat-ap/browse/api)).