### PR TITLE
Add OGC logo to config

### DIFF
--- a/responsible-use/index.html
+++ b/responsible-use/index.html
@@ -70,11 +70,26 @@
             charterDisclosureURI: "https://www.w3.org/2017/sdwig/charter.html#patentpolicy",
             edDraftURI: "https://w3c.github.io/sdw/responsible-use/",
             shortName: "responsible-use-spatial",
-	    latestVersion: null,
+	        latestVersion: null,
             group: "sdw",
             wgPublicList: "public-geospatial-data-use",
             maxTocLevel: 4,
-            github: "https://github.com/w3c/sdw"
+            github: "https://github.com/w3c/sdw",
+            logos: [
+            {
+                src: "https://www.w3.org/StyleSheets/TR/2016/logos/W3C",
+                alt: "W3C",
+                height: "48",
+                width: "72",
+                url: "https://www.w3.org/"
+            },
+            {
+                src: "https://www.w3.org/2017/01/ogc_logo.png",
+                alt: "OGC",
+                height: "68",
+                width: "147",
+                url: "http://www.opengeospatial.org/"
+            }],
         };
     </script>
 </head>


### PR DESCRIPTION
We consider documents from the SDWIG to be joint from W3C and OGC and should therefore include the OGC logo. 

Sorry this was caught just too late... 