### PR TITLE
Fix member predicate in OWL-Time example

### DIFF
--- a/time/rdf/geologicTimeScale.ttl
+++ b/time/rdf/geologicTimeScale.ttl
@@ -193,10 +193,10 @@ geol:Silurian
 geol:TimeScale
   rdf:type :TRS ;
   rdfs:label "Geologic timescale" ;
-  :hasMember geol:Archean ;
-  :hasMember geol:Hadean ;
-  :hasMember geol:Phanerozoic ;
-  :hasMember geol:Proterozoic ;
+  rdfs:member geol:Archean ;
+  rdfs:member geol:Hadean ;
+  rdfs:member geol:Phanerozoic ;
+  rdfs:member geol:Proterozoic ;
 .
 geol:Triassic
   rdf:type :ProperInterval ;


### PR DESCRIPTION
No `:hasMember` property in OWL-Time.
Use `rdfs:member` instead.

Fixes #1407 