### PR TITLE
BP: Added missing namespace prefix in example

### DIFF
--- a/bp/index.html
+++ b/bp/index.html
@@ -1959,9 +1959,10 @@ Connection: close
             <p>The following [[TURTLE]] snippet shows the [[GeoDCAT-AP]] representation of the dataset in <a href="#ex-schemaorg-dataset-and-place"></a>. Here the bounding box is provided in multiple literal encodings (<a>WKT</a>, [[GML]], GeoJSON [[RFC7946]]), by using property <code>locn:geometry</code> [[LOCN]].</p>
             <aside class="example" id="ex-geodcat-ap-bag-addresses" title="[GeoDCAT-AP] representation of dataset spatial coverage (bounding box) in multiple encodings">
               <pre>
-@prefix dcat:    &lt;http://www.w3.org/ns/dcat#&gt; .
-@prefix dcterms: &lt;http://purl.org/dc/terms/&gt; .
-@prefix locn:    &lt;http://www.w3.org/ns/locn#&gt; .
+@prefix dcat:      &lt;http://www.w3.org/ns/dcat#&gt; .
+@prefix dcterms:   &lt;http://purl.org/dc/terms/&gt; .
+@prefix geosparql: &lt;http://www.opengis.net/ont/geosparql#&gt; .
+@prefix locn:      &lt;http://www.w3.org/ns/locn#&gt; .
 
 &lt;http://www.ldproxy.net/bag/inspireadressen/&gt; a dcat:Dataset ;
   dcterms:title "Adressen"@nl ;


### PR DESCRIPTION
The declaration of namespace prefix `geosparql` was missing in [Example 15](https://w3c.github.io/sdw/bp/#ex-geodcat-ap-bag-addresses).