### PR TITLE
Fix error in bpconfig.js

### DIFF
--- a/bp/bpconfig.js
+++ b/bp/bpconfig.js
@@ -251,19 +251,19 @@ var respecConfig = {
         "title": "Web Data",
         "date": "1 November 2016"
       },
-      "FAIR-XG":{
-	"authors": ["Directorate-General for Research and Innovation"]      
-	"href":"https://doi.org/10.2777/1524",
-	"publisher": "Publications Office",
-	"title":"Turning FAIR into reality. Final report and action plan from the European Commission expert group on FAIR data",
-	"date": "2018"
+      "FAIR-XG": {
+        "authors": ["Directorate-General for Research and Innovation"],
+        "href":"https://doi.org/10.2777/1524",
+        "publisher": "Publications Office",
+        "title":"Turning FAIR into reality. Final report and action plan from the European Commission expert group on FAIR data",
+        "date": "2018"
       },
-      "FAIR-DMM":{
+      "FAIR-DMM": {
         "href":"https://doi.org/10.15497/rda00050",
         "publisher": "Research Data Alliance",
-	"title":"FAIR Data Maturity Model. Specification and Guidelines (1.0)",
+        "title":"FAIR Data Maturity Model. Specification and Guidelines (1.0)",
         "date": "2020"
-      },	    
+      },
 
 // ALREADY IN SPECREF
 


### PR DESCRIPTION
https://w3c.github.io/sdw/bp/ broke in https://github.com/w3c/sdw/pull/1333:

```
bpconfig.js:256 Uncaught SyntaxError: Unexpected string
w3c.js:79 ReferenceError: respecConfig is not defined
    at Mn (base-runner.js:17:20)
    at fr (respec.js:13:11)

```
