### PR TITLE
Remove BBC's "sameAs" example

### DIFF
--- a/bp/index.html
+++ b/bp/index.html
@@ -3099,10 +3099,6 @@ Content-type: application/geo+json
                       <p><a href="http://open.vocab.org/terms/similarTo"><code>ov:similarTo</code></a> defined by <a href="http://vocab.org/open/">Open.vocab.org</a>, with the description:</p>
                       <blockquote>Having two things that are not the owl:sameAs but are similar to a certain extent. It is thought of being used where owl:sameAs is too strong but rdfs:seeAlso is too loose.</blockquote>
                     </li>
-                    <li>
-                      <p><a href="http://www.bbc.co.uk/ontologies/coreconcepts#terms_sameAs"><code>http://www.bbc.co.uk/ontologies/coreconcepts/sameAs</code></a>, defined by the <a href="https://www.bbc.co.uk/">BBC</a>, whose description states that the property:</p>
-                      <blockquote>Indicates that something is the same as something else, but in a way that is slightly weaker than owl:sameAs. Its purpose is to connect separate identities of the same thing, whilst keeping separation between the original statements of each.</blockquote>
-                    </li>
                   </ul>
 
                   <p>All of the properties list above, are concerned with equality or similarity about resources themselves. However, we often want to talk about the similarity of Spatial Things in terms of location or <em>place</em>. Spatial relations (see <a href="#link-type-spatial-rels" class="sectionRef">above</a>) can be used to describe how locations are related &mdash; either using rigorous topological relationships derived from geometry, such as <a href="http://www.opengis.net/ont/geosparql#sfEquals"><code>geosparql:sfEquals</code></a>, or ones without formal mathematical underpinning, such as <a href="http://www.geonames.org/ontology#nearby"><code>geonames:nearby</code></a>. But <em>place</em> is a social concept that reflect how we humans perceive the space around us, often with a vague or imprecise notion of location; you can’t always define a boundary for a place like <a href="http://sws.geonames.org/2212709/">The Sahara</a> because not everyone agrees where its edge lies!</p>


### PR DESCRIPTION
As it no longer exists. Seems that BBC has moved away from linked data - but for us, that just implies removing this example. The section already has two other examples, which still work.

To resolve https://github.com/w3c/sdw/issues/1328