### PR TITLE
Remove Editors note about missing namespace

### DIFF
--- a/bp/index.html
+++ b/bp/index.html
@@ -725,11 +725,6 @@ function bpCrossRefs() {
       <section id="ns-rdf">
       <h3> RDF Namespaces </h3>
       <p>The following RDF namespace prefixes are used within this document. Use of a namespace does not imply endorsement of the associated data platform or vocabulary.</p>
-
-<aside class="ednote">
-<p>Added the following missing namespaces: <code>geodcatap</code>, <code>ldqd</code>, <code>sdmx-attribute</code>.</p>
-</aside>
-
       <table class="simple" id="ns-rdf-table">
         <caption>RDF namespaces used in the document</caption>
         <thead>


### PR DESCRIPTION
Because someone has already added them, so the note was no longer true.