### PR TITLE
Updated URI for example record to meet what was deployed

### DIFF
--- a/bp/BP-implementation-report-00002.md
+++ b/bp/BP-implementation-report-00002.md
@@ -26,7 +26,7 @@ The following programming languages and tools are used by this API:
 <http://linked.data.gov.au/dataset/gnaf>
 
 ### Example
-<http://linked.data.gov.au/address/GAACT714845933>
+<http://linked.data.gov.au/dataset/gnaf/address/GAACT714845933>
 
 ## Best Practice Scorecard
 


### PR DESCRIPTION
This URI was done before the production URI's were officially allocated (based on an assumption of the URI structure). Now they're in place, the URI has been updated to match what was deployed.