### PR TITLE
corrected language tags

### DIFF
--- a/time/rdf/time.ttl
+++ b/time/rdf/time.ttl
@@ -1159,7 +1159,7 @@ DBPedia provides a set of resources corresponding to the IANA timezones, with a 
   skos:prefLabel "giorno"@it ;
   skos:prefLabel "jour"@fr ;
   skos:prefLabel "يوماً ما"@ar ;
-  skos:prefLabel "ある日"@jp ;
+  skos:prefLabel "ある日"@ja ;
   skos:prefLabel "一天"@zh ;
   skos:prefLabel "언젠가"@kr ;
   :days "1"^^xsd:decimal ;
@@ -1184,7 +1184,7 @@ DBPedia provides a set of resources corresponding to the IANA timezones, with a 
   skos:prefLabel "один час\"@ru" ;
   skos:prefLabel "ساعة واحدة"@ar ;
   skos:prefLabel "一小時"@zh ;
-  skos:prefLabel "一時間"@jp ;
+  skos:prefLabel "一時間"@ja ;
   skos:prefLabel "한 시간"@kr ;
   :days "0"^^xsd:decimal ;
   :hours "1"^^xsd:decimal ;
@@ -1207,7 +1207,7 @@ DBPedia provides a set of resources corresponding to the IANA timezones, with a 
   skos:prefLabel "minuut"@nl ;
   skos:prefLabel "одна минута"@ru ;
   skos:prefLabel "دقيقة واحدة"@ar ;
-  skos:prefLabel "一分"@jp ;
+  skos:prefLabel "一分"@ja ;
   skos:prefLabel "等一下"@zh ;
   skos:prefLabel "분"@kr ;
   :days "0"^^xsd:decimal ;
@@ -1230,7 +1230,7 @@ DBPedia provides a set of resources corresponding to the IANA timezones, with a 
   skos:prefLabel "month"@en ;
   skos:prefLabel "один месяц"@ru ;
   skos:prefLabel "شهر واحد"@ar ;
-  skos:prefLabel "一か月"@jp ;
+  skos:prefLabel "一か月"@ja ;
   skos:prefLabel "一個月"@zh ;
   skos:prefLabel "한달"@kr ;
   :days "0"^^xsd:decimal ;
@@ -1245,7 +1245,7 @@ DBPedia provides a set of resources corresponding to the IANA timezones, with a 
   rdf:type :TemporalUnit ;
   rdfs:label "Second (unit of temporal duration)"@en ;
   skos:prefLabel "Sekunde"@de ;
-  skos:prefLabel "Sekundę"@pl ;
+  skos:prefLabel "sekundę"@pl ;
   skos:prefLabel "second"@en ;
   skos:prefLabel "seconde"@fr ;
   skos:prefLabel "seconde"@nl ;
@@ -1253,7 +1253,7 @@ DBPedia provides a set of resources corresponding to the IANA timezones, with a 
   skos:prefLabel "segundo"@es ;
   skos:prefLabel "segundo"@pt ;
   skos:prefLabel "ثانية واحدة"@ar ;
-  skos:prefLabel "一秒"@jp ;
+  skos:prefLabel "一秒"@ja ;
   skos:prefLabel "一秒"@zh ;
   skos:prefLabel "일초"@kr ;
   :days "0"^^xsd:decimal ;
@@ -1291,7 +1291,7 @@ DBPedia provides a set of resources corresponding to the IANA timezones, with a 
   skos:prefLabel "одна неделя"@ru ;
   skos:prefLabel "سبوع واحد"@ar ;
   skos:prefLabel "一周"@zh ;
-  skos:prefLabel "一週間"@jp ;
+  skos:prefLabel "一週間"@ja ;
   skos:prefLabel "일주일"@kr ;
   :days "0"^^xsd:decimal ;
   :hours "0"^^xsd:decimal ;
@@ -1305,7 +1305,7 @@ DBPedia provides a set of resources corresponding to the IANA timezones, with a 
   rdf:type :TemporalUnit ;
   rdfs:label "Year (unit of temporal duration)"@en ;
   skos:prefLabel "1 년"@kr ;
-  skos:prefLabel "1年"@jp ;
+  skos:prefLabel "一年"@ja ;
   skos:prefLabel "Jahr"@de ;
   skos:prefLabel "rok"@pl ;
   skos:prefLabel "an"@fr ;


### PR DESCRIPTION
Corrected @jp to @ja for Japanese language.

Removed spurious Polish capitalization.

Corrected Chinese and Japanese unit from '1' (one) to '一' (yi).

Not corrected Korean use of '1' as I do not know enough..