### PR TITLE
typo in example

### DIFF
--- a/time-entity-relations/index.html
+++ b/time-entity-relations/index.html
@@ -423,7 +423,7 @@
 
   <section id="examples">
     <h2>Examples</h2>
-    <p>Jack's wedding concides with Abby's birthday in 2020.</p>
+    <p>Jack's wedding coincides with Abby's birthday in 2020.</p>
     <aside id="ex-jack" class="example">
       <pre class="nohighlight turtle">
       ex:JackWeddingDay time:equals ex:AbbyBirthday2020 . 


### PR DESCRIPTION
missing 'i' in example annotation