### PR TITLE
Updated WebVMT Note

### DIFF
--- a/proposals/geotagging/webvmt/index.html
+++ b/proposals/geotagging/webvmt/index.html
@@ -831,7 +831,18 @@ NOTE End (linear) interpolation of live2 data
             A <a>WebVMT path</a> describes the trajectory of a moving object which consists of a timed sequence of locations. The object's location may be interpolated between consecutive values in the sequence to calculate the distance travelled over time.
           </p>
           <p>
-            The <code>path</code> attribute may be set to identify an individual path. This allows a path to be styled with CSS, e.g. colour, and the speed and distance attributes to be identified during playback.
+            The <code>path</code> attribute may be set to identify an individual path. This allows a path:
+            <ul>
+              <li>
+                to be styled with CSS, e.g. colour;
+              </li>
+              <li>
+                to be associated with speed and distance attributes during playback;
+              </li>
+              <li>
+                to be uniquely associated with the video footage.
+              </li>
+            </ul>
           </p>
           <p>
             In this example, an interpolated path is traced from London to Brighton:
@@ -844,6 +855,7 @@ NOTE Associated video
 MEDIA
 url:LondonBrighton.mp4
 mime-type:video/mp4
+path:cam1
 
 NOTE Map config
 

--- a/proposals/geotagging/webvmt/index.html
+++ b/proposals/geotagging/webvmt/index.html
@@ -750,7 +750,9 @@ WEBVMT
 NOTE Required blocks omitted for clarity
 
 NOTE Step interpolation of live1 data
+     gear = 4 after 4 secs until next update
 
+00:00:04.000 --&gt;
 { "sync":
   { "type": "org.webvmt.example", "id": "live1", "data":
     { "gear": "4" }

--- a/proposals/geotagging/webvmt/index.html
+++ b/proposals/geotagging/webvmt/index.html
@@ -855,6 +855,7 @@ NOTE Associated video
 MEDIA
 url:LondonBrighton.mp4
 mime-type:video/mp4
+start-time:2018-02-19T12:34:56.789Z
 path:cam1
 
 NOTE Map config

--- a/proposals/geotagging/webvmt/index.html
+++ b/proposals/geotagging/webvmt/index.html
@@ -66,6 +66,9 @@
     </section>
     <section id='sotd'>
       <p>
+        This document is a Note, it has not been widely reviewed and should be considered as experimental only. It may serve as the base for an upcoming W3C Recommendation.
+      </p>
+      <p>
         This document is an explanatory specification, intended to communicate and develop the draft WebVMT format through discussion with user communities.
       </p>
     </section>
@@ -1927,6 +1930,9 @@ mime-type:video/mp4
             A <a data-cite='HTML51/infrastructure.html#valid-global-date-and-time-string'>valid global date and time string</a>.
           </li>
         </ol>
+        <p class='note' title='Media Start Time'>
+          <a>WebVMT media start time setting</a> should include millisecond data in order to allow the <a>WebVMT file</a> to be accurately synchronized with Coordinated Universal Time (UTC).
+        </p>
         <p>
           A <dfn>WebVMT media path setting</dfn> consists of the following components, in the order given:
         </p>


### PR DESCRIPTION
Added wording suggested by W3C to document status
Added note on 'media start time' to section 6.3
Corrected live step interpolation example
Reinstated changes from PR #1406 which were removed by mistake
Added start time example