### PR TITLE
mark as outdated

### DIFF
--- a/ssn/rdf/sosa.ttl
+++ b/ssn/rdf/sosa.ttl
@@ -1,3 +1,7 @@
+# ---------------------------------------------------------------------------------------------------------------
+# OUTDATED, PLEASE USE THE SOSA FILE AT https://github.com/w3c/sdw/blob/gh-pages/ssn/integrated/sosa.ttl INSTEAD.
+# ---------------------------------------------------------------------------------------------------------------
+
 # baseURI: http://www.w3.org/ns/sosa/
 # prefix: sosa
 


### PR DESCRIPTION
Would this be a solution for the moment:

# ---------------------------------------------------------------------------------------------------------------
# OUTDATED, PLEASE USE THE SOSA FILE AT https://github.com/w3c/sdw/blob/gh-pages/ssn/integrated/sosa.ttl INSTEAD.
# ---------------------------------------------------------------------------------------------------------------