### PR TITLE
Reduce ambiguity

### DIFF
--- a/bp/index.html
+++ b/bp/index.html
@@ -3459,7 +3459,7 @@ Content-type: application/geo+json
             href="https://www.w3.org/TR/dwbp/#APIHttpVerbs">Best Practice 24: Use Web Standards 
           as the foundation of APIs</a>, but include APIs targeted at a specific programming 
           language, for example, JavaScript.</p>
-        <p>In the list of options above, a third option is included as sharing <a>spatial data</a>
+        <p>In the list of options above, the third option - Bespoke API - is included because sharing <a>spatial data</a>
           on the Web using the first two options (bulk download or generalized APIs) may not
           be sufficient for reaching application developers. Reasons for this include:</p>  
         <ul>  


### PR DESCRIPTION
The list is quite a long way above (with several bullet points between), so including the phrase "Bespoke API" helps.

"as" is ambiguous (I initially read it as about to introduce the name/description of the third option); "because" is less so.