### PR TITLE
SOSA-OMS Alignment

### DIFF
--- a/ssn/integrated/readme.md
+++ b/ssn/integrated/readme.md
@@ -1,3 +1,73 @@
+# SOSA/SSN - OMS Alignment
+
+Notes about the integration of new OMS v3 concepts into the SOSA/SSN ontology (2023).
+
+
+## Design choices:
+
+ - No change to URIs of existing SOSA/SSN classes and properties.
+ - Only allow minor documentation changes or clarifications that don't fundamentally change the meaning of existing concepts.
+ - Keep most notes and examples from OMS
+ - Some changes to relations to better integrate new OMS classes (range or domain)
+ - Rename associations with more specific names since unique URIs are neeeded in RDF
+
+
+## Summary of the changes:
+
+### New concepts introduced from SSN extensions
+
+#### Classes:
+ - ObservationCollection
+
+#### Associations:
+ - hasOriginalSample
+ - hasSampledFeature
+ - hasUltimateFeatureOfInterest
+
+
+### New concepts introduced from OMS
+
+#### Classes:
+ - ObservingProcedure
+ - SamplingProcedure
+ - PreparationProcedure
+ - Observer
+ - Host
+ - SpatialSample
+ - MaterialSample
+ - StatisticalSample
+ - SampleCollection
+
+#### Associations:
+ - ObservingProcedure subclassOf Procedure
+ - SamplingProcedure subclassOf Procedure
+ - PreparationProcedure subclassOf Procedure
+ - Sensor subclassOf Observer
+ - Platform subclassOf Host
+ - SpatialSample subclassOf Sample
+ - MaterialSample subclassOf Sample
+ - StatisticalSample subclassOf Sample 
+ - Observation usedProcedure ObservingProcedure
+ - Observation madeByObserver (but kept madeBySensor)
+ - Observation madeOnHost 
+ - Observer implements ObservingProcedure
+ - Sampling usedProcedure SamplingProcedure
+ - Sampling preparedSample
+ - Sampler implements SamplingProcedure
+
+
+### New concepts introduced for consistency
+
+#### Classes:
+ - ActuationProcedure
+
+#### Associations:
+ - Actuation usedProcedure ActuatingProcedure
+ - Actuator implements ActuatingProcedure
+
+
+
+
 # oldSSN/newSSN/SOSA/alignments Integration
 
 This folder contains a proposal for the various documents that need to be exposed by the W3C server:

--- a/ssn/integrated/sosa.ttl
+++ b/ssn/integrated/sosa.ttl
@@ -221,6 +221,37 @@ sosa:Procedure a rdfs:Class , owl:Class ;
   skos:note "Many observations may be created via the same Procedure, the same way as many tables are assembled using the same instructions (as information objects, not their concrete realization)."@en ;
   rdfs:isDefinedBy sosa: .
 
+sosa:ObservingProcedure a rdfs:Class , owl:Class ;
+  rdfs:subClassOf sosa:Procedure ;
+  rdfs:label "Observing Procedure"@en ;
+  skos:definition "The description of steps performed in order to determine the value of an ObservableProperty by an Observer."@en ;
+  rdfs:comment "The description of steps performed in order to determine the value of an ObservableProperty by an Observer."@en ;
+  skos:example "A workflow, protocol, plan, algorithm, or computational method specifying how to make an observation; the description of the process utilized by an observer. This could be a chemical analysis method, a protocol for measuring an object, but could also be a checklist utilized by a human observer during a biodiversity campaign."@en ;
+  skos:note "The observing procedure cannot describe a sensor instance, but it can describe the sensor type."@en ;
+  rdfs:isDefinedBy sosa: .
+
+sosa:ActuationProcedure a rdfs:Class , owl:Class ;
+  rdfs:subClassOf sosa:Procedure ;
+  rdfs:label "Actuation Procedure"@en ;
+  skos:definition "The description of steps performed by an Actuator to change the ActuableProperty."@en ;
+  rdfs:comment "The description of steps performed by an Actuator to change the ActuableProperty."@en ;
+  rdfs:isDefinedBy sosa: .
+
+sosa:SamplingProcedure a rdfs:Class , owl:Class ;
+  rdfs:subClassOf sosa:Procedure ;
+  rdfs:label "Sampling Procedure"@en ;
+  skos:definition "The description of steps performed by a Sampler in order to extract a Sample from its sampled Feature in the frame of a Sampling."@en ;
+  rdfs:comment "The description of steps performed by a Sampler in order to extract a Sample from its sampled Feature in the frame of a Sampling."@en ;
+  rdfs:isDefinedBy sosa: .
+
+sosa:PreparationProcedure a rdfs:Class , owl:Class ;
+  rdfs:subClassOf sosa:Procedure ;
+  rdfs:label "Preparation Procedure"@en ;
+  skos:definition "The description of preparation steps performed on a Sample."@en ;
+  rdfs:comment "The description of preparation steps performed on a Sample."@en ;
+  rdfs:isDefinedBy sosa: .
+
+
 ## ProcedureExecutors
 
 sosa:Sensor a rdfs:Class , owl:Class ;

--- a/ssn/integrated/sosa.ttl
+++ b/ssn/integrated/sosa.ttl
@@ -102,6 +102,22 @@ A Sample is intended to sample some FatureOfInterest, so there is an expectation
     owl:inverseOf sosa:hasSample ;
     rdfs:isDefinedBy sosa: .
 
+  sosa:hasOriginalSample a owl:ObjectProperty ;
+    rdfs:label "has original sample"@en ;
+    skos:definition "Link to the original sample that is related to the context sample through a chain of isSampleOf relations."@en ;
+    rdfs:comment "Link to the original sample that is related to the context sample through a chain of isSampleOf relations."@en ;
+    schema:domainIncludes sosa:Sample ;
+    schema:rangeIncludes sosa:Sample ;
+    rdfs:isDefinedBy sosa: .
+
+  sosa:hasSampledFeature a owl:ObjectProperty ;
+    rdfs:label "has ultimate sampled feature"@en ;
+    skos:definition "Link to the ultimate feature of interest of the context sample - i.e. the end of a chain of isSampleOf relations"@en ;
+    rdfs:comment "Link to the ultimate feature of interest of the context sample - i.e. the end of a chain of isSampleOf relations"@en ;
+    schema:domainIncludes sosa:Sample ;
+    schema:rangeIncludes sosa:FeatureOfInterest ;
+    rdfs:isDefinedBy sosa: .
+
 
 ## Platform 
 
@@ -211,6 +227,18 @@ sosa:hasFeatureOfInterest a owl:ObjectProperty ;
   schema:rangeIncludes sosa:FeatureOfInterest ;
   schema:rangeIncludes sosa:Sample ;
   owl:inverseOf sosa:isFeatureOfInterestOf ;
+  rdfs:isDefinedBy sosa: .
+
+sosa:hasUltimateFeatureOfInterest a owl:ObjectProperty ;
+  rdfs:label "has ultimate feature of interest"@en  ;
+  skos:definition "Link to the ultimate feature of interest of an observation or act of sampling. This is useful when the proximate feature of interest is a sample of the ultimate feature of interest, directly or transitively." ;
+  rdfs:comment "Link to the ultimate feature of interest of an observation or act of sampling. This is useful when the proximate feature of interest is a sample of the ultimate feature of interest, directly or transitively." ;
+  rdfs:comment """should match a property chain something like this but with sosa:isSampleOf*
+      owl:propertyChainAxiom ( sosa:hasFeatureOfInterest sosa:isSampleOf )""" ;
+  schema:domainIncludes sosa:Observation ;
+  schema:domainIncludes sosa:Actuation ;
+  schema:domainIncludes sosa:Sampling ;
+  schema:rangeIncludes sosa:FeatureOfInterest ;
   rdfs:isDefinedBy sosa: .
 
 sosa:isFeatureOfInterestOf a owl:ObjectProperty ;
@@ -337,6 +365,53 @@ sosa:Sampling a rdfs:Class , owl:Class ;
     schema:rangeIncludes sosa:Sampler ;
     owl:inverseOf sosa:madeSampling ;
     rdfs:isDefinedBy sosa: .
+
+## Observation Collection and related stuff
+
+sosa:Observation
+  rdfs:comment """If values are not provided for the following Observation properties, they may be provided by the ObservationCollection of which it is a member:
+  - hasFeatureOfInterest
+  - hasUltimateFeatureOfInterest
+  - madeBySensor
+  - observedProperty
+  - phenomenonTime
+  - resultTime
+  - usedProcedure""" .
+
+sosa:ObservationCollection a rdfs:Class , owl:Class ;
+  rdfs:label "Observation Collection"@en ;
+  skos:definition "A collection of observations, typically with one or more property shared by all of its members."@en ;
+  rdfs:comment "A collection of observations, typically with one or more property shared by all of its members."@en ;
+  rdfs:isDefinedBy sosa: .
+
+sosa:hasMemberObs a owl:ObjectProperty ;
+  rdfs:label "member observation" ;
+  rdfs:comment "Link to a member within a collection of (observations) or (collections of observations) that share the same value for one or more of the characteristic properties" ;
+  schema:domainIncludes sosa:ObservationCollection ;
+  schema:rangeIncludes sosa:Observation ;
+  schema:rangeIncludes sosa:ObservationCollection ;
+  rdfs:subPropertyOf rdfs:member .
+
+sosa:hasFeatureOfInterest
+  schema:domainIncludes sosa:ObservationCollection .
+
+sosa:hasUltimateFeatureOfInterest
+  schema:domainIncludes sosa:ObservationCollection .
+
+sosa:madeBySensor
+  schema:domainIncludes sosa:ObservationCollection .
+
+sosa:observedProperty
+  schema:domainIncludes sosa:ObservationCollection .
+
+sosa:phenomenonTime
+  schema:domainIncludes sosa:ObservationCollection .
+
+sosa:resultTime
+  schema:domainIncludes sosa:ObservationCollection .
+
+sosa:usedProcedure
+  schema:domainIncludes sosa:ObservationCollection .
 
 
 ## Result 

--- a/ssn/integrated/sosa.ttl
+++ b/ssn/integrated/sosa.ttl
@@ -118,6 +118,14 @@ A Sample is intended to sample some FatureOfInterest, so there is an expectation
     schema:rangeIncludes sosa:FeatureOfInterest ;
     rdfs:isDefinedBy sosa: .
 
+  sosa:hasPreparationStep a owl:ObjectProperty ;
+    rdfs:label "has preparation step"@en ;
+    skos:definition "Link to the ultimate feature of interest of the context sample - i.e. the end of a chain of isSampleOf relations"@en ;
+    rdfs:comment "Link to the ultimate feature of interest of the context sample - i.e. the end of a chain of isSampleOf relations"@en ;
+    schema:domainIncludes sosa:Sample ;
+    schema:rangeIncludes sosa:PreparationStep ;
+    rdfs:isDefinedBy sosa: .
+
 sosa:SpatialSample a rdfs:Class , owl:Class ;
   rdfs:subClassOf sosa:Sample ;
   rdfs:label "Spatial Sample"@en ;
@@ -408,7 +416,21 @@ sosa:Sampling a rdfs:Class , owl:Class ;
     owl:inverseOf sosa:madeSampling ;
     rdfs:isDefinedBy sosa: .
 
-## Observation Collection and related stuff
+sosa:PreparationStep a rdfs:Class , owl:Class ;
+  rdfs:label "Preparation Step"@en ;
+  skos:definition "A PreparationStep is an individual step pertaining to a PreparationProcedure."@en ;
+  rdfs:comment "A PreparationStep is an individual step pertaining to a PreparationProcedure."@en ;
+  skos:example "???"@en ;
+  rdfs:isDefinedBy sosa: .
+
+  sosa:preparedSample a owl:ObjectProperty ;
+    rdfs:label "prepared sample"@en ;
+    skos:definition "The Sample on which the PreparationProcedure is performed."@en ;
+    rdfs:comment "The Sample on which the PreparationProcedure is performed."@en ;
+    schema:domainIncludes sosa:PreparationStep ;
+    schema:rangeIncludes sosa:Sample ;
+    rdfs:isDefinedBy sosa: .
+
 
 sosa:Observation
   rdfs:comment """If values are not provided for the following Observation properties, they may be provided by the ObservationCollection of which it is a member:

--- a/ssn/integrated/sosa.ttl
+++ b/ssn/integrated/sosa.ttl
@@ -375,12 +375,12 @@ sosa:Observation a rdfs:Class , owl:Class ;
     rdfs:isDefinedBy sosa: .
 
   sosa:madeBySensor rdf:type owl:ObjectProperty ;
-   rdfs:label "made by sensor"@en ;
-   skos:definition "Relation between an Observation and the Sensor which made the Observation."@en ;
-   rdfs:comment "Relation between an Observation and the Sensor which made the Observation."@en ;
-   schema:domainIncludes sosa:Observation ;
-   schema:rangeIncludes sosa:Sensor ;
-   owl:inverseOf sosa:madeObservation ;
+    rdfs:label "made by sensor"@en ;
+    skos:definition "Relation between an Observation and the Sensor which made the Observation."@en ;
+    rdfs:comment "Relation between an Observation and the Sensor which made the Observation."@en ;
+    schema:domainIncludes sosa:Observation ;
+    schema:rangeIncludes sosa:Sensor ;
+    owl:inverseOf sosa:madeObservation ;
     rdfs:subPropertyOf sosa:madeByObserver ;
     rdfs:isDefinedBy sosa: .
 

--- a/ssn/integrated/sosa.ttl
+++ b/ssn/integrated/sosa.ttl
@@ -172,6 +172,7 @@ sosa:hasMemberSample a owl:ObjectProperty ;
 ## Platform 
 
 sosa:Platform a rdfs:Class , owl:Class ;
+  rdfs:subClassOf sosa:Host ;
   rdfs:label "Platform"@en ;
   skos:definition "A Platform is an entity that hosts other entities, particularly Sensors, Actuators, Samplers, and other Platforms."@en ;
   rdfs:comment "A Platform is an entity that hosts other entities, particularly Sensors, Actuators, Samplers, and other Platforms."@en ;
@@ -182,11 +183,11 @@ sosa:hosts a owl:ObjectProperty ;
   rdfs:label "hosts"@en ;
   skos:definition "Relation between a Platform and a Sensor, Actuator, Sampler, or Platform, hosted or mounted on it."@en ;
   rdfs:comment "Relation between a Platform and a Sensor, Actuator, Sampler, or Platform, hosted or mounted on it."@en ;
-  schema:domainIncludes sosa:Platform ;
+  schema:domainIncludes sosa:Host ;
+  schema:rangeIncludes sosa:Observer ;
   schema:rangeIncludes sosa:Actuator ;
-  schema:rangeIncludes sosa:Sensor ;
   schema:rangeIncludes sosa:Sampler ;
-  schema:rangeIncludes sosa:Platform ;
+  schema:rangeIncludes sosa:Host ;
   owl:inverseOf sosa:isHostedBy ;
   rdfs:isDefinedBy sosa: .
 
@@ -194,12 +195,19 @@ sosa:isHostedBy a owl:ObjectProperty ;
   rdfs:label "is hosted by"@en ;
   skos:definition "Relation between a Sensor, Actuator, Sampler, or Platform, and the Platform that it is mounted on or hosted by."@en ;
   rdfs:comment "Relation between a Sensor, Actuator, Sampler, or Platform, and the Platform that it is mounted on or hosted by."@en ;
+  schema:domainIncludes sosa:Observer ;
   schema:domainIncludes sosa:Actuator ;
-  schema:domainIncludes sosa:Sensor ;
   schema:domainIncludes sosa:Sampler ;
-  schema:domainIncludes sosa:Platform ;
-  schema:rangeIncludes sosa:Platform ;
+  schema:domainIncludes sosa:Host ;
+  schema:rangeIncludes sosa:Host ;
   owl:inverseOf sosa:hosts ;
+  rdfs:isDefinedBy sosa: .
+
+sosa:Host a rdfs:Class , owl:Class ;
+  rdfs:label "Host"@en ;
+  skos:definition "A grouping of Observers for a specific reason."@en ;
+  rdfs:comment "A grouping of Observers for a specific reason."@en ;
+  skos:example "An environmental monitoring facility. A platform that hosts a set of sensors. A team performing a survey, where each team member would be modeled as an Observer."@en ;
   rdfs:isDefinedBy sosa: .
 
 
@@ -216,6 +224,7 @@ sosa:Procedure a rdfs:Class , owl:Class ;
 ## ProcedureExecutors
 
 sosa:Sensor a rdfs:Class , owl:Class ;
+  rdfs:subClassOf sosa:Observer ;
   rdfs:label "Sensor"@en ;
   skos:definition "Device, agent (including humans), or software (simulation) involved in, or implementing, a Procedure. Sensors respond to a stimulus, e.g., a change in the environment, or input data composed from the results of prior Observations, and generate a Result. Sensors can be hosted by Platforms."@en ;
   rdfs:comment "Device, agent (including humans), or software (simulation) involved in, or implementing, a Procedure. Sensors respond to a stimulus, e.g., a change in the environment, or input data composed from the results of prior Observations, and generate a Result. Sensors can be hosted by Platforms."@en ;
@@ -227,6 +236,7 @@ sosa:Sensor a rdfs:Class , owl:Class ;
     skos:definition "Relation between a Sensor and an ObservableProperty that it is capable of sensing."@en ;
     rdfs:comment "Relation between a Sensor and an ObservableProperty that it is capable of sensing."@en ;
     schema:domainIncludes sosa:Sensor ;
+    schema:domainIncludes sosa:Observer ;
     schema:rangeIncludes sosa:ObservableProperty ;
     owl:inverseOf sosa:isObservedBy ;
     rdfs:isDefinedBy sosa: .
@@ -237,6 +247,7 @@ sosa:Sensor a rdfs:Class , owl:Class ;
     rdfs:comment "Relation between an ObservableProperty and the Sensor able to observe it."@en ;
     schema:domainIncludes sosa:ObservableProperty ;
     schema:rangeIncludes sosa:Sensor ;
+    schema:rangeIncludes sosa:Observer ;
     owl:inverseOf sosa:observes ;
     rdfs:isDefinedBy sosa: .
 
@@ -253,6 +264,18 @@ sosa:Sampler a rdfs:Class , owl:Class ;
   rdfs:comment "A device that is used by, or implements, a Sampling Procedure to create or transform one or more samples."@en ;
   skos:example "A ball mill, diamond drill, hammer, hypodermic syringe and needle, image Sensor or a soil auger can all act as sampling devices (i.e., be Samplers). However, sometimes the distinction between the Sampler and the Sensor is not evident, as they are packaged as a unit. A Sampler need not be a physical device."@en ;
   rdfs:isDefinedBy sosa: .
+
+sosa:Observer a rdfs:Class , owl:Class ;
+  rdfs:label "Observer"@en ;
+  skos:definition "An identifiable entity that can generate Observations pertaining to an ObservableProperty by implementing an ObservingProcedure."@en ;
+  rdfs:comment "An identifiable entity that can generate Observations pertaining to an ObservableProperty by implementing an ObservingProcedure."@en ;
+  skos:example "Accelerometers, gyroscopes, barometers, magnetometers, and so forth are Observers that are typically mounted on a modern smartphone (which acts as Host). Other examples of Sensors include the human eyes."@en ;
+  skos:note "Different Observers can follow the same (reusable) observing Procedure for the creation of different Observations."@en ;
+  skos:note "The Observer is the entity instance, not the entity type. Pertaining to sensors, the Observer would reference the explicit sensor, while the Procedure would reference the methodology utilized by that sensor type;"@en ;
+  skos:note "An Observer can be hosted by one or more Host."@en ;
+  skos:note "The Observer is an instance of a sensor, instrument, implementation of an algorithm, or a being such as a person."@en ;
+  rdfs:isDefinedBy sosa: .
+
 
 ## ProcedureExecutions
 
@@ -315,6 +338,7 @@ sosa:Observation a rdfs:Class , owl:Class ;
     skos:definition "Relation between a Sensor and an Observation made by the Sensor."@en ;
     rdfs:comment "Relation between a Sensor and an Observation made by the Sensor."@en ;
     schema:domainIncludes sosa:Sensor ;
+    schema:domainIncludes sosa:Observer ;
     schema:rangeIncludes sosa:Observation ;
     owl:inverseOf sosa:madeBySensor ;
     rdfs:isDefinedBy sosa: .
@@ -326,6 +350,7 @@ sosa:Observation a rdfs:Class , owl:Class ;
    schema:domainIncludes sosa:Observation ;
    schema:rangeIncludes sosa:Sensor ;
    owl:inverseOf sosa:madeObservation ;
+    rdfs:subPropertyOf sosa:madeByObserver ;
     rdfs:isDefinedBy sosa: .
 
   sosa:observedProperty a owl:ObjectProperty ;
@@ -334,6 +359,23 @@ sosa:Observation a rdfs:Class , owl:Class ;
     rdfs:comment "Relation linking an Observation to the property that was observed. The ObservableProperty should be a property of the FeatureOfInterest (linked by hasFeatureOfInterest) of this Observation."@en ;
     schema:domainIncludes sosa:Observation ;
     schema:rangeIncludes sosa:ObservableProperty ;
+    rdfs:isDefinedBy sosa: .
+
+  sosa:madeByObserver rdf:type owl:ObjectProperty ;
+    rdfs:label "made by observer"@en ;
+    skos:definition "Relation between an Observation and the Observer which made the Observation."@en ;
+    rdfs:comment "Relation between an Observation and the Observer which made the Observation."@en ;
+    schema:domainIncludes sosa:Observation ;
+    schema:rangeIncludes sosa:Observer ;
+    owl:inverseOf sosa:madeObservation ;
+    rdfs:isDefinedBy sosa: .
+
+  sosa:madeOnHost rdf:type owl:ObjectProperty ;
+    rdfs:label "made on host"@en ;
+    skos:definition "Relation between an Observation and the Host the Observer was attached to at the time the observation was made."@en ;
+    rdfs:comment "Relation between an Observation and the Host the Observer was attached to at the time the observation was made."@en ;
+    schema:domainIncludes sosa:Observation ;
+    schema:rangeIncludes sosa:Host ;
     rdfs:isDefinedBy sosa: .
 
 sosa:Actuation a rdfs:Class , owl:Class ;
@@ -432,11 +474,15 @@ sosa:PreparationStep a rdfs:Class , owl:Class ;
     rdfs:isDefinedBy sosa: .
 
 
+## Observation Collection
+
 sosa:Observation
   rdfs:comment """If values are not provided for the following Observation properties, they may be provided by the ObservationCollection of which it is a member:
   - hasFeatureOfInterest
   - hasUltimateFeatureOfInterest
   - madeBySensor
+  - madeByObserver
+  - madeOnHost
   - observedProperty
   - phenomenonTime
   - resultTime
@@ -463,6 +509,12 @@ sosa:hasUltimateFeatureOfInterest
   schema:domainIncludes sosa:ObservationCollection .
 
 sosa:madeBySensor
+  schema:domainIncludes sosa:ObservationCollection .
+
+sosa:madeByObserver
+  schema:domainIncludes sosa:ObservationCollection .
+
+sosa:madeOnHost
   schema:domainIncludes sosa:ObservationCollection .
 
 sosa:observedProperty

--- a/ssn/integrated/sosa.ttl
+++ b/ssn/integrated/sosa.ttl
@@ -118,6 +118,48 @@ A Sample is intended to sample some FatureOfInterest, so there is an expectation
     schema:rangeIncludes sosa:FeatureOfInterest ;
     rdfs:isDefinedBy sosa: .
 
+sosa:SpatialSample a rdfs:Class , owl:Class ;
+  rdfs:subClassOf sosa:Sample ;
+  rdfs:label "Spatial Sample"@en ;
+  skos:definition "A SpatialSample is a geospatial Sample. When observations are made to estimate properties of a geospatial feature, in particular where the value of a property varies within the scope of the feature, a SpatialSample is used."@en ;
+  rdfs:comment "A SpatialSample is a geospatial Sample. When observations are made to estimate properties of a geospatial feature, in particular where the value of a property varies within the scope of the feature, a SpatialSample is used."@en ;
+  skos:example "Some common names for spatial samples include: borehole, flightline, interval, lidar cloud, map horizon, microscope slide, mine level, mine, observation well, profile, pulp, quadrat, scene, section, ship track, spot, station, swath, trajectory, traverse, etc..."@en ;
+  skos:note "Depending on accessibility and on the nature of the expected property variation, the SpatialSample may be extensive in one, two or three spatial dimensions."@en ;
+  rdfs:isDefinedBy sosa: .
+
+sosa:MaterialSample a rdfs:Class , owl:Class ;
+  rdfs:subClassOf sosa:Sample ;
+  rdfs:label "Material Sample"@en ;
+  skos:definition "A MaterialSample is a physical, tangible Sample."@en ;
+  rdfs:comment "A MaterialSample is a physical, tangible Sample."@en ;
+  skos:example "A piece of rock, a blood sample, a water sample, etc."@en ;
+  skos:note "MaterialSamples that are curated and preserved are sometimes known as 'specimens'."@en ;
+  skos:note "MaterialSamples can be destroyed in connexion with the observation act."@en ;
+  rdfs:isDefinedBy sosa: .
+
+sosa:StatisticalSample a rdfs:Class , owl:Class ;
+  rdfs:subClassOf sosa:Sample ;
+  rdfs:label "Statistical Sample"@en ;
+  skos:definition "A StatisticalSample is a statistical subset of a feature-of-interest, defined for the purpose of creating Observation(s)."@en ;
+  rdfs:comment "A StatisticalSample is a statistical subset of a feature-of-interest, defined for the purpose of creating Observation(s)."@en ;
+  skos:example "The male or female subset of a population."@en ;
+  skos:note "StatisticalSamples usually apply to populations or other sets, of which certain subset may be of specific interest."@en ;
+  rdfs:isDefinedBy sosa: .
+
+sosa:SampleCollection a rdfs:Class , owl:Class ;
+  rdfs:label "Sample Collection"@en ;
+  skos:definition "A collection of Samples."@en ;
+  rdfs:comment "A collection of Samples."@en ;
+  rdfs:isDefinedBy sosa: .
+
+sosa:hasMemberSample a owl:ObjectProperty ;
+  rdfs:label "member sample" ;
+  rdfs:comment "Link to a member within a collection of samples" ;
+  schema:domainIncludes sosa:SampleCollection ;
+  schema:rangeIncludes sosa:Sample ;
+  schema:rangeIncludes sosa:SampleCollection ;
+  rdfs:subPropertyOf rdfs:member .
+
 
 ## Platform 
 

--- a/ssn/integrated/ssn.ttl
+++ b/ssn/integrated/ssn.ttl
@@ -304,7 +304,7 @@ sosa:Observation a owl:Class ;
     
   sosa:madeBySensor 
     rdfs:isDefinedBy sosa: .
-
+    
   sosa:madeByObserver 
     rdfs:isDefinedBy sosa: .
     
@@ -374,6 +374,30 @@ sosa:PreparationStep a owl:Class ;
 
   sosa:preparedSample a owl:FunctionalProperty ;
     rdfs:isDefinedBy sosa: .
+
+
+## Observation collection
+
+sosa:ObservationCollection a owl:Class ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:madeByObserver ; owl:cardinality "1"^^xsd:nonNegativeInteger ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:madeByObserver ; owl:allValuesFrom sosa:Observer ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:madeBySensor ; owl:cardinality "1"^^xsd:nonNegativeInteger ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:madeBySensor ; owl:allValuesFrom sosa:Sensor ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:madeOnHost ; owl:cardinality "1"^^xsd:nonNegativeInteger ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:madeOnHost ; owl:allValuesFrom sosa:Host ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:usedProcedure ; owl:allValuesFrom sosa:ObservingProcedure ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasFeatureOfInterest ; owl:cardinality "1"^^xsd:nonNegativeInteger ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasFeatureOfInterest ; owl:allValuesFrom sosa:FeatureOfInterest ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasUltimateFeatureOfInterest ; owl:minCardinality "1"^^xsd:nonNegativeInteger ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasUltimateFeatureOfInterest ; owl:allValuesFrom sosa:FeatureOfInterest ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:observedProperty ; owl:cardinality "1"^^xsd:nonNegativeInteger ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:observedProperty ; owl:allValuesFrom sosa:ObservableProperty ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:phenomenonTime ; owl:cardinality "1"^^xsd:nonNegativeInteger ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:resultTime ; owl:cardinality "1"^^xsd:nonNegativeInteger ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasMemberObs ; owl:allValuesFrom sosa:Observation ] ;
+  rdfs:isDefinedBy sosa: .
+
+
 ## Stimulus
 
 ssn:Stimulus a owl:Class ;

--- a/ssn/integrated/ssn.ttl
+++ b/ssn/integrated/ssn.ttl
@@ -110,6 +110,19 @@ sosa:Sample
   sosa:isSampleOf a owl:FunctionalProperty ;
     rdfs:isDefinedBy sosa: .
 
+sosa:SpatialSample
+  rdfs:isDefinedBy sosa: .
+
+sosa:MaterialSample
+  rdfs:isDefinedBy sosa: .
+
+sosa:StatisticalSample
+  rdfs:isDefinedBy sosa: .
+
+sosa:SampleCollection
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasMemberSample ; owl:allValuesFrom sosa:Sample ] ;
+  rdfs:isDefinedBy sosa: .
+
 
 ## Platform
 

--- a/ssn/integrated/ssn.ttl
+++ b/ssn/integrated/ssn.ttl
@@ -97,6 +97,10 @@ sosa:Sample
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:isResultOf ; owl:minCardinality "1"^^xsd:nonNegativeInteger ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:isSampleOf ; owl:allValuesFrom sosa:FeatureOfInterest ]  ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:isSampleOf ; owl:minCardinality "1"^^xsd:nonNegativeInteger ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasOriginalSample ; owl:allValuesFrom sosa:Sample ]  ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasOriginalSample ; owl:minCardinality "1"^^xsd:nonNegativeInteger ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasSampledFeature ; owl:allValuesFrom sosa:FeatureOfInterest ]  ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasSampledFeature ; owl:minCardinality "1"^^xsd:nonNegativeInteger ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:isResultOf ; owl:allValuesFrom sosa:Sampling ] ;
   rdfs:isDefinedBy sosa: .
 
@@ -218,6 +222,9 @@ sosa:usedProcedure
 sosa:hasFeatureOfInterest
   rdfs:isDefinedBy sosa: .
 
+sosa:hasUltimateFeatureOfInterest
+  rdfs:isDefinedBy sosa: .
+
 sosa:isFeatureOfInterestOf
   rdfs:isDefinedBy sosa: .
 
@@ -227,6 +234,8 @@ sosa:Observation a owl:Class ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:usedProcedure ; owl:allValuesFrom sosa:Procedure ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasFeatureOfInterest ; owl:cardinality "1"^^xsd:nonNegativeInteger ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasFeatureOfInterest ; owl:allValuesFrom sosa:FeatureOfInterest ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasUltimateFeatureOfInterest ; owl:minCardinality "1"^^xsd:nonNegativeInteger ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasUltimateFeatureOfInterest ; owl:allValuesFrom sosa:FeatureOfInterest ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:observedProperty ; owl:cardinality "1"^^xsd:nonNegativeInteger ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:observedProperty ; owl:allValuesFrom sosa:ObservableProperty ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:wasOriginatedBy ; owl:cardinality "1"^^xsd:nonNegativeInteger] ;
@@ -252,6 +261,8 @@ sosa:Actuation a owl:Class ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:usedProcedure ; owl:allValuesFrom sosa:Procedure ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasFeatureOfInterest ; owl:cardinality "1"^^xsd:nonNegativeInteger ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasFeatureOfInterest ; owl:allValuesFrom sosa:FeatureOfInterest ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasUltimateFeatureOfInterest ; owl:cardinality "1"^^xsd:nonNegativeInteger ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasUltimateFeatureOfInterest ; owl:allValuesFrom sosa:FeatureOfInterest ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:actsOnProperty ; owl:minCardinality "1"^^xsd:nonNegativeInteger ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:actsOnProperty ; owl:allValuesFrom sosa:ActuatableProperty ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasResult ; owl:minCardinality "1"^^xsd:nonNegativeInteger ] ;
@@ -278,6 +289,8 @@ sosa:Sampling a owl:Class ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:usedProcedure ; owl:allValuesFrom sosa:Procedure ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasFeatureOfInterest ; owl:cardinality "1"^^xsd:nonNegativeInteger ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasFeatureOfInterest ; owl:allValuesFrom sosa:FeatureOfInterest ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasUltimateFeatureOfInterest ; owl:minCardinality "1"^^xsd:nonNegativeInteger ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasUltimateFeatureOfInterest ; owl:allValuesFrom sosa:FeatureOfInterest ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasResult ; owl:minCardinality "1"^^xsd:nonNegativeInteger ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasResult ; owl:allValuesFrom sosa:Sample ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:resultTime ; owl:cardinality "1"^^xsd:nonNegativeInteger ] ;

--- a/ssn/integrated/ssn.ttl
+++ b/ssn/integrated/ssn.ttl
@@ -137,9 +137,13 @@ sosa:SampleCollection
 
 ## Platform
 
-sosa:Platform 
-  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hosts ; owl:allValuesFrom ssn:System ]  ;
+sosa:Host
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:inDeployment ; owl:allValuesFrom ssn:Deployment ]  ;
+  rdfs:isDefinedBy sosa: .
+
+sosa:Platform 
+  rdfs:subClassOf ssn:System ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hosts ; owl:allValuesFrom ssn:System ]  ;
   rdfs:isDefinedBy sosa: .
 
   sosa:hosts
@@ -206,11 +210,15 @@ ssn:implementedBy a owl:ObjectProperty ;
   owl:inverseOf ssn:implements ;
   rdfs:isDefinedBy ssn: .
 
-sosa:Sensor
-  rdfs:subClassOf ssn:System ;
+sosa:Observer
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:implements ; owl:minCardinality "1"^^xsd:nonNegativeInteger ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:observes ; owl:allValuesFrom sosa:ObservableProperty ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:madeObservation ; owl:allValuesFrom sosa:Observation ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:isHostedBy ; owl:allValuesFrom sosa:Host ]  ;
+  rdfs:isDefinedBy sosa: .
+
+sosa:Sensor
+  rdfs:subClassOf ssn:System ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:detects ; owl:allValuesFrom ssn:Stimulus ] ;
   rdfs:isDefinedBy sosa: .
 
@@ -253,9 +261,12 @@ sosa:isFeatureOfInterestOf
   rdfs:isDefinedBy sosa: .
 
 sosa:Observation a owl:Class ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:madeByObserver ; owl:cardinality "1"^^xsd:nonNegativeInteger ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:madeByObserver ; owl:allValuesFrom sosa:Observer ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:madeBySensor ; owl:cardinality "1"^^xsd:nonNegativeInteger ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:madeBySensor ; owl:allValuesFrom sosa:Sensor ] ;
-  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:usedProcedure ; owl:allValuesFrom sosa:Procedure ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:madeOnHost ; owl:cardinality "1"^^xsd:nonNegativeInteger ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:madeOnHost ; owl:allValuesFrom sosa:Host ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasFeatureOfInterest ; owl:cardinality "1"^^xsd:nonNegativeInteger ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasFeatureOfInterest ; owl:allValuesFrom sosa:FeatureOfInterest ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasUltimateFeatureOfInterest ; owl:minCardinality "1"^^xsd:nonNegativeInteger ] ;
@@ -274,6 +285,12 @@ sosa:Observation a owl:Class ;
     rdfs:isDefinedBy sosa: .
     
   sosa:madeBySensor 
+    rdfs:isDefinedBy sosa: .
+
+  sosa:madeByObserver 
+    rdfs:isDefinedBy sosa: .
+    
+  sosa:madeOnHost
     rdfs:isDefinedBy sosa: .
 
   sosa:observedProperty 
@@ -417,15 +434,30 @@ ssn:System a owl:Class ;
 
 ssn:Deployment a owl:Class ;
   rdfs:label "Deployment"@en ;
-  skos:definition "Describes the Deployment of one or more Systems for a particular purpose. Deployment may be done on a Platform."@en ;
-  rdfs:comment "Describes the Deployment of one or more Systems for a particular purpose. Deployment may be done on a Platform."@en ;
+  skos:definition "Describes the Deployment of one or more assets for a particular purpose. Deployment may be done on a Host."@en ;
+  rdfs:comment "Describes the Deployment of one or more assets for a particular purpose. Deployment may be done on a Host."@en ;
   skos:example "For example, a temperature Sensor deployed on a wall, or a whole network of Sensors deployed for an Observation campaign."@en ;
-  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:deployedSystem ; owl:allValuesFrom ssn:System ]  ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:deployedSystem ; owl:allValuesFrom ssn:System ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:deployedAsset ; owl:allValuesFrom [ a owl:Class ; owl:unionOf ( sosa:Observer sosa:Host ssn:System ) ] ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:deployedOnPlatform ; owl:allValuesFrom sosa:Platform ]  ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:deployedOnHost ; owl:allValuesFrom sosa:Host ]  ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:forProperty ; owl:allValuesFrom ssn:Property ]  ;
   rdfs:isDefinedBy ssn: .
 
+  ssn:deployedAsset a owl:ObjectProperty ;
+    rdfs:label "deployed asset"@en ;
+    skos:definition "Relation between a Deployment and a deployed asset."@en ;
+    rdfs:comment "Relation between a Deployment and a deployed asset."@en ;
+    rdfs:isDefinedBy ssn: .
+
+  ssn:deployedOnHost a owl:ObjectProperty ;
+    rdfs:label "deployed on host"@en ;
+    skos:definition "Relation between a Deployment and the Host on which the Systems are deployed."@en ;
+    rdfs:comment "Relation between a Deployment and the Host on which the Systems are deployed."@en ;
+    rdfs:isDefinedBy ssn: .
+
   ssn:deployedSystem a owl:ObjectProperty ;
+    rdfs:subPropertyOf ssn:deployedAsset ;
     rdfs:label "deployed system"@en ;
     skos:definition "Relation between a Deployment and a deployed System."@en ;
     rdfs:comment "Relation between a Deployment and a deployed System."@en ;
@@ -440,6 +472,7 @@ ssn:Deployment a owl:Class ;
     rdfs:isDefinedBy ssn: .
 
   ssn:deployedOnPlatform a owl:ObjectProperty ;
+    rdfs:subPropertyOf ssn:deployedOnHost ;
     rdfs:label "deployed on platform"@en ;
     skos:definition "Relation between a Deployment and the Platform on which the Systems are deployed."@en ;
     rdfs:comment "Relation between a Deployment and the Platform on which the Systems are deployed."@en ;

--- a/ssn/integrated/ssn.ttl
+++ b/ssn/integrated/ssn.ttl
@@ -112,6 +112,12 @@ sosa:Sample
   sosa:isSampleOf a owl:FunctionalProperty ;
     rdfs:isDefinedBy sosa: .
 
+  sosa:hasOriginalSample a owl:FunctionalProperty ;
+    rdfs:isDefinedBy sosa: .
+
+  sosa:hasSampledFeature a owl:FunctionalProperty ;
+    rdfs:isDefinedBy sosa: .
+
   sosa:hasPreparationStep a owl:FunctionalProperty ;
     rdfs:isDefinedBy sosa: .
 
@@ -325,6 +331,12 @@ sosa:PreparationStep a owl:Class ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:preparedSample ; owl:cardinality "1"^^xsd:nonNegativeInteger ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:preparedSample ; owl:allValuesFrom sosa:Sample ] ;
   rdfs:isDefinedBy sosa: .
+
+  sosa:madeSampling 
+    rdfs:isDefinedBy sosa: .
+
+  sosa:madeBySampler 
+    rdfs:isDefinedBy sosa: .
 
   sosa:preparedSample a owl:FunctionalProperty ;
     rdfs:isDefinedBy sosa: .

--- a/ssn/integrated/ssn.ttl
+++ b/ssn/integrated/ssn.ttl
@@ -154,13 +154,11 @@ sosa:Platform
     rdfs:isDefinedBy sosa: .
 
 
-
 ## Procedures
 
 sosa:Procedure 
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:hasInput ; owl:allValuesFrom ssn:Input ]  ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:hasOutput ; owl:allValuesFrom ssn:Output ]  ;
-  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:implementedBy ; owl:allValuesFrom ssn:System ] ;
   rdfs:isDefinedBy sosa: .
 
   ssn:hasInput a owl:ObjectProperty ;
@@ -191,6 +189,22 @@ sosa:Procedure
       rdfs:subClassOf [ a owl:Restriction ; owl:onProperty [ owl:inverseOf ssn:hasOutput ] ; owl:allValuesFrom sosa:Procedure ] ;
       rdfs:isDefinedBy ssn: .
 
+sosa:ObservingProcedure
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:implementedBy ; owl:allValuesFrom sosa:Observer ] ;
+  rdfs:isDefinedBy sosa: .
+
+sosa:ActuationProcedure
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:implementedBy ; owl:allValuesFrom sosa:Actuator ] ;
+  rdfs:isDefinedBy sosa: .
+
+sosa:SamplingProcedure
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:implementedBy ; owl:allValuesFrom sosa:Sampler ] ;
+  rdfs:isDefinedBy sosa: .
+
+sosa:PreparationProcedure
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:implementedBy ; owl:allValuesFrom sosa:PreparationStep ] ;
+  rdfs:isDefinedBy sosa: .
+
 
 ## ProcedureExecutors
 
@@ -212,6 +226,7 @@ ssn:implementedBy a owl:ObjectProperty ;
 
 sosa:Observer
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:implements ; owl:minCardinality "1"^^xsd:nonNegativeInteger ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:implements ; owl:allValuesFrom sosa:ObservingProcedure ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:observes ; owl:allValuesFrom sosa:ObservableProperty ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:madeObservation ; owl:allValuesFrom sosa:Observation ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:isHostedBy ; owl:allValuesFrom sosa:Host ]  ;
@@ -232,6 +247,7 @@ sosa:Sensor
 sosa:Actuator
   rdfs:subClassOf ssn:System ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:implements ; owl:minCardinality "1"^^xsd:nonNegativeInteger ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:implements ; owl:allValuesFrom sosa:ActuationProcedure ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:forProperty ; owl:allValuesFrom sosa:ActuatableProperty ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:madeActuation ; owl:allValuesFrom sosa:Actuation ] ;
   rdfs:isDefinedBy sosa: .
@@ -239,6 +255,7 @@ sosa:Actuator
 sosa:Sampler 
   rdfs:subClassOf ssn:System ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:implements ; owl:minCardinality "1"^^xsd:nonNegativeInteger ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty ssn:implements ; owl:allValuesFrom sosa:SamplingProcedure ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:madeSampling ; owl:allValuesFrom sosa:Sampling ] ;
   rdfs:isDefinedBy sosa: .
 
@@ -267,6 +284,7 @@ sosa:Observation a owl:Class ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:madeBySensor ; owl:allValuesFrom sosa:Sensor ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:madeOnHost ; owl:cardinality "1"^^xsd:nonNegativeInteger ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:madeOnHost ; owl:allValuesFrom sosa:Host ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:usedProcedure ; owl:allValuesFrom sosa:ObservingProcedure ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasFeatureOfInterest ; owl:cardinality "1"^^xsd:nonNegativeInteger ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasFeatureOfInterest ; owl:allValuesFrom sosa:FeatureOfInterest ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasUltimateFeatureOfInterest ; owl:minCardinality "1"^^xsd:nonNegativeInteger ] ;
@@ -299,7 +317,7 @@ sosa:Observation a owl:Class ;
 sosa:Actuation a owl:Class ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:madeByActuator ; owl:cardinality "1"^^xsd:nonNegativeInteger ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:madeByActuator ; owl:allValuesFrom sosa:Actuator ] ;
-  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:usedProcedure ; owl:allValuesFrom sosa:Procedure ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:usedProcedure ; owl:allValuesFrom sosa:ActuationProcedure ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasFeatureOfInterest ; owl:cardinality "1"^^xsd:nonNegativeInteger ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasFeatureOfInterest ; owl:allValuesFrom sosa:FeatureOfInterest ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasUltimateFeatureOfInterest ; owl:cardinality "1"^^xsd:nonNegativeInteger ] ;
@@ -323,11 +341,10 @@ sosa:Actuation a owl:Class ;
   sosa:isActedOnBy
     rdfs:isDefinedBy sosa: .
 
-
 sosa:Sampling a owl:Class ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:madeBySampler ; owl:cardinality "1"^^xsd:nonNegativeInteger ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:madeBySampler ; owl:allValuesFrom sosa:Sampler ] ;
-  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:usedProcedure ; owl:allValuesFrom sosa:Procedure ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:usedProcedure ; owl:allValuesFrom sosa:SamplingProcedure ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasFeatureOfInterest ; owl:cardinality "1"^^xsd:nonNegativeInteger ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasFeatureOfInterest ; owl:allValuesFrom sosa:FeatureOfInterest ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasUltimateFeatureOfInterest ; owl:minCardinality "1"^^xsd:nonNegativeInteger ] ;

--- a/ssn/integrated/ssn.ttl
+++ b/ssn/integrated/ssn.ttl
@@ -89,6 +89,7 @@ ssn:Property a owl:Class ;
     rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:isActedOnBy ; owl:allValuesFrom sosa:Actuation ] ;
     rdfs:isDefinedBy sosa: .
 
+
 ## Sample
 
 sosa:Sample
@@ -102,12 +103,16 @@ sosa:Sample
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasSampledFeature ; owl:allValuesFrom sosa:FeatureOfInterest ]  ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasSampledFeature ; owl:minCardinality "1"^^xsd:nonNegativeInteger ] ;
   rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:isResultOf ; owl:allValuesFrom sosa:Sampling ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:hasPreparationStep ; owl:allValuesFrom sosa:PreparationStep ] ;
   rdfs:isDefinedBy sosa: .
 
   sosa:hasSample a owl:InverseFunctionalProperty ;
     rdfs:isDefinedBy sosa: .
 
   sosa:isSampleOf a owl:FunctionalProperty ;
+    rdfs:isDefinedBy sosa: .
+
+  sosa:hasPreparationStep a owl:FunctionalProperty ;
     rdfs:isDefinedBy sosa: .
 
 sosa:SpatialSample
@@ -315,7 +320,14 @@ sosa:Sampling a owl:Class ;
   sosa:madeBySampler 
     rdfs:isDefinedBy sosa: .
 
+sosa:PreparationStep a owl:Class ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:usedProcedure ; owl:allValuesFrom sosa:PreparationProcedure ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:preparedSample ; owl:cardinality "1"^^xsd:nonNegativeInteger ] ;
+  rdfs:subClassOf [ a owl:Restriction ; owl:onProperty sosa:preparedSample ; owl:allValuesFrom sosa:Sample ] ;
+  rdfs:isDefinedBy sosa: .
 
+  sosa:preparedSample a owl:FunctionalProperty ;
+    rdfs:isDefinedBy sosa: .
 ## Stimulus
 
 ssn:Stimulus a owl:Class ;


### PR DESCRIPTION
This is my initial attempt to merge SSN Extensions and OMS concepts into the SOSA/SSN Ontology.

Only Turtle files have been modified so far. RDF files are still the original version so they don't match. We can regenerate them automatically when ready.

The changes are recorded in [readme.md](https://github.com/sensiasoft/w3c_sdw/blob/oms-alignment/ssn/integrated/readme.md).


## Design Choices

 - No change to URIs of existing SOSA/SSN classes and properties.
 - Only allow minor documentation changes or clarifications that don't fundamentally change the meaning of existing concepts.
 - Keep most notes and examples from OMS
 - Allowed some changes to relations to better integrate new OMS classes (range or domain)
 - Rename OMS associations with more specific names since unique URIs are needed in RDF


## Discussion Items

- `Observer` and `Host` are kept more abstract (they are not `Systems`). Is everybody OK with this?

- More specific procedure types are introduced by OMS. I made the choice to reinforce the constraints on the existing properties to reflect this, but this is a breaking changes compared to the existing version. So we may prefer to keep the existing looser constraint, or create a separate sub-property with a stricter constraint (e.g. have both `usedProcedure` and `usedObservingProcedure` on `Observation`)  

- Should we also add `observableProperty` association between `ObservingProcedure` and `ObservableProperty`? (requested by Sylvain Grellet). If we do, then we should also add the `actuableProperty` association between `ActuationProcedure` and `ActuableProperty`. This makes sense to me so we can discover procedures by property.

- `SampleCollection` could get common properties like `ObservationCollection` (e.g. same `Sampler` or same `SamplingProcedure` used for all samples in the collection). OMS doesn't define this, but should we do it here?