### PR TITLE
ex-geodcat-ap-dataset-spatial-representation-type - fix broken Link

### DIFF
--- a/bp/index.html
+++ b/bp/index.html
@@ -3879,7 +3879,7 @@ a:Dataset a dcat:Dataset ;
             <aside class="example" id="ex-geodcat-ap-dataset-spatial-representation-type" title="Specification of spatial representation type in [GeoDCAT-AP]">
               <p>[[GeoDCAT-AP]] models this information by using <code>adms:representationTechnique</code> [[VOCAB-ADMS]], with URIs
                 corresponding to the items in the appropriate <a
-                  href="https://geo-ide.noaa.gov/wiki/index.php?title=ISO_19115_and_19115-2_CodeList_Dictionaries#MD_SpatialRepresentationTypeCode"
+                  href="https://schemas.isotc211.org/schemas/Resources/codelists.xml#MD_SpatialRepresentationTypeCode"
                   >ISO 19115 code list</a>.</p>
               <p>The following [[TURTLE]] snippet provides an example of the [[GeoDCAT-AP]] specification of two datasets using, respectively, a vector and a grid spatial representation type. The URIs in the example, denoting the spatial representation type, are taken from the corresponding code list of the <a href="http://inspire.ec.europa.eu/metadata-codelist/SpatialRepresentationType">INSPIRE Registry</a>.</p>
               <pre>


### PR DESCRIPTION
Link to ISO/TC 211 publication of codelists.xml for MD_SpatialRepresentationTypeCode
Currently, the fragment identifier within the file isn't actually a link target, so the link goes to the top of the file.