### PR TITLE
Minor changes to TimeseriesML section in CoverageJSON document

### DIFF
--- a/coverage-json/index.html
+++ b/coverage-json/index.html
@@ -392,7 +392,8 @@ _:SST &lt;http://www.w3.org/2005/Incubator/ssn/ssnx/ssn#observedProperty&gt; &lt
 
     <section>
       <h3>OGC TimeseriesML</h3>
-      <p>CoverageJSON can be used to record data that take the form of timeseries, for example measurements of flow rate in in a river, or average London rainfall over time. [[TimeseriesML]] specializes in recording such data and provides features over and above the capabilities of CoverageJSON. For example, in TimeseriesML, richer metadata can be added to better describe the data values being measured (the range) and their relationship to time (the domain). For example, a data value in the range may be defined to represent an accumulation or average of a quantity over time, and the time values in the domain may be defined to mark the start, end or middle of the time period in question. In CoverageJSON, this level of description is not yet possible.</p>
+      <p>CoverageJSON can be used to record data that take the form of timeseries, for example measurements of flow rate in in a river, or average London rainfall over time. [[TimeseriesML]] specializes in recording such data and provides some features that are not provided in CoverageJSON. For example, in TimeseriesML, richer metadata can be added to better describe the data values being measured (the range) and their relationship to time (the domain). For example, a data value in the range may be defined to represent an accumulation, maximum, minimum or average of a quantity over time, and the time values in the domain may be defined to mark the start, end or middle of the time period in question. In CoverageJSON, this level of description is not yet possible.</p>
+      <p>Version 1.0 of TimeseriesML (the current version at the time of writing) does not permit the association of multiple parameters at each data point, whereas this is permitted in CoverageJSON.</p>
     </section>
     </section>
 


### PR DESCRIPTION
Following comments by Chris Little. Added more examples of "interpolation types" and highlighted that TimeseriesML v1.0 does not support multiple parameters being associated with a data point.