### PR TITLE
[time] Apply Director's recommendations, fix broken links and redirects

### DIFF
--- a/time/config.js
+++ b/time/config.js
@@ -12,7 +12,7 @@ var respecConfig = {
     {
         name: "Simon Cox",
         company: "CSIRO",
-        companyURL: "http://www.csiro.au/", 
+        companyURL: "https://www.csiro.au/",
         w3cid: 1796
       },{
         name: "Chris Little",
@@ -90,7 +90,7 @@ var respecConfig = {
       "cr-14": {
         authors: ["S.J.D. Cox" , "S.M. Richard"], 
         date: "2014", 
-        href: "http://dx.doi.org/10.1007/s12145-014-0166-2",
+        href: "http://doi.org/10.1007/s12145-014-0170-6",
         title: "A geologic timescale ontology and service. Earth Sci. Informatics.. 8 5–19. "
       },
       "fips": {
@@ -153,9 +153,10 @@ var respecConfig = {
         title: "The process file of the OWL-S 0.9 release"
       },
       "rc-14": {
-        href: "https://journals.uair.arizona.edu/index.php/radiocarbon/about/submissionsauthorGuidelines",
-        title: "Guidelines to Authors, Radiocarb. Mag. ",
-        date: "2014"
+        href: "http://nvlpubs.nist.gov/nistpubs/jres/109/2/j92cur.pdf",
+        title: "The Remarkable Metrological History of Radiocarbon Dating [II]",
+        date: "March-April 2004",
+        authors: ["Journal of Research of the National Institute of Standards and Technology"]
       }
     },
     issueBase: "https://www.w3.org/2015/spatial/track/issues/"

--- a/time/index.html
+++ b/time/index.html
@@ -76,7 +76,7 @@ temporal position including date-time information. Time positions and durations 
 <p><strong>For OGC -</strong> This is a Public Draft of a document prepared by the Spatial Data on the Web Working Group 
 	(<a href="http://www.opengeospatial.org/projects/groups/sdwwg">SDWWG</a>)
 — a joint W3C-OGC project (see <a href="https://www.w3.org/2015/spatial/charter">charter</a>). 
-The document is prepared following W3C conventions. </p>
+The document is prepared following W3C conventions. This document is not an OGC Standard. This document is distributed for review and comment. This document is subject to change without notice and may not be referred to as an OGC Standard. Recipients of this document are invited to submit, with their comments, notification of any relevant patent rights of which they are aware and to provide supporting documentation.</p>
 <p>The group expects to request transition to Proposed Recommendation once it has reviewed datasets that have adopted the ontology and completed the implementation report</p>
 <p class="note">New classes and properties are introduced in this revision of OWL-Time. The new elements primarily relate to relaxing the limitation that time position uses the Gregorian Calendar, and are placed in a logical hierarchy in relation to the original elements. While there is inevitably less implementation evidence for these than the elements that were introduced in the 2006 version, the new elements are essential to satisfying key requirements in the revision. However, a small number of other new elements - <code><a href="#time:MonthOfYear">:MonthOfYear</a></code>, <code><a href="#time:hasTime">:hasTime</a></code>, <code><a href="#time:hasXSDDuration">:hasXSDDuration</a></code>, <code><a href="#time:monthOfYear">:monthOfYear</a></code> - have been less strongly motivated and tested, so these are formally <i>features at risk</i> pending the accumulation of evidence of implementation. </p>
 </section>
@@ -114,7 +114,7 @@ The specification document has been completely re-written. </p>
 
 <section id="namespaces">
 <h2>Notation and namespaces</h2>
-	<p>Classes and properties from the Time Ontology are denoted using <a href="https://www.w3.org/TR/curie/">Compact URIs</a> [[!curie]]. </p>
+	<p>Classes and properties from the Time Ontology are denoted in this specification using <a href="https://www.w3.org/TR/curie/">Compact URIs</a> [[curie]]. </p>
 <p>The namespace for OWL-Time is <code>http://www.w3.org/2006/time#</code>. OWL-Time does not re-use elements from any other vocabularies, but does use some built-in datatypes from OWL and some additional types from XML Schema Part 2. </p>
 <p>The table below indicates the full list of namespaces and prefixes used in this document.</p>
 <table id="namespacesTable">
@@ -165,7 +165,7 @@ The specification document has been completely re-written. </p>
 </tbody>
 </table>
 
-<p>Where class descriptions include local restrictions on properties, these are described using the <a href="https://www.w3.org/TR/owl2-manchester-syntax/#Descriptions">OWL 2 Manchester Syntax</a> [[!owl2-manchester-syntax]]. </p>
+<p>Where class descriptions include local restrictions on properties, these are described using the <a href="https://www.w3.org/TR/owl2-manchester-syntax/#Descriptions">OWL 2 Manchester Syntax</a> [[owl2-manchester-syntax]]. </p>
 
 <p>Examples and other code fragments are serialized using <a href="https://www.w3.org/TR/turtle/">RDF 1.1 Turtle</a> notation [[!turtle]].</p>
 
@@ -341,7 +341,7 @@ xsd:gDay, respectively. </td>
 </tr>
 <tr>
 <td>Subclass of:</td>
-<td><code><a href="time:hasTRS">time:hasTRS</a> value <a href="http://www.opengis.net/def/uom/ISO-8601/0/Gregorian">&lt;http://www.opengis.net/def/uom/ISO-8601/0/Gregorian&gt;</a></code></td>
+<td><code><a href="#time:hasTRS">time:hasTRS</a> value <a href="http://www.opengis.net/def/uom/ISO-8601/0/Gregorian">&lt;http://www.opengis.net/def/uom/ISO-8601/0/Gregorian&gt;</a></code></td>
 </tr>
 <tr>
 <td>Subclass of:</td>
@@ -491,9 +491,6 @@ each of the numeric properties is restricted to <a href="https://www.w3.org/TR/x
 </tbody>
 </table>
 <p class="note">In the Gregorian calendar the length of the month is not fixed. Therefore, a value like "2.5 months" cannot be exactly compared with a similar duration expressed in terms of weeks or days.</p>
-<!--
-<p>Other duration concepts can be straightforwardly defined - see <a href="#specialization">examples below</a>.</p>
--->
 </section>
 
 <section>
@@ -2650,12 +2647,6 @@ The range of this property is not specified, so can be replaced by any specific 
 <p>IANA maintains a <a href="http://www.iana.org/time-zones">database of timezones</a>. These are well maintained and generally considered authoritative, but individual items are not available at individual URIs, so cannot be used directly within data expressed using OWL-Time. </p>
 <p>DBPedia provides a <a href="https://en.wikipedia.org/wiki/List_of_tz_database_time_zones">set of resources corresponding to the IANA timezones</a>, with a URI for each (e.g. <a href="http://dbpedia.org/resource/Australia/Eucla">http://dbpedia.org/resource/Australia/Eucla</a>). The World Clock service also provides a <a href="https://www.timeanddate.com/time/zones/">list of time zones</a> with the description of each available as an individual webpage with a convenient individual URI (e.g. <a href="https://www.timeanddate.com/time/zones/acwst">https://www.timeanddate.com/time/zones/acwst</a>). These or other, similar, resources might be used as a value of the <code><a href="#time:timeZone">time:timeZone</a></code> property. </p>
 </div>
-
-<!--        <p>An ontology for time zone descriptions is provided <a href="#timezone">below</a>.</p>
-<p class="issue" data-number="996">(Was local Issue 10) The time zone ontology provided in the Annex is immature and incomplete. Use of a <code>tzont:TimeZone</code> from that ontology as the range of an ObjectProperty in OWL-Time creates an implied dependency which
-is not ideal. We propose adding a stub class <code><a href="#time:TimeZone">:TimeZone</a></code> into the the main namespace (i.e. no
-properties) which can then be a super-class or equivalent class to any time zone formalization.(Compare with <a href="#time:">
-time:TRS</a> which is handled this way.) </p> -->
 </section>
 
 <section>
@@ -3446,7 +3437,7 @@ prov:startedAtTime owl:propertyChainAxiom (
 
 <section id="dcat-example">
 <h3>Legal interval</h3>
-<p>The <a href="https://www.w3.org/TR/vocab-dcat/#basic-example">basic example</a> in the [[vocab-dcat]] specification described the 'temporal range' of a dataset with reference to the resource <a href="http://reference.data.gov.uk/id/quarter/2006-Q1">http://reference.data.gov.uk/id/quarter/2006-Q1</a> which is one of many available from <code>data.gov.uk</code>. This resource defines a specific legal period - the first quarter of 2006 - formalized using the <a href="http://reference.data.gov.uk/def/intervals/">interval ontology</a> which is (currently) based on the 2006 version of OWL-Time. The period can be fully described using OWL-Time, omitting all elements from the intervals ontology, as follows: </p>
+<p>The <a href="https://www.w3.org/TR/vocab-dcat/#basic-example">basic example</a> in the [[vocab-dcat]] specification described the 'temporal range' of a dataset with reference to the resource <a href="http://reference.data.gov.uk/id/quarter/2006-Q1">http://reference.data.gov.uk/id/quarter/2006-Q1</a> which is one of many available from <code>data.gov.uk</code>. This resource defines a specific legal period - the first quarter of 2006 - formalized using the <a href="http://reference.data.gov.uk/def/intervals">interval ontology</a> which is (currently) based on the 2006 version of OWL-Time. The period can be fully described using OWL-Time, omitting all elements from the intervals ontology, as follows: </p>
 
 <pre>ex:i2006-Q1
   rdf:type :ProperInterval ;
@@ -3897,7 +3888,7 @@ The principal technical changes are as follows: </p>
 <li>The ontology is internally consistent with respect to domains, ranges, inverses, and any other ontology features specified.</li>
 <li>Each class and property must satisfy at least one of: 
 	<ul>
-		<li>Demonstrated use in two external implementations</li>
+		<li>Demonstrated use in two external producer implementations and two external consumer implementations</li>
 		<li>Has a position in the upper levels of a subsumption hierarchy within OWL-Time itself</li>
 		<li>Is required to complete a set where other members of the set meet one of the previous criteria (e.g. days, months, interval-relations).</li>
 	</ul>


### PR DESCRIPTION
This commit contains changes made to publish the Candidate Recommendation of the ontology, in response to Director's comments and errors reported by W3C pubrules and link checkers.

References to Curie and Manchester syntax are now informative in particular.