### PR TITLE
[SSN] Fix reported wrong links and typos

### DIFF
--- a/ssn/index.html
+++ b/ssn/index.html
@@ -1005,7 +1005,7 @@ their usage are given.</p>
         <section class="informative" id="Actuations-overview">
           <h4>Overview and examples</h4>
           <p>The following figure provides an overview of the core classes
-             and properties that are secifically related to modeling Actuations.
+             and properties that are specifically related to modeling Actuations.
             <span class="ssn">SOSA axioms are shown in green, while SSN-only axioms are shown in blue.</span>
           </p>
           <div class="buttonpanel" style="justify-content: center;">
@@ -1367,7 +1367,7 @@ their usage are given.</p>
       <section class="informative" id="Sampling-overview">
         <h4>Overview and examples</h4>
         <p>The following figure provides an overview of the core classes
-           and properties that are secifically related to modeling Samplings.
+           and properties that are specifically related to modeling Samplings.
           <span class="ssn">SOSA axioms are shown in green, while SSN-only axioms are shown in blue.</span>
         </p>
         <div class="buttonpanel" style="justify-content: center;">
@@ -1757,7 +1757,7 @@ their usage are given.</p>
         <h4>Overview and examples</h4>
         <div class="ssn">
           <p>The following figure provides an overview of the core classes
-             and properties that are secifically related to modeling Features of Interest and Properties.
+             and properties that are specifically related to modeling Features of Interest and Properties.
             <span class="ssn">SOSA axioms are shown in green, while SSN-only axioms are shown in blue.</span>
           </p>
           <figure>
@@ -2040,7 +2040,7 @@ their usage are given.</p>
           <h4>Overview and examples</h4>
           <div>
             <p>The following figure provides an overview of the core classes
-               and properties that are secifically related to modeling Results.
+               and properties that are specifically related to modeling Results.
               SOSA axioms are shown in green, while SSN-only axioms are shown in blue.
             </p>
             <figure>
@@ -2235,7 +2235,7 @@ their usage are given.</p>
           <h4>Overview and examples</h4>
           <div>
             <p>The following figure provides an overview of the core classes
-               and properties that are secifically related to modeling Procedures.
+               and properties that are specifically related to modeling Procedures.
               SOSA axioms are shown in green, while SSN-only axioms are shown in blue.
             </p>
             <figure class="ssn">
@@ -2566,7 +2566,7 @@ their usage are given.</p>
           <h4>Overview and examples</h4>
           <div>
             <p>The following figure provides an overview of the core classes
-               and properties that are secifically related to modeling systems and their deployment.
+               and properties that are specifically related to modeling systems and their deployment.
               SOSA axioms are shown in green, while SSN-only axioms are shown in blue.
             </p>
             <figure class="ssn">
@@ -4409,7 +4409,7 @@ their usage are given.</p>
             </tr>
             <tr>
               <td> dul: </td>
-              <td> <a href="http://purl.oclc.org/NET/ssnx/ssn">http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#</a>
+              <td> <a href="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl">http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#</a>
               </td>
             </tr>
           </tbody>
@@ -5644,7 +5644,7 @@ their usage are given.</p>
             </tr>
             <tr>
               <td> prov: </td>
-              <td> <a href="http://www.w3.org/ns/prov-o">http://www.w3.org/ns/prov#</a>
+              <td> <a href="http://www.w3.org/ns/prov">http://www.w3.org/ns/prov#</a>
               </td>
             </tr>
             <tr>
@@ -6571,7 +6571,7 @@ ex:TemperatureSensor  rdfs:subClassOf [
 
 # using SSN one can explicitly state that &lt;VCAB-DP1-BP-40#groundDisplacementSpeed&gt; is the property of &lt;VCAB-DP1-BP-40#location&gt; .
 
-&lt;VCAB-DP1-BP-40#location&gt; ssn:hasProperty &lt;VCAB-DP1-BP-40#groundDisplacementSpeed&gt; ;
+&lt;VCAB-DP1-BP-40#location&gt; ssn:hasProperty &lt;VCAB-DP1-BP-40#groundDisplacementSpeed&gt; .
 </pre>
           </div>
           <div class="sosa" style="display: none">

--- a/ssn/index.html
+++ b/ssn/index.html
@@ -7082,8 +7082,8 @@ ex:TemperatureSensor  rdfs:subClassOf [
 &lt;PCBBoard2&gt; a ssn:System , sosa:Platform ;
   rdfs:label "PCB Board 2"@en ;
   rdfs:comment "PCB Board 2 hosts DHT22 temperature and humidity sensor #4579 permanently, one can say it has it as one of its subsystems."@en ;
-  sosa:hosts &lt;DHT22/4578&gt; ;
-  ssn:hasSubSystem &lt;DHT22/4578&gt; .
+  sosa:hosts &lt;DHT22/4579&gt; ;
+  ssn:hasSubSystem &lt;DHT22/4579&gt; .
 
   &lt;DHT22/4579&gt; a ssn:System ;
     rdfs:label "DHT22 sensor #4579."@en ;
@@ -7093,8 +7093,8 @@ ex:TemperatureSensor  rdfs:subClassOf [
 &lt;PCBBoard3&gt; a ssn:System , sosa:Platform ;
   rdfs:label "PCB Board 3"@en ;
   rdfs:comment "PCB Board 3 hosts DHT22 temperature and humidity sensor #4580 permanently, one can say it has it as one of its subsystems."@en ;
-  sosa:hosts &lt;DHT22/4578&gt; ;
-  ssn:hasSubSystem &lt;DHT22/4578&gt; .
+  sosa:hosts &lt;DHT22/4580&gt; ;
+  ssn:hasSubSystem &lt;DHT22/4580&gt; .
 
   &lt;DHT22/4580&gt; a ssn:System ;
     rdfs:label "DHT22 sensor #4580."@en ;


### PR DESCRIPTION
See https://lists.w3.org/Archives/Public/public-sdwig/2017Dec/0000.html
(note some of the wrong links only exist in the published version)

See https://lists.w3.org/Archives/Public/public-sdw-wg/2017Dec/0001.html

See w3c/sdw-sosa-ssn#80 as well for the typo in the Turtle example