### PR TITLE
time-gregorian.ttl: Fixed corrupted Russian, Japanese, Chinese, Arabic, and Polish labels

### DIFF
--- a/time/rdf/time-gregorian.ttl
+++ b/time/rdf/time-gregorian.ttl
@@ -99,27 +99,27 @@ greg:January
   skos:historyNote """A _class_ with the local-name January was present in the 2006 version of OWL-Time. 
 It was presented as an example of how DateTimeDescription could be specialized. 
 In the 2017 version of OWL-Time that class is deprecated, but this individual provided instead, in a separate namespace. """ ;
-  skos:prefLabel "/=20@L"@ru ;
-  skos:prefLabel "1"@ja ;
-  skos:prefLabel "1"@zh ;
+  skos:prefLabel "Январь"@ru ;
+  skos:prefLabel "1月"@ja ;
+  skos:prefLabel "1月"@zh ;
   skos:prefLabel "Enero"@es ;
   skos:prefLabel "Gennaio"@it ;
-  skos:prefLabel "JF'J1 (4G1)"@ar ;
+  skos:prefLabel "يناير (شهر)"@ar ;
   skos:prefLabel "Janeiro"@pt ;
   skos:prefLabel "Januar"@de ;
   skos:prefLabel "Januari"@nl ;
   skos:prefLabel "January"@en ;
   skos:prefLabel "Janvier"@fr ;
-  skos:prefLabel "StyczeD"@pl ;
+  skos:prefLabel "Styczeń"@pl ;
   time:month "--01"^^xsd:gMonth ;
 .
 greg:July
   rdf:type time:MonthOfYear ;
   rdfs:label "July"@en ;
-  skos:prefLabel "N;L"@ru ;
-  skos:prefLabel "7"@ja ;
-  skos:prefLabel "7"@zh ;
-  skos:prefLabel "JHDJH"@ar ;
+  skos:prefLabel "Июль"@ru ;
+  skos:prefLabel "7月"@ja ;
+  skos:prefLabel "7月"@zh ;
+  skos:prefLabel "يوليو"@ar ;
   skos:prefLabel "Juillet"@fr ;
   skos:prefLabel "Julho"@pt ;
   skos:prefLabel "Juli"@de ;
@@ -133,12 +133,12 @@ greg:July
 greg:June
   rdf:type time:MonthOfYear ;
   rdfs:label "June"@en ;
-  skos:prefLabel "N=L"@ru ;
-  skos:prefLabel "6"@ja ;
-  skos:prefLabel "6"@zh ;
+  skos:prefLabel "Июнь"@ru ;
+  skos:prefLabel "6月"@ja ;
+  skos:prefLabel "6月"@zh ;
   skos:prefLabel "Czerwiec"@pl ;
   skos:prefLabel "Giugno"@it ;
-  skos:prefLabel "JHFJH"@ar ;
+  skos:prefLabel "يونيو"@ar ;
   skos:prefLabel "Juin"@fr ;
   skos:prefLabel "June"@en ;
   skos:prefLabel "Junho"@pt ;


### PR DESCRIPTION
A tool seemingly cast 16-bit characters directly to 8-bit integers by throwing away the high byte.
Because of this:
- All non-Latin characters (Arabic, Cyrillic, Japanese Kanji) were corrupted into printable and control ASCII characters.
- Since U+6708 (Japanese Kanji 月) and U+0418 (Cyrillic И) happen to have low-byte values of 0x08 and 0x18, they introduced actual control bytes into the file.
- These control bytes are fundamentally illegal in XML 1.0 documents, causing any standard OWL parser attempting to parse the XML serialization of the Turtle file to crash.

This patch fixes the incorrect labels.