### PR TITLE
Update index.html - DCAT2

### DIFF
--- a/bp/index.html
+++ b/bp/index.html
@@ -758,7 +758,7 @@ function bpCrossRefs() {
           <tr>
             <td><code>dcat</code></td>
             <td>http://www.w3.org/ns/dcat#</td>
-            <td>Data Catalog Vocabulary (DCAT) [[VOCAB-DCAT]]</td>
+            <td>Data Catalog Vocabulary (DCAT) [[VOCAB-DCAT-2]]</td>
           </tr>
           <tr>
             <td><code>dcterms</code></td>
@@ -1277,7 +1277,7 @@ function bpCrossRefs() {
 
           <aside class="note">
             <p>Deciding whether your <a>spatial data</a> is a single dataset or not is somewhat arbitrary. To decide this, it is often useful to consider attributes such as the license under which the data will be made available, the refresh or publication schedules, the quality of the data and the governance regime applied in managing the data. Typically, all of these attributes should be consistent within a single dataset.</p>
-            <p>[[VOCAB-DCAT]] provides a useful definition of dataset that supports this approach: “A collection of data, published or curated by a single agent, and available for access or download in one or more formats.”</p>
+            <p>[[VOCAB-DCAT-2]] provides a useful definition of dataset that supports this approach: “A collection of data, published or curated by a single agent, and available for access or download in one or more representations.”</p>
           </aside>
 
           <p>However, we need to look inside the datasets at the resources described within your data. If you want these resources to be visible within the Web’s information space, by which we mean that others can refer to or talk about those resources, then they must also be assigned URIs (see [[DWBP]] <a href="https://www.w3.org/TR/dwbp/#identifiersWithinDatasets">Best Practice 10: Use persistent URIs as identifiers within datasets</a>). These URIs are like 'Web-scale foreign keys' that enable information from different sources to be stitched together.</p>
@@ -1904,7 +1904,7 @@ Connection: close
 <p>Moreover, the original GeoJSON datatype URI used in the example (corresponding to <a href="https://www.iana.org/assignments/media-types/application/geo+json">the GeoJSON IANA Media Type URL</a>) has been replaced with <code>geosparql:geoJSONLiteral</code>, included in the draft of the new version of [[GeoSPARQL]] (see issues <a href="https://github.com/opengeospatial/ogc-geosparql/issues/1">opengeospatial/ogc-geosparql/issues/1</a> and  <a href="https://github.com/opengeospatial/ogc-geosparql/issues/48">opengeospatial/ogc-geosparql/issues/48</a>), already adopted in [[GeoDCAT-AP-20201223]].</p>
 </aside>
 
-            <p>The following [[TURTLE]] snippet shows the [[GeoDCAT-AP]] representation of the dataset in <a href="#ex-schemaorg-dataset-and-place"></a>. Here the bounding box is provided in multiple literal encodings (<a>WKT</a>, [[GML]], GeoJSON [[RFC7946]]), by using property <a href="https://www.w3.org/TR/vocab-dcat-2/#Property:location_bbox"><code>dcat:bbox</code></a> [[VOCAB-DCAT]].</p>
+            <p>The following [[TURTLE]] snippet shows the [[GeoDCAT-AP]] representation of the dataset in <a href="#ex-schemaorg-dataset-and-place"></a>. Here the bounding box is provided in multiple literal encodings (<a>WKT</a>, [[GML]], GeoJSON [[RFC7946]]), by using property <a href="https://www.w3.org/TR/vocab-dcat-2/#Property:location_bbox"><code>dcat:bbox</code></a> [[VOCAB-DCAT-2]].</p>
 
 	    <div class="issue" data-number="1252"></div>
 
@@ -2221,7 +2221,7 @@ Connection: close
 <p>Added the following example on the use of [[VOCAB-DCAT-2]] for the specification of centroids and bounding boxes.</p>
 </aside>
 
-<p>The same example can be written as follows, using the relevant properties from [[VOCAB-DCAT]] (<a href="https://www.w3.org/TR/vocab-dcat-2/#Property:location_centroid"><code>dcat:centroid</code></a> and <a href="https://www.w3.org/TR/vocab-dcat-2/#Property:location_bbox"><code>dcat:bbox</code></a>):</p>
+<p>The same example can be written as follows, using the relevant properties from [[VOCAB-DCAT-2]] (<a href="https://www.w3.org/TR/vocab-dcat-2/#Property:location_centroid"><code>dcat:centroid</code></a> and <a href="https://www.w3.org/TR/vocab-dcat-2/#Property:location_bbox"><code>dcat:bbox</code></a>):</p>
 <pre>
 @prefix bag:       &lt;http://bag.basisregistraties.overheid.nl/def/bag#&gt; .
 @prefix dcat:      &lt;http://www.w3.org/ns/dcat#&gt; .
@@ -4058,16 +4058,16 @@ a:Dataset a dcat:Dataset ;
               <li>As shown in [[DWBP]] <a
               href="https://www.w3.org/TR/dwbp/#DescriptiveMetadata">Best Practice 2: Provide descriptive metadata</a>:
                 Include the spatial extent of the things described by the dataset using
-                [[VOCAB-DCAT]] and a reference to a named place in a common vocabulary for
+                [[VOCAB-DCAT-2]] and a reference to a named place in a common vocabulary for
                 geospatial semantics (e.g. <a
                   href="http://www.geonames.org/ontology/documentation.html">GeoNames</a>).</li>
               <li>
-                <p>Again, use [[VOCAB-DCAT]], but instead of a reference to a named place, use a set
+                <p>Again, use [[VOCAB-DCAT-2]], but instead of a reference to a named place, use a set
                 of coordinates to specify the boundaries of the area either as a bounding box
                 or a polygon &mdash; see <a href="#ex-geodcat-ap-bag-addresses"></a>.</p>
 <!--
                 <p>This can be done, e.g., by using the approach defined in the spatial extension of 
-                [[VOCAB-DCAT]], [[GeoDCAT-AP]] &mdash; see <a href="#ex-geodcat-ap-bag-addresses"></a>.</p>
+                [[VOCAB-DCAT-2]], [[GeoDCAT-AP]] &mdash; see <a href="#ex-geodcat-ap-bag-addresses"></a>.</p>
                 <aside class="note">
                   <p>[[GeoDCAT-AP]] provides an <a>RDF</a> [[RDF11-PRIMER]]
                     syntax binding for the metadata elements defined in the core profile of [[ISO-19115]]
@@ -4077,7 +4077,7 @@ a:Dataset a dcat:Dataset ;
               </li>
               <li>
                 <p>Use [[GeoDCAT-AP]] to specify spatial
-                attributes that are not available in [[VOCAB-DCAT]] &mdash; 
+                attributes that are not available in [[VOCAB-DCAT-2]] &mdash; 
                 see <a href="#ex-geodcat-ap-dataset-spatial-representation-type"></a>
                 and <a href="#ex-geodcat-ap-spatial-resolution"></a>.</p>
                 <aside class="note">
@@ -4304,9 +4304,9 @@ a:Dataset a dcat:Dataset ;
 <p>The following paragraphs have been added in order to update the BP wrt to [[VOCAB-DCAT-2]] and [[GeoDCAT-AP-20201223]].</p>
 </aside>
 
-<p>The [[VOCAB-DQV]] approach is recommended also in [[VOCAB-DCAT]] as a general solution to specify precision and accuracy. However, in order to address the most common case of spatial resolution (i.e., as horizontal ground distance), [[VOCAB-DCAT]] defines also a specific property, <a href="https://www.w3.org/TR/vocab-dcat-2/#Property:dataset_spatial_resolution"><code>dcat:spatialResolutionInMeters</code></a>. By using this property, <a href="#ex-dqv-dataset-quality" class="exampleRef"></a> can be re-written as follows:</p>
+<p>The [[VOCAB-DQV]] approach is recommended also in [[VOCAB-DCAT-2]] as a general solution to specify precision and accuracy. However, in order to address the most common case of spatial resolution (i.e., as horizontal ground distance), [[VOCAB-DCAT-2]] defines also a specific property, <a href="https://www.w3.org/TR/vocab-dcat-2/#Property:dataset_spatial_resolution"><code>dcat:spatialResolutionInMeters</code></a>. By using this property, <a href="#ex-dqv-dataset-quality" class="exampleRef"></a> can be re-written as follows:</p>
 
-<aside class="example" id="ex-dcat-dataset-quality" title="[VOCAB-DCAT] specification of spatial resolution and accuracy">
+<aside class="example" id="ex-dcat-dataset-quality" title="[VOCAB-DCAT-2] specification of spatial resolution and accuracy">
 <pre>
 :myDataset a dcat:Dataset ;
    dqv:hasQualityMeasurement :myDatasetAccuracy ;
@@ -4331,25 +4331,19 @@ a:Dataset a dcat:Dataset ;
 <p>Finally, [[GeoDCAT-AP]], building upon the [[VOCAB-DQV]] approach, defines specific individuals for the different types of spatial resolution in [[ISO-19115]] and [[ISO-19115-1-2014]] &mdash; namely:</p>
 
 <ul>
-<li>horizontal ground distance (<a href="https://semiceu.github.io/GeoDCAT-AP/releases/#metric-spatial-resolution-as-distance"><code>geodcatap:spatialResolutionAsDistance</code></a>);</li>
 <li>equivalent scale (<a href="https://semiceu.github.io/GeoDCAT-AP/releases/#metric-spatial-resolution-as-scale"><code>geodcatap:spatialResolutionAsScale</code></a>);</li>
 <li>angular distance (<a href="https://semiceu.github.io/GeoDCAT-AP/releases/#metric-spatial-resolution-as-angular-distance"><code>geodcatap:spatialResolutionAsAngularDistance</code></a>);</li>
-<li>vertical distance (<a href="https://semiceu.github.io/GeoDCAT-AP/releases/#metric-spatial-resolution-as-vertical-distance"><code>geodcatap:spatialResolutionAsVerticalDistance</code></a>).</li>
+<li>vertical distance (<a href="https://semiceu.github.io/GeoDCAT-AP/releases/#metric-spatial-resolution-as-vertical-distance"><code>geodcatap:spatialResolutionAsVerticalDistance</code></a>);</li>
+<li>horizontal ground distance (<a href="https://semiceu.github.io/GeoDCAT-AP/releases/#metric-spatial-resolution-as-distance"><code>geodcatap:spatialResolutionAsDistance</code></a>) can be used if the distance isn't expressed in metres.</li>
 </ul>
 
-<p> The use of these individuals is illustrated in the following example:</p>
+<p>These are illustrated in the following example:</p>
 
 <aside class="example" id="ex-geodcat-ap-spatial-resolution" title="[GeoDCAT-AP] specification of different types of spatial resolution">
 <pre>
 resource:a12345 dqv:hasQualityMeasurement [ a dqv:QualityMeasurement ;
       dqv:isMeasurementOf geodcatap:spatialResolutionAsScale ;
       dqv:value "0.000001"^^xsd:decimal ] ;
-.
-
-resource:b23456 dqv:hasQualityMeasurement [ a dqv:QualityMeasurement ;
-      sdmx-attribute:unitMeasure &lt;http://qudt.org/vocab/unit/M&gt; ;
-      dqv:isMeasurementOf geodcatap:spatialResolutionAsDistance ;
-      dqv:value "100.0"^^xsd:decimal ] ;
 .
 
 resource:c34567 dqv:hasQualityMeasurement [ a dqv:QualityMeasurement ;
@@ -4363,6 +4357,10 @@ resource:d45678 dqv:hasQualityMeasurement [ a dqv:QualityMeasurement ;
       dqv:isMeasurementOf geodcatap:spatialResolutionAsVerticalDistance ;
       dqv:value "10.0"^^xsd:decimal ] ;
 .
+resource:b23456 dqv:hasQualityMeasurement [ a dqv:QualityMeasurement ;
+      sdmx-attribute:unitMeasure <http://qudt.org/vocab/unit/MI_N&gt; ;
+      dqv:isMeasurementOf geodcatap:spatialResolutionAsDistance ;
+      dqv:value "0.1"^^xsd:decimal ] ;
 </pre>
 </aside>
 
@@ -4469,7 +4467,9 @@ resource:d45678 dqv:hasQualityMeasurement [ a dqv:QualityMeasurement ;
       </section>
       <section>
         <h3>Describing dataset structure and service behaviors</h3>
-        <p>Even if all <a>spatial data</a> should become findable directly through search engines, data portals would still remain important hubs for data discovery &mdash; for example, because the metadata records registered there can be made crawlable. But in addition, different data portals can harvest each other's information provided there is consistency in the types and meaning of included information, even if structures and technologies vary. In the eGovernment sector, [[VOCAB-DCAT-2]] is a standard for dataset metadata publication and harvesting implemented by these portals. Because it is lacking in possibilities for describing some specific characteristics spatial datasets, an application profile for <a>spatial data</a>, [[GeoDCAT-AP-20201223]], has been developed in the framework of <a href="https://ec.europa.eu/isa2/">ISA Programme of the European Union</a>, with the primary purpose of enabling the sharing of spatial metadata across domains and catalogue platforms. [[GeoDCAT-AP-20201223]] is mentioned in the "Possible approach" section of several Best Practices in this document. </p>
+        <p>Even if all <a>spatial data</a> should become findable directly through search engines, data portals would still remain important hubs for data discovery &mdash; for example, because the metadata records registered there can be made crawlable. But in addition, different data portals can harvest each other's information provided there is consistency in the types and meaning of included information, even if structures and technologies vary. In the eGovernment sector, [[VOCAB-DCAT-2]] is a standard for dataset metadata publication and harvesting implemented by these portals. 
+		Version 1 of DCAT, and therefore it's European Union profile, was not good at describing spatial datasets so [[GeoDCAT-AP]] extended the EU application profile for <a>spatial data</a>.
+		Some of the ideas of GeoDCAT-AP have been adopted in DCAT2 and GeoDCAT-AP has been updated accordingly. [[GeoDCAT-AP-20201223]] is mentioned in the "Possible approach" section of several Best Practices in this document. It still adds some properties beyond DCAT2 that are useful in certain cases.</p>
           <p>With the goal of sharing spatial metadata, [[GeoDCAT-AP-20201223]] defined <a>RDF</a> bindings covering the core profile of [[ISO-19115]] and the INSPIRE metadata schema [[INSPIRE-MD]], enabling the harmonized <a>RDF</a> representation of existing spatial metadata. The reason of this choice was to focus first on the most used metadata elements, whereas additional mappings could be defined in future versions of the specification, based on users’ and implementation feedback.</p>
          <p>The next step is evolution towards a single standard for metadata as it is used in data portals, without loss of relevant metadata, while still understandable and not too complicated. A working group in the Open Geospatial Consortium is currently working on a standardized Web API, <a href="https://ogcapi.ogc.org/records/">OGC API Records</a>, for metadata publication and discovery. It offers the capability to create, modify, and query metadata on the Web by providing a simple, extendable record schema for describing datasets and other resources, a way to organize records in collections, and an API to access and interact with these collections. When finished, this standard will support the publication of metadata catalogs in conformance to the best practices in this document.</p>
 
@@ -4758,7 +4758,7 @@ resource:d45678 dqv:hasQualityMeasurement [ a dqv:QualityMeasurement ;
           href="http://lov.okfn.org/dataset/lov/vocabs?tag=Time">Time</a>.</p>
 	
 <aside class="ednote">
-<p>Added column for [[VOCAB-DCAT]].</p>
+<p>Added column for [[VOCAB-DCAT-2]].</p>
 </aside>
 
 <table class="simple" id="table-vocabs-matrix">
@@ -4775,7 +4775,7 @@ resource:d45678 dqv:hasQualityMeasurement [ a dqv:QualityMeasurement ;
 <th>[[SCHEMA-ORG]]</th>
 <th>[[GeoSPARQL]]</th>
 <th>[[LOCN]]</th>
-<th>[[VOCAB-DCAT]]</th>
+<th>[[VOCAB-DCAT-2]]</th>
 </tr>
 </thead>
 <tbody>

--- a/bp/index.html
+++ b/bp/index.html
@@ -1266,8 +1266,6 @@ function bpCrossRefs() {
 
 <div class="issue" data-number="1146"></div>
 
-<div class="issue" data-number="1084"></div>
-
       <section id="bp-webprinciples">
         <h3>Web principles for spatial data</h3>
         <p><a>Spatial data</a>, like any other data, should be published on the Web. By this we mean more than providing spatial data file downloads or services; for data to be <em>on the Web</em>, the resources it describes need to be identified using HTTP URIs, be published in such a way that they are indexable by search engines, and be connected, or linked, to other resources. This makes the data easy to find and easy to access for non-specialist users: the spatial data becomes integrated within the wider Web of data. </p>


### PR DESCRIPTION
Changes related to https://github.com/w3c/sdw/issues/1297

Some DCAT -> DCAT2 changes had already been made

Should we remove DCAT1 from the informative references? If so, should we then re-use the id/link VOCAB-DCAT to mean DCAT2?