### PR TITLE
Logistics page for first IG F2F meeting in Amersfoort

### DIFF
--- a/index.html
+++ b/index.html
@@ -215,7 +215,15 @@ article, aside, details, figcaption, figure, footer, header, hgroup, menu, nav, 
                 </thead>
                 <tbody>
                   <tr>
-                    <td>17 January 2017<br/>20:00 UTC</td>
+                    <td>19-20 February 2018</td>
+                    <td>F2F Meeting, Amersfoort, The Netherlands</td>
+                    <td>
+                      <a href="https://w3c.github.io/sdw/meetings/f2f-1.html">Logistics</a><br/>
+                      <a href="https://www.w3.org/2002/09/wbs/102593/sdwig-f2F-2018-q1/">Registration</a>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>17 January 2018<br/>20:00 UTC</td>
                     <td>Spatial Data on the Web Best Practices</td>
                     <td>
                       <a href="https://lists.w3.org/Archives/Public/public-sdwig/2017Dec/0015.html">Agenda</a><br/>
@@ -278,7 +286,6 @@ article, aside, details, figcaption, figure, footer, header, hgroup, menu, nav, 
                 </tbody>
               </table>
               <p>The meeting password for Spatial Data on the Web Interest Group calls is <a href="https://lists.w3.org/Archives/Member/w3c-archive/2017Oct/0152.html">available to W3C Members</a>. IG participants who cannot access that link should get in touch with <a href="mailto:fd@w3.org">François Daoust</a>.</p>
-              <p>No face-to-face meeting planned for 2017. A face-to-face meeting is planned for Q1 2018. Time and location are still to be determined.</p>
             </article>
             <article class="line">
               <h2>Deliverables of W3C/OGC Spatial Data on the Web Interest Group</h2>

--- a/meetings/f2f-1.html
+++ b/meetings/f2f-1.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>
+      W3C Spatial Data on the Web Interest Group
+    </title><!--[if IE]>
+  <script src="https://www.w3.org/2008/site/js/html5shiv.js"></script>
+  <![endif]-->
+    <link rel="Help" href="https://www.w3.org/Help/">
+    <link rel="stylesheet" href="https://www.w3.org/2008/site/css/minimum"
+    type="text/css" media="handheld, all">
+    <style type="text/css" media="print, screen and (min-width: 481px)">
+@import url("https://www.w3.org/2008/site/css/advanced");
+    </style>
+    <link rel="stylesheet" href="https://www.w3.org/2008/site/css/print" type=
+    "text/css" media="print">
+    <link rel="shortcut icon" href=
+    "https://www.w3.org/2008/site/images/favicon.ico" type="image/x-icon">
+    <style>
+article, aside, details, figcaption, figure, footer, header, hgroup, menu, nav, section { display: block; }
+    .grouplogo {
+      background: #0D5E99;
+      height: 110px;
+    }
+    
+    .grouplogo object {
+      width: 100px;
+      height: 100px;
+      margin-top: 3px;
+      margin-left: 2.3em;
+    }
+
+    .infobar {
+      right: 4em;
+      margin: 1em;
+      width: 90%;
+      float: right;
+      background-color: blue;
+      background: #DBE7F0;
+      border: 1px solid #C6D4E0;
+      border-radius: 8px;
+      -moz-border-radius: 8px;
+      padding: 0.1em 0.1em 0.1em 0.5em;
+      list-item-style: bullet;
+    }
+
+    .infobar ul {
+      list-style-type:circle;
+    }
+
+    .secondary_nav {
+      float: right;
+      margin-right: 1.5em;
+    }
+
+    ol {
+      list-style-type: decimal;
+    }
+
+    .warning {
+      border: thin orange solid;
+      margin: 1em;
+      padding: 0em 1em 1em 1em;
+      border-radius: 1em;
+    }
+
+    img.wg_logo {
+      margin-top: 10px;
+      display: block;
+      margin-left: auto;
+      margin-right: auto;
+      width: 250px;
+      height: 180px;
+    }
+
+    .w3c_sec_nav > ul.secondary_nav {
+      visibility: hidden;
+    }
+
+    .w3c_leftCol {
+      display: block;
+    }
+
+    table { border-collapse: collapse; min-width: 400px; margin: 20px 20px 0; }
+    thead th { background-color: #036; color: #fff; padding: 0.5em; }
+    th, td { border-bottom:  thin solid; border-top:  thin solid; }
+    tbody td { padding: 0.5em; }
+
+    .todo {
+      display: inline-block;
+      color: darkorange;
+      pointer-events: none;
+      border-bottom: none !important;
+    }
+    .todo:after {
+      content: " (TBD)" !important;
+    }
+
+    @media all and (max-width: 970px) {
+      aside.infobar {
+        margin-left: 20px;
+        margin-right: 20px;
+      }
+
+      .w3c_leftCol {
+        min-width: 120px;
+      }
+      
+      .size2on3 {
+        width: 100%;
+      }
+      
+    }
+
+    #mast {
+      background-color: #fff;
+    }
+    #mast a:link,
+    #mast a:visited {
+      border-bottom: none;
+    }
+
+    @media print, screen and (min-width: 481px) {
+      #mast {
+        padding-left: 20px;
+      }
+    }
+    </style>
+  </head>
+  <body id="www-w3-org" class="w3c_public">
+    <div id="w3c_container">
+      <div id="mast" style="">
+        <a tabindex="2" accesskey="1" href="https://www.w3.org/"><img src=
+          "https://www.w3.org/Icons/WWW/w3c_home_nb-v.svg" height="72" alt="W3C"></a>
+        <a tabindex="2" accesskey="2" href="http://www.opengeospatial.org/"><img src=
+          "../ogc_logo.png" height="72" alt="Open Geospatial Consortium (OGC)"></a>
+      </div>
+      <div id="w3c_main">
+        <nav id="w3c_sidenavigation" class="w3c_leftCol">
+          <h2 class="offscreen">
+            Site Navigation
+          </h2>
+          <h3 class="category" style="margin-top: 18px">
+            <span class="ribbon"><b><a href=
+            "https://www.w3.org/2017/sdwig/">Group Details</a></b></span>
+          </h3>
+          <ul class="theme">
+            <li>
+              <a href=
+              "https://www.w3.org/2017/sdwig/charter.html">Charter</a>
+            </li>
+            <li>
+              <a href=
+              "https://lists.w3.org/Archives/Public/public-sdwig/">Mailing
+              List</a>
+            </li>
+            <li>
+              <a href=
+              "https://www.w3.org/2000/09/dbwg/details?group=102593&amp;public=1&amp;gs=1">
+              Group Participants</a>
+            </li>
+            <li>
+              <a href=
+              "https://www.w3.org/2004/01/pp-impl/102593/status">Royalty-Free
+              Patent Policy</a>
+            </li>
+            <li>
+              <a href="https://www.w3.org/2004/01/pp-impl/102593/join">Join This Group</a>
+            </li>
+          </ul>
+        </nav>
+        <div class="w3c_mainCol">
+          <h1 class="title">
+            <span>Spatial Data on the Web Interest Group</span>
+          </h1>
+          
+          <h2>First face-to-face meeting<br/>
+            19-20 February 2018</h2>
+
+          <article>
+            <h3>Location</h3>
+            <p><b>Address:</b>
+              <br/>Barchman Wuytierslaan 10
+              <br/>3818 LH, Amersfoort
+              <br/>The Netherlands
+            </p>
+            <p><b>Instructions:</b>
+              <br/>The meeting is hosted by Geonovum.
+              <br/>The location is right across from the railway station in Amersfoort. There are direct trains between Schiphol airport and Amersfoort every 30 minutes (xx:07 and xx:37, usually from platform 1 or 2).
+            </p>
+          </article>
+
+          <article>
+            <h3>Hotels</h3>
+            <ul>
+              <li>The <a href="http://www.nh-hotels.nl/hotel/nh-amersfoort">Hotel NH Amersfoort</a>, 5 minutes walk from Geonovum's office, the railway station and the city center.</li>
+              <li>The <a href="http://www.berghotelamersfoort.nl/">Berghotel Amersfoort</a>, further away from the railway station and city center.</li>
+              <li>Smaller (and possibly cheaper) <a href="http://www.booking.com/city/nl/amersfoort.nl.html">hotels in the city center</a>, approximatively 10-15 minutes walk from Genovum's office.</li>
+            </ul>
+          </article>
+
+          <article>
+            <h3>Registration</h3>
+            <p>Please <a href="https://www.w3.org/2002/09/wbs/102593/sdwig-f2F-2018-q1/">register for the F2F</a> before <b>9 February 2018</b>.</p>
+          </article>
+
+          <article>
+            <h2 class="todo">Agenda</h2>
+            <p></p>
+          </article>
+        </div>
+      </div><!-- /end #w3c_mainCol -->
+    </div><!-- end #w3c_main -->
+    <footer id="w3c_footer">
+      <div id="w3c_footer-inner">
+        <address>
+          For further information, please email the <b>Team Contact for the
+          Spatial Data on the Web Interest Group</b>:<br>
+          <a href="https://www.w3.org/People/#fd">François Daoust</a> -
+          <a href="mailto:fd@w3.org">fd@w3.org</a>
+        </address>
+    <div id="w3c_scripts">
+      <script type="text/javascript" src=
+      "https://www.w3.org/2008/site/js/main">
+</script>
+    </div>
+  </body>
+</html>

--- a/meetings/f2f-1.html
+++ b/meetings/f2f-1.html
@@ -187,7 +187,7 @@ article, aside, details, figcaption, figure, footer, header, hgroup, menu, nav, 
             </p>
             <p><b>Instructions:</b>
               <br/>The meeting is hosted by Geonovum.
-              <br/>The location is right across from the railway station in Amersfoort. There are direct trains between Schiphol airport and Amersfoort every 30 minutes (xx:07 and xx:37, usually from platform 1 or 2).
+              <br/>The location is right across from the railway station in Amersfoort. There are direct trains between Schiphol airport and Amersfoort every 30 minutes (xx:06 and xx:36, usually from platform 3).
             </p>
           </article>
 


### PR DESCRIPTION
Taking for granted that the F2F is planned on 19-20 February, and hosted by Geonovum, I created a logistics page with basic information about location, hotels nearby, and a link to a registration form. Agenda is still TBD at this time.

@lvdbrink I copied the logistic information over from a [past meeting](https://www.w3.org/2015/spatial/wiki/Location_F2F3), hope the information is still accurate.