### PR TITLE
[SSN] Fix Apartment 134 example for real as noted in #996

### DIFF
--- a/ssn/index.html
+++ b/ssn/index.html
@@ -6283,7 +6283,7 @@ ex:TemperatureSensor  rdfs:subClassOf [
 
 &lt;actuation/188&gt; rdf:type sosa:Actuation ;
   sosa:actsOnProperty  &lt;window/104#state&gt; ;
-  sosa:actuationMadeBy &lt;windowCloser/987&gt; ; 
+  sosa:madeByActuator &lt;windowCloser/987&gt; ;
   sosa:hasSimpleResult true ;
   sosa:resultTime "2017-04-18T17:24:00+02:00"^^xsd:dateTimeStamp .
           </pre></div>
@@ -6377,7 +6377,7 @@ ex:TemperatureSensor  rdfs:subClassOf [
 
 &lt;actuation/188&gt; rdf:type sosa:Actuation ;
   sosa:actsOnProperty  &lt;window/104#state&gt; ;
-  sosa:actuationMadeBy &lt;windowCloser/987&gt; ; 
+  sosa:madeByActuator &lt;windowCloser/987&gt; ;
   sosa:hasSimplResult true ;
   sosa:resultTime "2017-04-18T17:24:00+02:00"^^xsd:dateTimeStamp .
           </pre></div>
@@ -7604,7 +7604,7 @@ ex:TemperatureSensor  rdfs:subClassOf [
           <li>Removed Features at Risk section</li>
           <li>Removed Candidate Recommendation Exit Criteria section</li>
         </ol>
-        <h3>Changes since W3C Recommendation 19 October 2017  <a href="https://www.w3.org/2017/10/vocab-ssn-errata.html">Errata #6</a> since W3C Recommendation 19 October 2017 <a href="https://www.w3.org/TR/2017/REC-vocab-ssn-20171019/">
+        <h3>Changes since W3C Recommendation 19 October 2017 <a href="https://www.w3.org/TR/2017/REC-vocab-ssn-20171019/">
             (https://www.w3.org/TR/2017/REC-vocab-ssn-20171019/)</a></h3>
         <ol>
           <li>Fixed remaining broken links to ontology graph and namespaces and "specifically" typo</li>


### PR DESCRIPTION
The Apartment 134 example incorrectly referenced a `sosa:actuationMadeBy` property, which used to exist but has now been replaced by `sosa:madeByActuator`.

Notes:
- The errata document already includes an entry for that: https://www.w3.org/2017/10/vocab-ssn-errata.html#entry-5
- The "Changes since W3C Recommendation" section also mentions this as fixed in the Editor's Draft, but actually this had not yet been fixed.

The commit also fixes the title of the "Changes since W3C Recommendation" section, which contained weird text.