### PR TITLE
updates to section 2 and 4 of SDW-WG charter

### DIFF
--- a/roadmap/charter-2020.html
+++ b/roadmap/charter-2020.html
@@ -191,10 +191,6 @@
 	    and best practices delivered by the Spatial Data on the Web Working Group.</p>
 
           <dl>
-	    <dt id="sdwbp"  class="spec"><a href="https://www.w3.org/TR/sdw-bp/">Spatial Data on the Web Best Practices</a></dt>
-	    <dd>This document advises on best practices related to the
-	    publication of spatial data on the Web; the use of Web
-	    technologies as they may be applied to location.</dd>
 	    <dt id="time-ont"  class="spec"><a
 				  href="https://www.w3.org/TR/owl-time/">Time Ontology</a></dt>
 	    <dd>OWL-Time is an OWL-2 DL ontology of temporal concepts,
@@ -208,9 +204,6 @@
 	    the involved procedures, the studied features of interest,
 	    the samples used to do so, and the observed properties, as
 	    well as actuators. Included in this specification is a core ontology called SOSA (Sensor, Observation, Sample, and Actuator).</dd>
-            <dt id="ssn-ext" class="spec"><a
-					      href="https://www.w3.org/TR/vocab-ssn-ext/">Extensions to the Semantic Sensor Network Ontology</a></dt>
-	    <dd>This document describes some extensions to the SSN ontology to enable linking directly to the ultimate feature-of-interest for an act of observation, sampling, or actuation and provide homogeneous collections of observations.</dd>
 	  </dl>
 
 
@@ -220,9 +213,20 @@
           <h3>
             Other Deliverables
           </h3>
-          <ul>
-            <li>W3C Note / OGC Discussion paper describing the Web Video Map Tracks Format (WebVMT).</li>
-          </ul>
+          <dl>
+	    <dt id="sdwbp"  class="spec"><a href="https://www.w3.org/TR/sdw-bp/">Spatial Data on the Web Best Practices</a></dt>
+	    <dd>This document advises on best practices related to the
+	    publication of spatial data on the Web; the use of Web
+	    technologies as they may be applied to location.</dd>
+            <dt id="ssn-ext" class="spec"><a href="https://www.w3.org/TR/vocab-ssn-ext/">Extensions to the Semantic Sensor Network Ontology</a></dt>
+	    <dd>This document describes some extensions to the SSN ontology to enable linking directly to the ultimate feature-of-interest for an act of observation, sampling, or actuation and provide homogeneous collections of observations.</dd>
+            <dt id="time-ext" class="spec"><a href="https://www.w3.org/TR/vocab-owl-time-rel/">Extensions to the OWL-Time Ontology - entity relations</a></dt>
+	    <dd>This document extends the OWL-Time ontology with the addition of four new temporal relations: disjoint, equals, hasInside, and notDisjoint.</dd>
+	    <dt id="webvmt"  class="spec"><a href="https://w3c.github.io/sdw/proposals/geotagging/webvmt/">WebVMT: The Web Video Map Tracks Format</a></dt>
+	    <dd>W3C Note / OGC Discussion paper describing the Web Video Map Tracks Format (WebVMT). which is an enabling technology whose main use is for marking up external map track resources in connection with the HTML &lt;track&gt; element. WebVMT files provide map presentation and annotation synchronised to video content, including animation support, and more generally any form of geolocation data that is time-aligned with audio or video content.</dd>
+	    <dt id="ethics"  class="spec"><p>Responsible use of location data</p></dt>
+	    <dd>W3C Note / OGC Discussion paper describing issues relating to the responsible use of location data - also referred to as the <em>ethics of geospatial</em>.</dd>
+	  </dl>
           <p>
             Other non-normative documents may be created such as:
           </p>
@@ -373,13 +377,6 @@
   </dl>
         </section>
 
-        <section>
-          <h3 id="external-coordination">External Organizations</h3>
-          <dl>
-            <dt><a href="http://inspire.ec.europa.eu/"><abbr title="Infrastructure for Spatial Information in the European Community">INSPIRE</abbr></a></dt>
-            <dd>The community and standards around the European INSPIRE Directive are an important reference point for the Working Group.</dd>
-          </dl>
-        </section>
       </section>
 
 


### PR DESCRIPTION
Section 2.1: SDW-BP and SSN-EXT removed from list of normative deliverables.
Section 2.2 SDW-BP, SSN-EXT, Time-EXT, and 'Responsible use of location data' added to non-normative list of deliverables.
Section 4.3: Removed - we no longer need to cite INSPIRE as a specific 'external organisation' with whom SDW-WG liaises. Engagement with the EU INSPIRE initiative is happening organically through members of W3C and OGC.