### PR TITLE
[time] Fix russian prefLabel for hour

### DIFF
--- a/time/rdf/time.jsonld
+++ b/time/rdf/time.jsonld
@@ -2770,7 +2770,10 @@
       "@language" : "en",
       "@value" : "Hour (unit of temporal duration)"
     },
-    "prefLabel" : [ "один час\"@ru", {
+    "prefLabel" : [ {
+      "@language" : "ru",
+      "@value" : "один час"
+    }, {
       "@language" : "jp",
       "@value" : "一時間"
     }, {

--- a/time/rdf/time.nt
+++ b/time/rdf/time.nt
@@ -361,7 +361,7 @@ _:Ba0297841f1348daab20c90af9a31183a <http://www.w3.org/1999/02/22-rdf-syntax-ns#
 <http://www.w3.org/2006/time#GeneralDateTimeDescription> <http://www.w3.org/2000/01/rdf-schema#subClassOf> _:B25a8c6650bdf6c88aff8c3a5d1239631 .
 <http://www.w3.org/2006/time#GeneralDateTimeDescription> <http://www.w3.org/2000/01/rdf-schema#comment> "Description of date and time structured with separate values for the various elements of a calendar-clock system"@en .
 <http://www.w3.org/2006/time#GeneralDateTimeDescription> <http://www.w3.org/2004/02/skos/core#definition> "Description of date and time structured with separate values for the various elements of a calendar-clock system"@en .
-<http://www.w3.org/2006/time#unitHour> <http://www.w3.org/2004/02/skos/core#prefLabel> "один час\"@ru" .
+<http://www.w3.org/2006/time#unitHour> <http://www.w3.org/2004/02/skos/core#prefLabel> "один час"@ru .
 <http://www.w3.org/2006/time#unitHour> <http://www.w3.org/2004/02/skos/core#prefLabel> "一時間"@jp .
 <http://www.w3.org/2006/time#unitHour> <http://www.w3.org/2006/time#days> "0"^^<http://www.w3.org/2001/XMLSchema#decimal> .
 <http://www.w3.org/2006/time#unitHour> <http://www.w3.org/2004/02/skos/core#prefLabel> "godzina"@pl .

--- a/time/rdf/time.rdf
+++ b/time/rdf/time.rdf
@@ -1476,7 +1476,7 @@ The range of this property is not specified, so can be replaced by any specific 
     <skos:prefLabel xml:lang="it">secondo</skos:prefLabel>
   </TemporalUnit>
   <TemporalUnit rdf:ID="unitHour">
-    <skos:prefLabel>один час"@ru</skos:prefLabel>
+    <skos:prefLabel xml:lang="ru">один час</skos:prefLabel>
     <skos:prefLabel xml:lang="jp">一時間</skos:prefLabel>
     <days rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal"
     >0</days>

--- a/time/rdf/time.ttl
+++ b/time/rdf/time.ttl
@@ -1233,7 +1233,7 @@ DBPedia provides a set of resources corresponding to the IANA timezones, with a 
   skos:prefLabel "hour"@en ;
   skos:prefLabel "ora"@it ;
   skos:prefLabel "uur"@nl ;
-  skos:prefLabel "один час\"@ru" ;
+  skos:prefLabel "один час"@ru ;
   skos:prefLabel "ساعة واحدة"@ar ;
   skos:prefLabel "一小時"@zh ;
   skos:prefLabel "一時間"@ja ;


### PR DESCRIPTION
The russian prefLabel for hour was `"один час\"@ru"` but should be `"один час"@ru`.