### PR TITLE
Fix link to SDW Working Group charter

### DIFF
--- a/index.html
+++ b/index.html
@@ -176,7 +176,7 @@ article, aside, details, figcaption, figure, footer, header, hgroup, menu, nav, 
           </h1>
           <div class="unit size2on3" id="maincol">
             <p>
-              The mission of the Spatio-Temporal Data on the Web Working Group is to develop and maintain vocabularies and best practices that encourage better sharing of spatio-temporal data on the Web; and identify areas where standards should be developed jointly by both W3C and the <a href="http://www.opengeospatial.org/">Open Geospatial Consortium</a> (OGC). Learn more about the <a href="https://www.w3.org/2021/10/sdw-charter.html">goals, scope, and deliverables</a>.
+              The mission of the Spatio-Temporal Data on the Web Working Group is to develop and maintain vocabularies and best practices that encourage better sharing of spatio-temporal data on the Web; and identify areas where standards should be developed jointly by both W3C and the <a href="http://www.opengeospatial.org/">Open Geospatial Consortium</a> (OGC). Learn more about the <a href="https://www.w3.org/2024/11/sdw-wg-charter.html">goals, scope, and deliverables</a>.
             </p>
             <p>
               The Spatio-Temporal Data on the Web Working Group is a W3C entity matched by a sub-committee of OGC's Technical Committee. Collectively, the two comprise the Joint W3C/OGC Organizing Committee, the <strong>JWOC</strong>.


### PR DESCRIPTION
Updated the link to the goals, scope, and deliverables of the Spatio-Temporal Data on the Web Working Group.