### PR TITLE
Consistency on "data is" rather than "data are"

### DIFF
--- a/bp/index.html
+++ b/bp/index.html
@@ -2113,8 +2113,8 @@ Connection: close
 <p>A number of techniques can be used to deliver representations of <a>geometries</a> at an accuracy, precision, and size fitting the requirements of a given use case.</p>
 <p>The following list, although not exhaustive, outlines the approaches most widely used, especially for the Web delivery and consumption of <a>geometry</a> data.</p>
 <p>Choosing the right technique requires taking primarily into account whether the derived <a>geometry</a> is fit for the target use case. Technical limits &mdash; as network bandwidth and processing capabilities &mdash; are of course important, but secondary. Of course, the ideal situation is when you are able to find the technique offering the right trade-off between these two types of requirements.</p>
-<p>Whatever option is used, the key requirement is that the derived <a>geometry</a> data are not replacing the original ones, but are made available as alternative representations.</p>
-  <p><a href="#describe-geometry"></a>, <a href="#desc-accuracy"></a> and <a href="#convenience-apis"></a> provide general guidelines that can be used for the publication of alternative representations of <a>geometries</a>, providing at the same time information on their characteristics. These include, but are not limited to, the use of different URIs for different representations, and HTTP content negotiation. Moreover, whenever <a>geometry</a> data are made available in <a>RDF</a> [[RDF11-PRIMER]], specific properties can be used to specify the geometry type and the level of accuracy and precision. More specific examples are included in the approaches described below.</p>
+<p>Whatever option is used, the key requirement is that the derived <a>geometry</a> does not replace the original ones, but are made available as alternative representations.</p>
+  <p><a href="#describe-geometry"></a>, <a href="#desc-accuracy"></a> and <a href="#convenience-apis"></a> provide general guidelines that can be used for the publication of alternative representations of <a>geometries</a>, providing at the same time information on their characteristics. These include, but are not limited to, the use of different URIs for different representations, and HTTP content negotiation. Moreover, whenever <a>geometry</a> is made available in <a>RDF</a> [[RDF11-PRIMER]], specific properties can be used to specify the geometry type and the level of accuracy and precision. More specific examples are included in the approaches described below.</p>
 <ol>
 <li>
 <p>Compress <a>geometry</a> data</p>
@@ -2140,7 +2140,7 @@ Connection: close
 <p>Providing <a>geometries</a> at different scales or resolutions is actually one of the first criteria to be considered for addressing different use cases. This is common practice in the geospatial domain, especially, but not only, for reference data. For instance, the dataset of the <a href="http://ec.europa.eu/eurostat/web/nuts/">Nomenclature of Territorial Units for Statistics</a> (NUTS) of the European Union is made available at five different scales &mdash; ranging from 1:1,000,000 to 1:60,000,000.</p>
 
 <aside class="example" id="ex-admin-areas-at-different-resolution" title="">
-<p>The <a href="http://gadm.geovocab.org/">GADM-RDF project</a> provides access to <a>geometries</a> of administrative areas at a resolution of 100m, 1km, 10km, and 100km. Each of these variants is associated with a different HTTP URI, and <a>geometry</a> data are made available in different formats. For instance, the geometry of Germany at 100m resolution is denoted by the following URI <a href="http://gadm.geovocab.org/id/0/60/geometry_100m"><code>http://gadm.geovocab.org/id/0/60/geometry_100m</code></a>, whereas the variant at 100km resolution is available from the following URI: <a href="http://gadm.geovocab.org/id/0/60/geometry_100km"><code>http://gadm.geovocab.org/id/0/60/geometry_100km</code></a> (see also <a href="#ex-http-uris-for-geometries"></a>).</p>
+<p>The <a href="http://gadm.geovocab.org/">GADM-RDF project</a> provides access to <a>geometries</a> of administrative areas at a resolution of 100m, 1km, 10km, and 100km. Each of these variants is associated with a different HTTP URI, and <a>geometry</a> is made available in different formats. For instance, the geometry of Germany at 100m resolution is denoted by the following URI <a href="http://gadm.geovocab.org/id/0/60/geometry_100m"><code>http://gadm.geovocab.org/id/0/60/geometry_100m</code></a>, whereas the variant at 100km resolution is available from the following URI: <a href="http://gadm.geovocab.org/id/0/60/geometry_100km"><code>http://gadm.geovocab.org/id/0/60/geometry_100km</code></a> (see also <a href="#ex-http-uris-for-geometries"></a>).</p>
 </aside>
 
 <p>Scale reduction uses a number of generalization techniques that can be used also outside this specific use case in order to provide <a>geometries</a> at different levels of accuracy and precision.</p>
@@ -2238,8 +2238,8 @@ Connection: close
 <li>Compressed version of geometry data can be obtained via HTTP content negotiation or other mechanisms.</li>
 <li>Centroids and bounding boxes are made available, without the need of downloading and processing the relevant geometry data.</li>
 <li>It is possible to get a 2-dimensional representation of a 3-dimensional geometry.</li>
-<li>Geometry data are available at different levels of precision, e.g., by allowing users to specify the maximum number of decimals in point coordinates.</li>
-<li>Geometry data are available at different scales / spatial resolutions.</li>
+<li>Geometry is available at different levels of precision, e.g., by allowing users to specify the maximum number of decimals in point coordinates.</li>
+<li>Geometry is available at different scales / spatial resolutions.</li>
 </ul>
 </section>
 <section class="ucr">


### PR DESCRIPTION
In most places, the SDW BP uses "data is" rather than "data are"; only BP 6 uses "data are". 

The remaining occurrences of "data are" are in the context of e.g. "small pieces of data are" or "best practices relating to handling sensor data are" - i.e. the are is in number agreement with something other than the word "data".

I don't want to open that debate - simply to be internally consistent. Not conclusive, but searching w3.org for "data is" returns 15,400 results whereas "data are" returns 4,600.