### PR TITLE
Correct "GPDR" to "GDPR" seven times

### DIFF
--- a/responsible-use/index.html
+++ b/responsible-use/index.html
@@ -376,10 +376,10 @@ per year in 2016.
                 nature of laws. Where ethical concerns within a region accelerate faster than other areas, legislators
                 create laws that provide protections deemed necessary by citizens. These laws often provide templates
                 for other regions, potentially influencing prevailing regional ethical concerns. In the case of data
-                privacy, <a href="https://gdpr-info.eu">GPDR</a> has provided a template that many countries have adapted, resulting in
+                privacy, <a href="https://gdpr-info.eu">GDPR</a> has provided a template that many countries have adapted, resulting in
                 a framework of rights that have found their way into legal frameworks for privacy. The following rights broadly capture
                 these concerns. Three laws were referred to in order that commonality across regions could be confirmed. These were the
-                General Data Protection Regulation (<a href="https://gdpr-info.eu">GPDR</a>), California Consumer Privacy Act (<a
+                General Data Protection Regulation (<a href="https://gdpr-info.eu">GDPR</a>), California Consumer Privacy Act (<a
                     href="https://oag.ca.gov/privacy/ccpa">CCPA</a>), and Australian Privacy Act. Where a right is included in these
                 laws, it is indicated under the corresponding right.
             </p>
@@ -393,7 +393,7 @@ per year in 2016.
                 how, and the existence of automated decision taking based on the information held.
             </p>
             <ul class='note' title='Laws That Include This Right'>
-                <li><a href="https://gdpr-info.eu">GPDR</a></li>
+                <li><a href="https://gdpr-info.eu">GDPR</a></li>
                 <li>Australian Privacy Act</li>
             </ul>
         </section>
@@ -407,7 +407,7 @@ per year in 2016.
                 and rights of the data subject including the ability to withdraw consent.
             </p>
             <ul class='note' title='Laws That Include This Right'>
-                <li><a href="https://gdpr-info.eu">GPDR</a>, referred to as the Right to be Informed</li>
+                <li><a href="https://gdpr-info.eu">GDPR</a>, referred to as the Right to be Informed</li>
                 <li><a href="https://oag.ca.gov/privacy/ccpa">CCPA</a></li>
                 <li>Australian Privacy Act</li>
             </ul>
@@ -420,7 +420,7 @@ per year in 2016.
                 of the data originating from their disclosure must be erased.
             </p>
             <ul class='note' title='Laws That Include This Right'>
-                <li><a href="https://gdpr-info.eu">GPDR</a></li>
+                <li><a href="https://gdpr-info.eu">GDPR</a></li>
                 <li><a href="https://oag.ca.gov/privacy/ccpa">CCPA</a>, referred to as the Right to Delete</li>
             </ul>
         </section>
@@ -431,7 +431,7 @@ per year in 2016.
                 data for the purposes originally consented to (e.g., direct marketing).
             </p>
             <ul class='note' title='Laws That Include This Right'>
-                <li><a href="https://gdpr-info.eu">GPDR</a>, included in the Right to be Informed</li>
+                <li><a href="https://gdpr-info.eu">GDPR</a>, included in the Right to be Informed</li>
                 <li><a href="https://oag.ca.gov/privacy/ccpa">CCPA</a></li>
                 <li>Australian Privacy Act</li>
             </ul>
@@ -495,7 +495,7 @@ per year in 2016.
                 For more information on these legal frameworks, you can follow the links below.
             </p>
             <ul class='note' title='Legal Frameworks Links'>
-                <li><a href="https://gdpr-info.eu">GPDR</a>: <a href="https://gdpr-info.eu">https://gdpr-info.eu</a></li>
+                <li><a href="https://gdpr-info.eu">GDPR</a>: <a href="https://gdpr-info.eu">https://gdpr-info.eu</a></li>
                 <li><a href="https://oag.ca.gov/privacy/ccpa">CCPA</a>: <a href="https://oag.ca.gov/privacy/ccpa">https://oag.ca.gov/privacy/ccpa</a></li>
                 <li>Australian Privacy Act: <a
                         href="https://www.oaic.gov.au/privacy/the-privacy-act/rights-and-responsibilities/">https://www.oaic.gov.au/privacy/the-privacy-act/rights-and-responsibilities/</a>


### PR DESCRIPTION
To match the better known acronym for this European legislation