### PR TITLE
Remove explicit declaration of xsd:dateTimeStamp.

### DIFF
--- a/time/rdf/time.jsonld
+++ b/time/rdf/time.jsonld
@@ -297,11 +297,6 @@
     "allValuesFrom" : "xsd:decimal",
     "onProperty" : "http://www.w3.org/2006/time#years"
   }, {
-    "@id" : "xsd:dateTimeStamp",
-    "@type" : "rdfs:Datatype",
-    "label" : "dateTimeStamp",
-    "subClassOf" : "rdfs:Literal"
-  }, {
     "@id" : "http://www.w3.org/2006/time",
     "@type" : "owl:Ontology",
     "contributor" : "mailto:chris.little@metoffice.gov.uk",

--- a/time/rdf/time.nt
+++ b/time/rdf/time.nt
@@ -138,9 +138,6 @@ _:B6ec84aa9X3A15c7c35e8daX3A71b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#fir
 _:Bfeef96a2857a97de6058f26bb57d11bc <http://www.w3.org/2002/07/owl#onProperty> <http://www.w3.org/2006/time#unitType> .
 _:Bfeef96a2857a97de6058f26bb57d11bc <http://www.w3.org/2002/07/owl#hasValue> <http://www.w3.org/2006/time#unitMonth> .
 _:Bfeef96a2857a97de6058f26bb57d11bc <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Restriction> .
-<http://www.w3.org/2001/XMLSchema#dateTimeStamp> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/2000/01/rdf-schema#Literal> .
-<http://www.w3.org/2001/XMLSchema#dateTimeStamp> <http://www.w3.org/2000/01/rdf-schema#label> "dateTimeStamp" .
-<http://www.w3.org/2001/XMLSchema#dateTimeStamp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Datatype> .
 <http://www.w3.org/2006/time#dayOfYear> <http://www.w3.org/2004/02/skos/core#definition> "The number of the day within the year"@en .
 <http://www.w3.org/2006/time#dayOfYear> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#nonNegativeInteger> .
 <http://www.w3.org/2006/time#dayOfYear> <http://www.w3.org/2000/01/rdf-schema#label> "day of year"@en .

--- a/time/rdf/time.rdf
+++ b/time/rdf/time.rdf
@@ -48,10 +48,6 @@ Ontology engineering by Simon J D Cox</skos:historyNote>
     <rdfs:comment xml:lang="en">Year number - formulated as a text string with a pattern constraint to reproduce the same lexical form as gYear, but not restricted to values from the Gregorian calendar. &#xD;
 Note that the value-space is not defined, so a generic OWL2 processor cannot compute ordering relationships of values of this type.</rdfs:comment>
   </rdfs:Datatype>
-  <rdfs:Datatype rdf:about="http://www.w3.org/2001/XMLSchema#dateTimeStamp">
-    <rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-    <rdfs:label>dateTimeStamp</rdfs:label>
-  </rdfs:Datatype>
   <rdfs:Datatype rdf:ID="generalMonth">
     <skos:definition xml:lang="en">Month of year - generalization of xsd:gMonth, formulated as a text string with a pattern constraint to reproduce the same lexical form as gMonth, except that values up to 20 are permitted, in order to support calendars with more than 12 months in the year. Note that the value-space is not defined, so a generic OWL2 processor cannot compute ordering relationships of values of this type.</skos:definition>
     <owl:withRestrictions rdf:parseType="Collection">

--- a/time/rdf/time.ttl
+++ b/time/rdf/time.ttl
@@ -8,11 +8,6 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-xsd:dateTimeStamp
-  rdf:type rdfs:Datatype ;
-  rdfs:label "dateTimeStamp" ;
-  rdfs:subClassOf rdfs:Literal ;
-.
 <http://www.w3.org/2006/time>
   rdf:type owl:Ontology ;
   dct:contributor <mailto:chris.little@metoffice.gov.uk> ;


### PR DESCRIPTION
Some details of the definition (the subclass of rdfs:Literal axiom) were confusing some processors (Protege)
Is defined in XSD datatypes specification anyway.
Discovered when attempting to register with Bioportal. 