### PR TITLE
[SSN] Add erratum for bad IP68 Smart Sensor link

### DIFF
--- a/ssn/errata.html
+++ b/ssn/errata.html
@@ -13,8 +13,8 @@
   <body>
     <section>
       <h1>Errata for Semantic Sensor Network Ontology</h1>
-      <h2><a name="w3c-doctype" id="w3c-doctype"></a>15 March 2018</h2>
-      <p class="copyright"><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a>&nbsp;©&nbsp;2018&nbsp;<a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="https://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.
+      <h2><a name="w3c-doctype" id="w3c-doctype"></a>08 January 2019</h2>
+      <p class="copyright"><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a>&nbsp;©&nbsp;2019&nbsp;<a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="https://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.
      </p>
       <hr/>
       <section>
@@ -45,6 +45,7 @@
           <li><a href="#entry-7">Unsatisfiable classes in DUL and SSNX alignment modules</a></li>
           <li><a href="#entry-8">Use of <code>qudt-1-1:numericalValue</code> instead of <code>qudt-1-1:numericValue</code> in Examples 12 and 13</a></li>
           <li><a href="#entry-9">Syntax error in apartment 134 examples</a></li>
+          <li><a href="#entry-10">Link error in IP68 Smart Sensor example</a></li>
         </ol>
 
         <p>Entries are detailed below:</p>
@@ -172,6 +173,13 @@ oldssn:FeatureOfInterest rdfs:subClassOf sosa:FeatureOfInterest (2')</pre>
           <dd>Description: The examples reference a non-existing <code>sosa:hasSimplResult</code> predicate.</dd>
           <dd>Correction: Replace <code>sosa:hasSimplResult</code> with <code>sosa:hasSimpleResult</code> in Example 10 and Example 11.</dd>
           <dd>Note: the same syntax error exists in the specification and in the RDF files containing a <a href="https://www.w3.org/TR/2017/REC-vocab-ssn-20171019/integrated/examples/seismograph.ttl">graph corresponding to Example 10</a> and a <a href="https://www.w3.org/TR/2017/REC-vocab-ssn-20171019/integrated/examples/apartment-134-sosa.ttl">graph corresponding to Example 11</a>.</dd>
+
+          <dt><a id="entry-10">10. Link error in IP68 Smart Sensor example</a></dt>
+          <dd>Added: 08 January 2019</dd>
+          <dd>Type: Editorial</dd>
+          <dd>Refers to: <a href="https://www.w3.org/TR/2017/REC-vocab-ssn-20171019/#ip68-smart-sensor">B.11 IP68 Smart Sensor</a></dd>
+          <dd>Description: The link to the graph corresponding to the example goes to the wrong file.</dd>
+          <dd>Correction: Fix the link to target the correct <a href="https://www.w3.org/TR/vocab-ssn/integrated/examples/ip68.ttl">IP68 Smart Sensor graph file</a>.</dd>
         </dl>
       </section>
     </section>


### PR DESCRIPTION
The link to the graph corresponding to the example is incorrect in the published Recommendation, as described in https://github.com/w3c/sdw-sosa-ssn/issues/17