### PR TITLE
time-prov: Drop subproperty axiom that leads to datatype conflict

### DIFF
--- a/time/rdf/time-prov.ttl
+++ b/time/rdf/time-prov.ttl
@@ -13,9 +13,6 @@
 @prefix time-prov: <http://www.w3.org/2006/time/prov#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-time:inXSDDateTimeStamp
-  rdfs:subPropertyOf time:inXSDDateTime ;
-.
 <http://www.w3.org/2006/time/prov>
   rdf:type owl:Ontology ;
   dc:creator "Simon J D Cox" ;


### PR DESCRIPTION
The file time-prov.ttl provides a non-normative alignment between OWL-Time and PROV-O.  One of the included suggestions is an alignment of the `time:inXSDDateTimeStamp` with the currently-deprecated property `time:inXSDDateTime`.

This patch drops that suggested alignment, for two reasons:

1. Entailment, in both RDFS and OWL semantics, would cause any usage of `time:inXSDDateTimeStamp` to induce usage of `time:inXSDDateTime` in the graph, which could raise OWL warnings about usage of a deprecated property.
2. A triple `X time:inXSDDateTimeStamp Y` would be required by the range of `time:inXSDDateTimeStamp` to have Y bear the datatype `xsd:dateTimeStamp`.  Entailment, in both RDFS and OWL semantics, would induce a triple `X time:inXSDDateTime Y`, with the same subject and object as in the original triple.  The literal `Y` would have an incompatible datatype with the range of the induced `time:inXSDDateTime` triple, because a second datatype could not be assigned to it per RDF design.

This contribution is made only by myself, and is not being made by the National Institute of Standards and Technology or any other organization.