### PR TITLE
[SSN] Fix typo in Examples 10 and 11 and add erratum

### DIFF
--- a/ssn/errata.html
+++ b/ssn/errata.html
@@ -13,7 +13,7 @@
   <body>
     <section>
       <h1>Errata for Semantic Sensor Network Ontology</h1>
-      <h2><a name="w3c-doctype" id="w3c-doctype"></a>26 February 2018</h2>
+      <h2><a name="w3c-doctype" id="w3c-doctype"></a>13 March 2018</h2>
       <p class="copyright"><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a>&nbsp;©&nbsp;2018&nbsp;<a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="https://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.
      </p>
       <hr/>
@@ -43,6 +43,7 @@
           <li><a href="#entry-5">Inexistent <code>sosa:actuationMadeBy</code> property used in apartment 134 example</a></li>
           <li><a href="#entry-6">Unsatisfiable classes in SSNX alignment module</a></li>
           <li><a href="#entry-7">Unsatisfiable classes in DUL and SSNX alignment modules</a></li>
+          <li><a href="#entry-8">Syntax error in apartment 134 examples</a></li>
         </ol>
 
         <p>Entries are detailed below:</p>
@@ -154,6 +155,14 @@ oldssn:FeatureOfInterest owl:equivalentClass sosa:FeatureOfInterest (2)</pre>
             <pre>sosa:FeatureOfInterest rdfs:subClassOf dul:Entity (1')
 oldssn:FeatureOfInterest rdfs:subClassOf sosa:FeatureOfInterest (2')</pre>
           <dd>Note: the change is made both in the specification and in the files containing <a href="http://www.w3.org/ns/ssn/dul">the DUL alignment</a> and <a href="http://www.w3.org/2017/01/ssn-ssnx/">SSN-SSNX</a>.</dd>
+
+          <dt><a id="entry-8">8. Syntax error in apartment 134 examples</a></dt>
+          <dd>Added: 13 March 2018</dd>
+          <dd>Type: Editorial</dd>
+          <dd>Refers to: <a href="https://www.w3.org/TR/2017/REC-vocab-ssn-20171019/#apartment-134">B.3 apartment 134</a></dd>
+          <dd>Description: The examples reference a non-existing <code>sosa:hasSimplResult</code> predicate.</dd>
+          <dd>Correction: Replace <code>sosa:hasSimplResult</code> with <code>sosa:hasSimpleResult</code> in Example 10 and Example 11.</dd>
+          <dd>Note: the same syntax error exists in the specification and in the RDF files containing a <a href="https://www.w3.org/TR/2017/REC-vocab-ssn-20171019/integrated/examples/seismograph.ttl">graph corresponding to Example 10</a> and a <a href="https://www.w3.org/TR/2017/REC-vocab-ssn-20171019/integrated/examples/apartment-134-sosa.ttl">graph corresponding to Example 11</a>.</dd>
         </dl>
       </section>
     </section>

--- a/ssn/index.html
+++ b/ssn/index.html
@@ -7611,6 +7611,7 @@ ex:TemperatureSensor  rdfs:subClassOf [
           <li>Fixed Seismographs example, replacing the final <code>;</code> with a <code>.</code></li>
           <li>Fixed targets of <code>sosa:hosts</code> and <code>ssn:hasSubSystem</code> in DHT Deployment example</li>
           <li>Fixed domain/range for <code>actsOnProperty</code> and <code>isActedOnBy</code> in actuation diagrams</li>
+          <li>Fixed <code>sosa:hasSimplResult</code> syntax errors in apartment 134 examples</li>
           <li>Replaced inexistent <code>sosa:actuationMadeBy</code> by <code>sosa:madeByActuator</code> in apartment 134 example</li>
           <li>Relaxed axioms in 6.2 SSNX Alignment Module:
             <ul>

--- a/ssn/index.html
+++ b/ssn/index.html
@@ -6378,7 +6378,7 @@ ex:TemperatureSensor  rdfs:subClassOf [
 &lt;actuation/188&gt; rdf:type sosa:Actuation ;
   sosa:actsOnProperty  &lt;window/104#state&gt; ;
   sosa:actuationMadeBy &lt;windowCloser/987&gt; ; 
-  sosa:hasSimplResult true ;
+  sosa:hasSimpleResult true ;
   sosa:resultTime "2017-04-18T17:24:00+02:00"^^xsd:dateTimeStamp .
           </pre></div>
           <div class="buttonpanel" style="justify-content: center;">

--- a/ssn/integrated/examples/apartment-134-sosa.ttl
+++ b/ssn/integrated/examples/apartment-134-sosa.ttl
@@ -87,5 +87,5 @@
 <actuation/188> rdf:type sosa:Actuation ;
   sosa:actsOnProperty  <window/104#state> ;
   sosa:actuationMadeBy <windowCloser/987> ; 
-  sosa:hasSimplResult true ;
+  sosa:hasSimpleResult true ;
   sosa:resultTime "2017-04-18T17:24:00+02:00"^^xsd:dateTimeStamp .

--- a/ssn/integrated/examples/apartment-134.ttl
+++ b/ssn/integrated/examples/apartment-134.ttl
@@ -92,6 +92,6 @@
 <actuation/188> rdf:type sosa:Actuation ;
   sosa:actsOnProperty  <window/104#state> ;
   sosa:actuationMadeBy <windowCloser/987> ; 
-  sosa:hasSimplResult true ;
+  sosa:hasSimpleResult true ;
   sosa:resultTime "2017-04-18T17:24:00+02:00"^^xsd:dateTimeStamp .
 


### PR DESCRIPTION
See w3c/sdw-sosa-ssn#79. While the typo had been fixed in the Editor's Draft for Example 10, the companion RDF file had not been fixed, and the typo also existed in Example 11.

The update also adds an entry to the errata document to mention the typo in the published Recommendation.