### PR TITLE
BP2: Additional work on the use of Schema.org for spatial data

### DIFF
--- a/bp/index.html
+++ b/bp/index.html
@@ -1567,6 +1567,9 @@ function init() {
             
             <div class="note">
               <p>In 2016, these topics were analyzed in a testbed organized by Geonovum in the Netherlands. More details can be found in reports from the testbed: <a href="http://geo4web-testbed.github.io/topic4/">Spatial Data on the Web using the current SDI</a> and <a href="https://github.com/geo4web-testbed/topic3/wiki">Crawlable geospatial data using the ecosystem of the Web and Linked Data</a>.</p>
+              
+<p>The use of [[SCHEMA-ORG]] for describing spatial information have been also investigated in two studies, concerning, <a href="https://webgate.ec.europa.eu/CITnet/stash/projects/ODCKAN/repos/locn-mapping/">the former</a>, the definitions of mappings between [[LOCN]], [[VCARD-RDF]] and [[SCHEMA-ORG]], and, <a href="https://webgate.ec.europa.eu/CITnet/stash/projects/ODCKAN/repos/dcat-ap-to-schema.org/">the latter</a>, the definitions of mappings between [[GeoDCAT-AP]] and [[SCHEMA-ORG]].</p>
+              
               <p>The use of [[SCHEMA-ORG]] for describing spatial information is continually evolving; spatial data publishers should familiarize themselves with current practices. A useful <a href="https://developers.google.com/search/docs/guides/intro-structured-data">Introduction to Structured Data</a> is provided in Google's developer portal.</p>
             </div>
             


### PR DESCRIPTION
The last note in [BP2 (Make your spatial data indexable by search engines)](http://w3c.github.io/sdw/bp/#indexable-by-search-engines) cites work concerning the publication of geospatial meta/data by using Schema.org.

The proposal is to cite additional work concerning:
- [The mapping of LOCN to vCard and Schema.org](https://webgate.ec.europa.eu/CITnet/stash/projects/ODCKAN/repos/locn-mapping/)
- [The mapping of DCAT-AP (and GeoDCAT-AP) to Schema.org](https://webgate.ec.europa.eu/CITnet/stash/projects/ODCKAN/repos/dcat-ap-to-schema.org/)